### PR TITLE
Fix typo in src/ch99-04-00-L1-L2-messaging.md

### DIFF
--- a/src/ch99-04-00-L1-L2-messaging.md
+++ b/src/ch99-04-00-L1-L2-messaging.md
@@ -177,7 +177,7 @@ struct u256 {
 }
 ```
 
-which will be serialized as **TWO** felts, one for the `low`, and one for the `high`. This means that to send only one `u256` to Cairo, you'll need to send a paylaod from L1 with **TWO** values.
+which will be serialized as **TWO** felts, one for the `low`, and one for the `high`. This means that to send only one `u256` to Cairo, you'll need to send a payload from L1 with **TWO** values.
 
 ```js
 uint256[] memory payload = new uint256[](2);


### PR DESCRIPTION
After introduce the typo-check workflow in CI
Thanks to [PR](https://github.com/cairo-book/cairo-book/pull/445)

I found this only one typo error. 