### PR TITLE
Update WASM-Cairo to v0.5.1 to support Cairo v2.3.1

### DIFF
--- a/theme/pkg/package.json
+++ b/theme/pkg/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "cryptonerdcn <cryptonerdcn@gmail.com>"
   ],
-  "version": "0.4.0",
+  "version": "0.5.1",
   "files": [
     "wasm-cairo_bg.wasm",
     "wasm-cairo.js",

--- a/theme/pkg/wasm-cairo.js
+++ b/theme/pkg/wasm-cairo.js
@@ -265,7 +265,7 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_log_9b2c8c4ceb28b489 = function(arg0, arg1) {
+    imports.wbg.__wbg_log_a176ce88c30149f2 = function(arg0, arg1) {
         console.log(getStringFromWasm0(arg0, arg1));
     };
 


### PR DESCRIPTION
As title.
You can find more about WASM-Cairo 0.5.1 [here](https://github.com/cryptonerdcn/wasm-cairo/releases/tag/v0.5.1).

@enitrat Can you review this update? Thanks!