### PR TITLE
Ch02 01 updates

### DIFF
--- a/src/appendix-01-keywords.md
+++ b/src/appendix-01-keywords.md
@@ -36,7 +36,7 @@ They cannot be used as names of any items.
 - `mod` - Define a module
 - `mut` - Denote variable mutability
 - `nopanic` - Functions marked with this notation mean that the function will never panic.
-- `of` - Implementation a trait
+- `of` - Implementation of a trait
 - `ref` - Parameter passed implicitly returned at the end of a function
 - `return` - Return from function
 - `struct` - Define a structure

--- a/src/appendix-02-operators-and-symbols.md
+++ b/src/appendix-02-operators-and-symbols.md
@@ -46,7 +46,7 @@ Table B-1 contains the operators in Cairo, an example of how the operator would 
 
 ## Non Operator Symbols
 
-The following list contains all symbols that are not used as operators; that is, they do not have the same behavior as a function or method call.
+The following list contains all symbols that are not used as operators; that is, they do not have the same behaviour as a function or method call.
 
 Table B-2 shows symbols that appear on their own and are valid in a variety of locations.
 
@@ -75,7 +75,7 @@ Table B-4 shows symbols that appear in the context of using generic type paramet
 | Symbol | Explanation |
 |--------|-------------|
 | `path<...>` | Specifies parameters to generic type in a type (e.g., `Vec<u8>`) |
-| `path::<...>`, `method::<...>` | Specifies parameters to generic type, function, or method in an expression; often referred to as turbofish |
+| `path::<...>`, `method::<...>` | Specifies parameters to a generic type, function, or method in an expression; often referred to as turbofish |
 | `fn ident<...> ...` | Define generic function |
 | `struct ident<...> ...` | Define generic structure |
 | `enum ident<...> ...` | Define generic enumeration |

--- a/src/ch02-01-variables-and-mutability.md
+++ b/src/ch02-01-variables-and-mutability.md
@@ -34,14 +34,14 @@ Error: failed to compile: src/lib.cairo
 ```
 
 This example shows how the compiler helps you find errors in your programs.
-Compiler errors can be frustrating, but really they only mean your program
+Compiler errors can be frustrating, but they only mean your program
 isn’t safely doing what you want it to do yet; they do _not_ mean that you’re
 not a good programmer! Experienced Caironautes still get compiler errors.
 
 You received the error message `Cannot assign to an immutable variable.`
 because you tried to assign a second value to the immutable `x` variable.
 
-It’s important that we get compile-time errors when we attempt to change a
+We must get compile-time errors when we attempt to change a
 value that’s designated as immutable because this specific situation can lead to
 bugs. If one part of our code operates on the assumption that a value will
 never change and another part of our code changes that value, it’s possible
@@ -136,7 +136,7 @@ new variable with the same name as a previous variable. Caironautes say that the
 first variable is _shadowed_ by the second, which means that the second
 variable is what the compiler will see when you use the name of the variable.
 In effect, the second variable overshadows the first, taking any uses of the
-variable name to itself until either it itself is shadowed or the scope ends.
+variable name to itself until either it is shadowed or the scope ends.
 We can shadow a variable by using the same variable’s name and repeating the
 use of the `let` keyword as follows:
 


### PR DESCRIPTION
As I was reading through the document. I saw these necessary improvements.
line 37
Compiler errors can be frustrating, but really they only mean your program 
Compiler errors can be frustrating, but they only mean your program
line 44
It’s important that we get compile-time errors when we attempt to change a
We must get compile-time errors when we attempt to change a
line 139
variable name to itself until either it itself is shadowed or the scope ends.
variable name to itself until either it is shadowed or the scope ends.

