### PR TITLE
Issue in wallet field types

### DIFF
--- a/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
+++ b/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
@@ -23,7 +23,7 @@ impl WalletMixImpl<T1, +Drop<T1>, U1, +Drop<U1>> of WalletMixTrait<T1, U1> {
 // ANCHOR: main
 fn main() {
     let w1: Wallet<bool, u128> = Wallet { balance: true, address: 10 };
-    let w2 = Wallet { balance: 32, address: 100_u8 };
+    let w2: Wallet<felt252, u8> = Wallet { balance: 32, address: 100 };
 
     let w3 = w1.mixup(w2);
 

--- a/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
+++ b/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
@@ -22,7 +22,7 @@ impl WalletMixImpl<T1, +Drop<T1>, U1, +Drop<U1>> of WalletMixTrait<T1, U1> {
 
 // ANCHOR: main
 fn main() {
-    let w1 = Wallet { balance: true, address: 10_u128 };
+    let w1: Wallet<bool, u128> = Wallet { balance: true, address: 10 };
     let w2 = Wallet { balance: 32, address: 100_u8 };
 
     let w3 = w1.mixup(w2);

--- a/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
+++ b/listings/ch08-generic-types-and-traits/no_listing_14_compiling/src/lib.cairo
@@ -22,8 +22,8 @@ impl WalletMixImpl<T1, +Drop<T1>, U1, +Drop<U1>> of WalletMixTrait<T1, U1> {
 
 // ANCHOR: main
 fn main() {
-    let w1 = Wallet { balance: true, address: 10 };
-    let w2 = Wallet { balance: 32, address: 100 };
+    let w1 = Wallet { balance: true, address: 10_u128 };
+    let w2 = Wallet { balance: 32, address: 100_u8 };
 
     let w3 = w1.mixup(w2);
 


### PR DESCRIPTION
At the end of the chapter 8.1, 2 `Wallet` are instanciated with the following code:

```
    let w1 = Wallet { balance: true, address: 10 };
    let w2 = Wallet { balance: 32, address: 100 };
```

Then, a paragraph explains that we create 2 instances: one of `Wallet<bool, u128>` and the other of `Wallet<felt252, u8>`.

I think that it's not correct as the compiler will use `felt252` to store `10`, `32` and `100` values by default.

To be sure to have an instance of `Wallet<bool, u128>` and another of `Wallet<felt252, u8>`, we have to use `10_u128` and `100_u8`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/490)
<!-- Reviewable:end -->
