### PR TITLE
Fix: Correct parameter type in Coin::Quarter variant

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no_listing_05_print_enum/src/lib.cairo
+++ b/listings/ch06-enums-and-pattern-matching/no_listing_05_print_enum/src/lib.cairo
@@ -22,7 +22,7 @@ fn value_in_cents(coin: Coin) -> felt252 {
         Coin::Penny(_) => 1,
         Coin::Nickel(_) => 5,
         Coin::Dime(_) => 10,
-        Coin::Quarter(state) => {
+        Coin::Quarter((state)) => {
             state.print();
             25
         },


### PR DESCRIPTION
The "value_in_cents" function encountered an issue where the "Coin::Quarter" variant was expecting (UsState,) instead of UsState. This resulted in a "Method print not found" error.

To resolve this, I updated the Coin::Quarter variant to expect the correct parameter type: ```Coin::Quarter((state))```

This change ensures that the UsState is correctly matched in the "value_in_cents" function, fixing the error related to the print method.