### PR TITLE
Fix small typo in 7.2. defining modules

### DIFF
--- a/src/ch07-02-defining-modules-to-control-scope.md
+++ b/src/ch07-02-defining-modules-to-control-scope.md
@@ -96,7 +96,7 @@ included too. That code is:
 {{#include ../listings/ch07-managing-cairo-projects-with-packages-crates-and-modules/no_listing_02_garden/src/lib.cairo}}
 ```
 
-The line `use garden::vegetables::Asparagus;` lets us use bring the `Asparagus` type into scope,
+The line `use garden::vegetables::Asparagus;` lets us bring the `Asparagus` type into scope,
 so we can use it in the `main` function.
 
 Now let’s get into the details of these rules and demonstrate them in action!


### PR DESCRIPTION
Replacing :

The line `use garden::vegetables::Asparagus;` lets us **use** bring the `Asparagus` type into scope,
so we can use it in the `main` function.

with :

The line `use garden::vegetables::Asparagus;` lets us bring the `Asparagus` type into scope,
so we can use it in the `main` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/492)
<!-- Reviewable:end -->
