### PR TITLE
Anonymous vs Named Generic Implementation Parameter

### DIFF
--- a/listings/ch08-generic-types-and-traits/no_listing_02_with_tdrop/src/lib.cairo
+++ b/listings/ch08-generic-types-and-traits/no_listing_02_with_tdrop/src/lib.cairo
@@ -1,4 +1,4 @@
-fn largest_list<T, +Drop<T>>(l1: Array<T>, l2: Array<T>) -> Array<T> {
+fn largest_list<T, impl TDrop: Drop<T>>(l1: Array<T>, l2: Array<T>) -> Array<T> {
     if l1.len() > l2.len() {
         l1
     } else {

--- a/listings/ch08-generic-types-and-traits/no_listing_03_missing_tcopy/src/lib.cairo
+++ b/listings/ch08-generic-types-and-traits/no_listing_03_missing_tcopy/src/lib.cairo
@@ -2,7 +2,7 @@
 
 // Given a list of T get the smallest one.
 // The PartialOrd trait implements comparison operations for T
-fn smallest_element<T, +PartialOrd<T>>(list: @Array<T>) -> T {
+fn smallest_element<T, impl TPartialOrd: PartialOrd<T>>(list: @Array<T>) -> T {
     // This represents the smallest element through the iteration
     // Notice that we use the desnap (*) operator
     let mut smallest = *list[0];


### PR DESCRIPTION
In the chapter 8.1 "Generic Functions", anonymous generic implementation parameters are described at the end of the chapter (in "Anonymous Generic Implementation Parameter (+ operator)" but they are used in the second and third code snippets, at the beginning of the chapter.

Then, the chapter "Constraints for Generic Types" mentions a `TDrop` implementation but in the code snippet, the drop implementation is anonymous.

To be more consistent with the chapter structure, this PR uses named generic implementation parameters in the first code snippets, until anonymous generic implementation parameter are described.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/489)
<!-- Reviewable:end -->
