### PR TITLE
Minor Typo fix in Chapter 10.3

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -7971,7 +7971,7 @@ msgstr ""
 
 #: src/ch11-03-hash.md:138
 msgid ""
-"In this example, we initialized a HashState (`hash`) and updateted it and "
+"In this example, we initialized a HashState (`hash`) and updated it and "
 "then called the function `finalize()` on the HashState to get the computed "
 "hash `hash_felt252`. We used the `poseidon_hash_span` on the `Span` of the "
 "`Array<felt252>` to compute its hash."

--- a/po/zh-cn.po
+++ b/po/zh-cn.po
@@ -14782,7 +14782,7 @@ msgstr ""
 
 #: src/ch11-03-hash.md:138
 msgid ""
-"In this example, we initialized a HashState (`hash`) and updateted it and then called the function `finalize()` on the\n"
+"In this example, we initialized a HashState (`hash`) and updated it and then called the function `finalize()` on the\n"
 "HashState to get the computed hash `hash_felt252`. We used the `poseidon_hash_span` on the `Span` of the `Array<felt252>` to compute its hash."
 msgstr ""
 "在这个例子中，我们初始化了一个 HashState (`hash`) 并更新了它，然后在 HashState 上调用了函数 `finalize()` 以获得计算出的哈希 `hash_felt252`。我们使用 `poseidon_hash_span` 对 "

--- a/src/ch11-03-hash.md
+++ b/src/ch11-03-hash.md
@@ -71,7 +71,7 @@ Hash trait on this structure it will rise an error because the structure contain
 
 ```
 
-In this example, we initialized a HashState (`hash`) and updateted it and then called the function `finalize()` on the
+In this example, we initialized a HashState (`hash`) and updated it and then called the function `finalize()` on the
 HashState to get the computed hash `hash_felt252`. We used the `poseidon_hash_span` on the `Span` of the `Array<felt252>` to compute its hash.
 
 ```rust


### PR DESCRIPTION
### Summary

- Making this amazing resource more typo free.

Replaced term `updateted` with `updated`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/486)
<!-- Reviewable:end -->
