### PR TITLE
Link to starknet documentation storage variables was broken

### DIFF
--- a/src/ch99-01-03-01-contract-storage.md
+++ b/src/ch99-01-03-01-contract-storage.md
@@ -119,4 +119,4 @@ If the key of a mapping is a struct, each element of the struct constitutes a ke
 
 Similarly, in the case of a nested mapping such as `LegacyMap((ContractAddress, ContractAddress), u8)`, the address will be computed in the same way: `h(h(sn_keccak(variable_name),k_1),k_2)`.
 
-For more details about the contract storage layout in the [Starknet Documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/#storage_variables)
+For more details about the contract storage layout in the [Starknet Documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage/#storage_variables)


### PR DESCRIPTION
Hi, 
Looks like the link was broken. 
I didn't regenerate the corresponding translation files (don't know if I should). 