### PR TITLE
Internal functions in a smart contract

### DIFF
--- a/listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo
@@ -96,6 +96,9 @@ mod NameRegistry {
     //ANCHOR_END: impl_public
 
     // ANCHOR: state_internal
+    // ANCHOR: generate_trait
+
+    // Could be a group of functions about a same topic
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
         fn _store_name(
@@ -116,9 +119,10 @@ mod NameRegistry {
 
         }
     }
-    // ANCHOR_END: state_internal
+    // ANCHOR_END: generate_trait
 
-    // ANCHOR: stateless_internal
+    // Free functions
+
     fn get_contract_name() -> felt252 {
         'Name Registry'
     }
@@ -128,7 +132,7 @@ mod NameRegistry {
         self.owner.address()
     //ANCHOR_END: owner_address
     }
-// ANCHOR_END: stateless_internal
+// ANCHOR_END: state_internal
 }
 //ANCHOR_END: all
 

--- a/src/ch99-01-03-02-contract-functions.md
+++ b/src/ch99-01-03-02-contract-functions.md
@@ -48,17 +48,14 @@ View functions are _public_ functions where the `self: ContractState` is passed 
 
 Functions that are not defined in a block annotated with the `#[abi(embed_v0)]` attribute are private functions (also called internal functions). They can only be called from within the contract.
 
+They can be grouped in a dedicated impl block (e.g in components, to easily import internal functions all at once in the embedding contracts) or just be added as free functions inside the contract module.
+Note that these 2 methods are equivalent. Just choose the one that makes your code more readable and easy to use.
+
 ```rust,noplayground
 {{#include ../listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo:state_internal}}
 ```
 
 > Wait, what is this `#[generate_trait]` attribute? Where is the trait definition for this implementation? Well, the `#[generate_trait]` attribute is a special attribute that tells the compiler to generate a trait definition for the implementation block. This allows you to get rid of the boilerplate code of defining a trait and implementing it for the implementation block. We will see more about this in the [next section](./ch99-01-03-04-reducing-boilerplate.md).
-
-At this point, you might still be wondering if all of this is really necessary if you don't need to access the contract's state in your function (for example, a helper/library function). As a matter of fact, you can also define internal functions outside of implementation blocks. The only reason why we _need_ to define functions inside impl blocks is if we want to access the contract's state.
-
-```rust,noplayground
-{{#include ../listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo:stateless_internal}}
-```
 
 ### 4. [abi(per_item)] attribute
 
@@ -71,4 +68,3 @@ Here is a short example:
 ```rust,noplayground
 {{#include ../listings/ch99-starknet-smart-contracts/listing_99_14_abi_per_item_attribute/src/lib.cairo}}
 ```
-

--- a/src/ch99-01-03-04-reducing-boilerplate.md
+++ b/src/ch99-01-03-04-reducing-boilerplate.md
@@ -3,12 +3,12 @@
 In a previous section, we saw this example of an implementation block in a contract that didn't have any corresponding trait.
 
 ```rust,noplayground
-{{#include ../listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo:state_internal}}
+{{#include ../listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo:generate_trait}}
 ```
 
 It's not the first time that we encounter this attribute, we already talked about in it [Traits in Cairo](./ch08-02-traits-in-cairo.md). In this section, we'll be taking a deeper look at it and see how it can be used in contracts.
 
-Recall that in order to access the ContractState in a function, this function must be defined in an implementation block whose generic parameter is `ContractState`. This implies that we first need to define a generic trait that takes a `TContractState`, and then implement this trait for the `ContractState` type.
+In order to access the ContractState in a function in an implementation block, this implementation block must be defined with a `ContractState` generic parameter. This implies that we first need to define a generic trait that takes a `TContractState`, and then implement this trait for the `ContractState` type.
 But by using the `#[generate_trait]` attribute, this whole process can be skipped and we can simply define the implementation block directly, without any generic parameter, and use `self: ContractState` in our functions.
 
 If we had to manually define the trait for the `InternalFunctions` implementation, it would look something like this:


### PR DESCRIPTION
By reading the explanation about how to write internal functions in a Cairo smart contract, it's not clear if these internal functions must be in an implementation block to access to `ContractState` or not, as the free function `get_owner_storage_address` uses the ContractState and is not in an implementation block.

After discussion on the Starknet discord, it appears that internal functions just have to be outside the implementation block tagged with `#[abi(embed_v0)]`. That means, they can be grouped in an implementation block if it makes the code more readable/easier to use, or just be added as free functions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/509)
<!-- Reviewable:end -->
