### PR TITLE
[feat]Let wasm-cairo run in each languages' path.

### DIFF
--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -340,6 +340,7 @@
         {{else}}
         <script src="{{ path_to_root }}../js/index.mjs"></script>
         {{/if}}
+        {{/if}}
 
         {{#if search_js}}
         <script src="{{ path_to_root }}elasticlunr.min.js"></script>

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -335,6 +335,10 @@
         <script src="{{ path_to_root }}mode-rust.js"></script>
         <script src="{{ path_to_root }}theme-dawn.js"></script>
         <script src="{{ path_to_root }}theme-tomorrow_night.js"></script>
+        {{#if (eq language "en")}}
+        <script src="{{ path_to_root }}js/index.mjs"></script>
+        {{else}}
+        <script src="{{ path_to_root }}../js/index.mjs"></script>
         {{/if}}
 
         {{#if search_js}}
@@ -346,7 +350,6 @@
         <script src="{{ path_to_root }}clipboard.min.js"></script>
         <script src="{{ path_to_root }}highlight.js"></script>
         <script src="{{ path_to_root }}book.js"></script>
-        <script src="{{ path_to_root }}js/index.mjs"></script>
 
         <!-- Custom JS scripts -->
         {{#each additional_js}}

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -335,11 +335,6 @@
         <script src="{{ path_to_root }}mode-rust.js"></script>
         <script src="{{ path_to_root }}theme-dawn.js"></script>
         <script src="{{ path_to_root }}theme-tomorrow_night.js"></script>
-        {{#if (eq language "en")}}
-        <script src="{{ path_to_root }}js/index.mjs"></script>
-        {{else}}
-        <script src="{{ path_to_root }}../js/index.mjs"></script>
-        {{/if}}
         {{/if}}
 
         {{#if search_js}}
@@ -351,6 +346,11 @@
         <script src="{{ path_to_root }}clipboard.min.js"></script>
         <script src="{{ path_to_root }}highlight.js"></script>
         <script src="{{ path_to_root }}book.js"></script>
+        {{#if (eq language "en")}}
+        <script src="{{ path_to_root }}js/index.mjs"></script>
+        {{else}}
+        <script src="{{ path_to_root }}../js/index.mjs"></script>
+        {{/if}}
 
         <!-- Custom JS scripts -->
         {{#each additional_js}}

--- a/theme/js/index.mjs
+++ b/theme/js/index.mjs
@@ -2,7 +2,7 @@ const maxWorkers = 1;
 let workerPath = '';
 
 // supported languages
-const supportedLanguages = ['zh-cn', 'fr', 'es'];
+const supportedLanguages = ['zh-cn', 'fr', 'es', 'id'];
 
 // path to mjs. This is the path to the current script, which is the last script in the document.
 const scripts = document.getElementsByTagName('script');

--- a/theme/js/index.mjs
+++ b/theme/js/index.mjs
@@ -1,5 +1,20 @@
-const maxWorkers = 1
-const worker = new Worker('js/worker.cjs')
+const maxWorkers = 1;
+let workerPath = '';
+
+// path to mjs. This is the path to the current script, which is the last script in the document.
+const scripts = document.getElementsByTagName('script');
+const currentScript = scripts[scripts.length - 1];
+const scriptUrl = currentScript.src;
+
+if (window.location.pathname.startsWith('/zh-cn')) {
+    workerPath = new URL('../js/worker.cjs', scriptUrl).toString();
+} else {
+    workerPath = new URL('./worker.cjs', scriptUrl).toString();
+}
+
+
+console.log(workerPath);
+const worker = new Worker(workerPath);
 
 window.runFunc = async (cairo_program) => {
     return new Promise((resolve, reject) => {
@@ -19,4 +34,4 @@ window.runFunc = async (cairo_program) => {
             reject(error);
         };
     });
-}
+};

--- a/theme/js/index.mjs
+++ b/theme/js/index.mjs
@@ -1,12 +1,15 @@
 const maxWorkers = 1;
 let workerPath = '';
 
+// supported languages
+const supportedLanguages = ['zh-cn', 'fr', 'es'];
+
 // path to mjs. This is the path to the current script, which is the last script in the document.
 const scripts = document.getElementsByTagName('script');
 const currentScript = scripts[scripts.length - 1];
 const scriptUrl = currentScript.src;
 
-if (window.location.pathname.startsWith('/zh-cn')) {
+if (supportedLanguages.some(lang => window.location.pathname.startsWith('/' + lang))) {
     workerPath = new URL('../js/worker.cjs', scriptUrl).toString();
 } else {
     workerPath = new URL('./worker.cjs', scriptUrl).toString();


### PR DESCRIPTION
I'm sorry for forgetting this for a long time. 
Basically before this PR, you can only run the code in the English version of CairoBook -- Because the js files are just under the `root/js`, so it can't be used in the subpath(such as `root/zh-cn/`).

Now all language versions of Cairobook can run the code!
You can test it here: 
https://starknetastro.github.io/cairo-book.github.io/zh-cn/ch01-02-hello-world.html

BTW: Because of Webworker's relative path problem I had to use an ugly way to solve this. https://github.com/parcel-bundler/parcel/issues/5430. I will update it when I find a good way.
@enitrat Can you review this PR? Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/477)
<!-- Reviewable:end -->
