### PR TITLE
proofread and fix a few grammar mistakes

### DIFF
--- a/src/ch03-02-dictionaries.md
+++ b/src/ch03-02-dictionaries.md
@@ -6,7 +6,7 @@ The `Felt252Dict<T>` type is useful when you want to organize your data in a cer
 
 ### Basic Use of Dictionaries
 
-It is normal in other languages when creating a new dictionary to define the data types of both key and value. In Cairo, the key type is restricted to `felt252` leaving only the possibility to specify the value data type, represented by `T` in `Felt252Dict<T>`.
+It is normal in other languages when creating a new dictionary to define the data types of both key and value. In Cairo, the key type is restricted to `felt252`, leaving only the possibility to specify the value data type, represented by `T` in `Felt252Dict<T>`.
 
 The core functionality of a `Felt252Dict<T>` is implemented in the trait `Felt252DictTrait` which includes all basic operations. Among them we can find:
 
@@ -109,7 +109,7 @@ In case of a change on any of the values of the first table, squashing would hav
 
 ### Dictionary Destruction
 
-If you run the examples from [Basic Use of Dictionaries](#basic-use-of-dictionaries) you'd notice that there was never a call to squash dictionary, but the program compiled successfully nonetheless. What happened behind the scene was that squash was called automatically via the `Felt252Dict<T>` implementation of the `Destruct<T>` trait. This call occurred just before the `balance` dictionary went out of scope.
+If you run the examples from [Basic Use of Dictionaries](#basic-use-of-dictionaries), you'd notice that there was never a call to squash dictionary, but the program compiled successfully nonetheless. What happened behind the scene was that squash was called automatically via the `Felt252Dict<T>` implementation of the `Destruct<T>` trait. This call occurred just before the `balance` dictionary went out of scope.
 
 The `Destruct<T>` trait represents another way of removing instances out of scope apart from `Drop<T>`. The main difference between these two is that `Drop<T>` is treated as a no-op operation, meaning it does not generate new CASM while `Destruct<T>` does not have this restriction. The only type which actively uses the `Destruct<T>` trait is `Felt252Dict<T>`, for every other type `Destruct<T>` and `Drop<T>` are synonyms. You can read more about these traits in [Drop and Destruct](/appendix-03-derivable-traits.md#drop-and-destruct).
 

--- a/src/ch04-01-what-is-ownership.md
+++ b/src/ch04-01-what-is-ownership.md
@@ -170,7 +170,7 @@ Here’s an example of the `clone` method in action.
 ```
 
 When you see a call to `clone`, you know that some arbitrary code is being executed and that code may be expensive. It’s a visual indicator that something different is going on.
-In this case, _value_ is being copied, resulting in new memory cells being used, and the a new _variable_ is created, referring to the new, copied value.
+In this case, _value_ is being copied, resulting in new memory cells being used, and a new _variable_ is created, referring to the new, copied value.
 
 ### Return Values and Scope
 

--- a/src/ch04-02-references-and-snapshots.md
+++ b/src/ch04-02-references-and-snapshots.md
@@ -77,7 +77,7 @@ In the following example, we want to calculate the area of a rectangle, but we d
 {{#include ../listings/ch04-understanding-ownership/no_listing_10_desnap/src/lib.cairo}}
 ```
 
-But, what happens if we try to modify something we’re passing as snapshot? Try the code in
+But, what happens if we try to modify something we’re passing as a snapshot? Try the code in
 Listing 4-6. Spoiler alert: it doesn’t work!
 
 <span class="filename">Filename: src/lib.cairo</span>

--- a/src/ch09-01-how-to-write-tests.md
+++ b/src/ch09-01-how-to-write-tests.md
@@ -251,7 +251,7 @@ The failure message indicates that this test did indeed panic as we expected, bu
 
 Sometimes, running a full test suite can take a long time. If you’re working on code in a particular area, you might want to run only the tests pertaining to that code. You can choose which tests to run by passing `scarb cairo-test` an option `-f` (for "filter"), followed by the name of the test you want to run as an argument.
 
-To demonstrate how to run a single test, we’ll first create two tests functions, as shown in Listing 9-10, and choose which ones to run.
+To demonstrate how to run a single test, we’ll first create two test functions, as shown in Listing 9-10, and choose which ones to run.
 
 <span class="filename">Filename: src/lib.cairo</span>
 

--- a/src/ch99-01-01-introduction-to-smart-contracts.md
+++ b/src/ch99-01-01-introduction-to-smart-contracts.md
@@ -1,6 +1,6 @@
 # Introduction to smart-contracts
 
-This chapter will give you a high level introduction to what smart-contracts are, what are they used for and why would blockchain developers use Cairo and Starknet.
+This chapter will give you a high level introduction to what smart-contracts are, what are they used for, and why would blockchain developers use Cairo and Starknet.
 If you are already familiar with blockchain programming, feel free to skip this chapter. The last part might still be interesting though.
 
 ## Smart-contracts


### PR DESCRIPTION
Noticed some mistakes when reading the book, this PR makes minor changes to fix them:
* "the a variable" -> "a variable"
* "two tests functions" -> "two test functions"
* "passing as snapshot" -> "passing as a snapshot"
* a few missing commas

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/522)
<!-- Reviewable:end -->
