### PR TITLE
i18n: Add Turkish Language

### DIFF
--- a/LANGUAGES
+++ b/LANGUAGES
@@ -1,1 +1,1 @@
-es fr zh-cn id
+es fr zh-cn id tr

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,33 +1,32 @@
-
 msgid ""
 msgstr ""
 "Project-Id-Version: The Cairo Programming Language\n"
-"POT-Creation-Date: 2024-02-08T05:36:14+03:00\n"
-"PO-Revision-Date: \n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"POT-Creation-Date: 2024-02-05T19:07:56+03:00\n"
+"PO-Revision-Date: 2024-02-05 16:55+0300\n"
+"Last-Translator:  <omeraydin2112@gmail.com>\n"
+"Language-Team: Turkish <gnome-turk@gnome.org>\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/SUMMARY.md:1 src/title-page.md:1
 msgid "The Cairo Programming Language"
-msgstr ""
+msgstr "Cairo Programlama Dili"
 
 #: src/SUMMARY.md:3
 msgid "The Cairo Programming Language Foreword Introduction"
-msgstr ""
+msgstr "Cairo Programlama Dili Önsöz Giriş"
 
 #: src/SUMMARY.md:7 src/SUMMARY.md:9 src/ch01-00-getting-started.md:1
 msgid "Getting Started"
-msgstr ""
+msgstr "Başlangıç"
 
 #: src/SUMMARY.md:11 src/ch01-01-installation.md:1
 #: src/ch01-01-installation.md:19
 msgid "Installation"
-msgstr ""
+msgstr "Kurulum"
 
 #: src/SUMMARY.md:12
 msgid "Hello, World!"
@@ -36,305 +35,311 @@ msgstr ""
 #: src/SUMMARY.md:14 src/SUMMARY.md:16
 #: src/ch02-00-common-programming-concepts.md:1
 msgid "Common Programming Concepts"
-msgstr ""
+msgstr "Genel Programlama Kavramları"
 
 #: src/SUMMARY.md:17 src/ch02-01-variables-and-mutability.md:1
 msgid "Variables and Mutability"
-msgstr ""
+msgstr "Değişkenler ve Değişkenlik"
 
 #: src/SUMMARY.md:18 src/ch02-02-data-types.md:1
 msgid "Data Types"
-msgstr ""
+msgstr "Veri Türleri"
 
 #: src/SUMMARY.md:19 src/ch02-03-functions.md:1
 msgid "Functions"
-msgstr ""
+msgstr "Fonksiyonlar"
 
 #: src/SUMMARY.md:20 src/ch02-04-comments.md:1
 msgid "Comments"
-msgstr ""
+msgstr "Yorumlar"
 
 #: src/SUMMARY.md:21 src/ch02-05-control-flow.md:1
 msgid "Control Flow"
-msgstr ""
+msgstr "Kontrol Akışı"
 
 #: src/SUMMARY.md:23 src/SUMMARY.md:25 src/ch03-00-common-collections.md:1
 msgid "Common Collections"
-msgstr ""
+msgstr "Ortak Koleksiyonlar"
 
 #: src/SUMMARY.md:26 src/ch03-01-arrays.md:1
 msgid "Arrays"
-msgstr ""
+msgstr "Diziler"
 
 #: src/SUMMARY.md:27 src/ch03-02-dictionaries.md:1
 msgid "Dictionaries"
-msgstr ""
+msgstr "Sözlükler"
 
 #: src/SUMMARY.md:28 src/ch03-03-custom-data-structures.md:1
 msgid "Custom Data Structures"
-msgstr ""
+msgstr "Özel Veri Yapıları"
 
 #: src/SUMMARY.md:30 src/SUMMARY.md:32
 msgid "Understanding Ownership"
-msgstr ""
+msgstr "Sahipliği Anlamak"
 
 #: src/SUMMARY.md:33
 msgid "What is Ownership?"
-msgstr ""
+msgstr "Sahiplik Nedir?"
 
 #: src/SUMMARY.md:34 src/ch04-02-references-and-snapshots.md:1
 msgid "References and Snapshots"
-msgstr ""
+msgstr "Referanslar ve Anlık Görüntüler"
 
 #: src/SUMMARY.md:36 src/SUMMARY.md:38
 #: src/ch05-00-using-structs-to-structure-related-data.md:1
 msgid "Using Structs to Structure Related Data"
-msgstr ""
+msgstr "İlgili Verileri Yapılandırmak için Structları Kullanma"
 
 #: src/SUMMARY.md:39 src/ch05-01-defining-and-instantiating-structs.md:1
 msgid "Defining and Instantiating Structs"
-msgstr ""
+msgstr "Structları Tanımlama ve Örnekleme"
 
 #: src/SUMMARY.md:40 src/ch05-02-an-example-program-using-structs.md:1
 msgid "An Example Program Using Structs"
-msgstr ""
+msgstr "Structları Kullanan Örnek Bir Program"
 
 #: src/SUMMARY.md:41 src/ch05-03-method-syntax.md:1
 msgid "Method Syntax"
-msgstr ""
+msgstr "Metod Sözdizimi"
 
 #: src/SUMMARY.md:43 src/SUMMARY.md:45
 #: src/ch06-00-enums-and-pattern-matching.md:1
 msgid "Enums and Pattern Matching"
-msgstr ""
+msgstr "Enumlar ve Kalıp Eşleştirme"
 
 #: src/SUMMARY.md:46 src/ch06-01-enums.md:1
 #: src/ch08-01-generic-data-types.md:186
 msgid "Enums"
-msgstr ""
+msgstr "Enumlar"
 
 #: src/SUMMARY.md:47 src/ch06-02-the-match-control-flow-construct.md:1
 msgid "The Match Control Flow Construct"
-msgstr ""
+msgstr "Eşleştirme Kontrol Akış Yapısı"
 
 #: src/SUMMARY.md:49 src/SUMMARY.md:51
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:1
 msgid "Managing Cairo Projects with Packages, Crates and Modules"
-msgstr ""
+msgstr "Cairo Projelerini Paketler, Kasalar ve Modüllerle Yönetme"
 
 #: src/SUMMARY.md:53 src/ch07-01-packages-and-crates.md:1
 msgid "Packages and Crates"
-msgstr ""
+msgstr "Paketler ve Kasalar"
 
 #: src/SUMMARY.md:54 src/ch07-02-defining-modules-to-control-scope.md:1
 msgid "Defining Modules to Control Scope"
-msgstr ""
+msgstr "Kapsamı Kontrol Etmek için Modülleri Tanımlama"
 
 #: src/SUMMARY.md:55
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:1
 msgid "Paths for Referring to an Item in the Module Tree"
-msgstr ""
+msgstr "Modül Ağacındaki Bir Öğeye Başvurma Yolları"
 
 #: src/SUMMARY.md:56
 msgid "Bringing Paths into Scope with the 'use' Keyword"
-msgstr ""
+msgstr "'use' Anahtar Sözcüğü ile Yolları Kapsam İçine Alma"
 
 #: src/SUMMARY.md:57 src/ch07-05-separating-modules-into-different-files.md:1
 msgid "Separating Modules into Different Files"
-msgstr ""
+msgstr "Modülleri Farklı Dosyalara Ayırma"
 
 #: src/SUMMARY.md:59 src/ch08-01-generic-data-types.md:1
 msgid "Generic Data Types"
-msgstr ""
+msgstr "Genel Veri Türleri"
 
 #: src/SUMMARY.md:61
 msgid "Generic Types"
-msgstr ""
+msgstr "Genel Türler"
 
 #: src/SUMMARY.md:63 src/ch08-01-generic-data-types.md:5
 msgid "Generic Functions"
-msgstr ""
+msgstr "Genel Fonksiyonlar"
 
 #: src/SUMMARY.md:64 src/ch08-02-traits-in-cairo.md:1
 msgid "Traits in Cairo"
-msgstr ""
+msgstr "Cairo'daki Özellikler"
 
 #: src/SUMMARY.md:66 src/SUMMARY.md:68 src/ch09-00-testing-cairo-programs.md:1
 msgid "Testing Cairo Programs"
-msgstr ""
+msgstr "Cairo Programlarını Test Etme"
 
 #: src/SUMMARY.md:70 src/ch09-01-how-to-write-tests.md:1
 msgid "How To Write Tests"
-msgstr ""
+msgstr "Testler Nasıl Yazılır"
 
 #: src/SUMMARY.md:71 src/ch09-02-test-organization.md:1
 msgid "Testing Organization"
-msgstr ""
+msgstr "Test Organizasyonu"
 
 #: src/SUMMARY.md:73 src/SUMMARY.md:75
 msgid "Error Handling"
-msgstr ""
+msgstr "Hata İşleme"
 
 #: src/SUMMARY.md:77 src/ch10-01-unrecoverable-errors-with-panic.md:1
 msgid "Unrecoverable Errors with panic"
-msgstr ""
+msgstr "Panic ile Kurtarılamayan Hatalar"
 
 #: src/SUMMARY.md:78
 msgid "Recoverable Errors with Result"
-msgstr ""
+msgstr "Result ile Kurtarılabilir Hatalar"
 
 #: src/SUMMARY.md:80 src/SUMMARY.md:82 src/ch11-00-advanced-features.md:1
 msgid "Advanced Features"
-msgstr ""
+msgstr "Gelişmiş Özellikler"
 
 #: src/SUMMARY.md:84 src/ch11-01-operator-overloading.md:1
 msgid "Operator Overloading"
-msgstr ""
+msgstr "Operatörün Aşırı Yüklenmesi"
 
 #: src/SUMMARY.md:85 src/ch11-02-macros.md:1
 msgid "Macros"
-msgstr ""
+msgstr "Makrolar"
 
 #: src/SUMMARY.md:86 src/ch11-03-hash.md:19
 msgid "Working with Hashes"
-msgstr ""
+msgstr "Hash'lerle Çalışma"
 
 #: src/SUMMARY.md:88
 msgid "Starknet smart contracts"
-msgstr ""
+msgstr "Starknet akıllı sözleşmeleri"
 
 #: src/SUMMARY.md:90 src/ch99-00-starknet-smart-contracts.md:1
 msgid "Starknet Smart Contracts"
-msgstr ""
+msgstr "Starknet Akıllı Sözleşmeleri"
 
 #: src/SUMMARY.md:92 src/ch99-01-01-introduction-to-smart-contracts.md:1
 msgid "Introduction to smart-contracts"
-msgstr ""
+msgstr "Akıllı sözleşmelere giriş"
 
 #: src/SUMMARY.md:93 src/ch99-01-02-a-simple-contract.md:1
 msgid "A simple contract"
-msgstr ""
+msgstr "Basit bir sözleşme"
 
 #: src/SUMMARY.md:94 src/ch99-01-03-00-a-deeper-dive-into-contracts.md:1
 msgid "A deeper dive into contracts"
-msgstr ""
+msgstr "Sözleşmelere daha derinlemesine bir bakış"
 
 #: src/SUMMARY.md:96 src/ch99-01-03-01-contract-storage.md:1
 msgid "Contract Storage"
-msgstr ""
+msgstr "Sözleşme Depolama"
 
 #: src/SUMMARY.md:97 src/ch99-01-03-02-contract-functions.md:1
 msgid "Contract Functions"
-msgstr ""
+msgstr "Sözleşme Fonksiyonları"
 
 #: src/SUMMARY.md:98
 msgid "Contract Events"
-msgstr ""
+msgstr "Sözleşme Olayları"
 
 #: src/SUMMARY.md:99 src/ch99-01-03-04-reducing-boilerplate.md:1
 msgid "Reducing boilerplate"
-msgstr ""
+msgstr "Boilerplate'i azaltma"
 
 #: src/SUMMARY.md:100
 msgid "Optimizing storage costs"
-msgstr ""
+msgstr "Depolama maliyetlerini optimize etme"
 
 #: src/SUMMARY.md:102
 msgid "Components"
-msgstr ""
+msgstr "Bileşenler"
 
 #: src/SUMMARY.md:104
 msgid "Under the hood"
-msgstr ""
+msgstr "Kaputun altı"
 
 #: src/SUMMARY.md:105 src/ch99-01-05-02-component-dependencies.md:1
 msgid "Component dependencies"
-msgstr ""
+msgstr "Bileşen bağımlılıkları"
 
 #: src/SUMMARY.md:106 src/ch99-01-05-03-testing-components.md:1
 msgid "Testing components"
-msgstr ""
+msgstr "Bileşenleri test etme"
 
 #: src/SUMMARY.md:108
 msgid "ABIs and Cross-contract Interactions"
-msgstr ""
+msgstr "ABI'ler ve Sözleşmeler Arası Etkileşimler"
 
 #: src/SUMMARY.md:110
 msgid "ABIs and Interfaces"
-msgstr ""
+msgstr "ABI'lar ve Arabirimler"
 
 #: src/SUMMARY.md:111
 msgid "Contract Dispatchers, Library Dispatchers and system calls"
-msgstr ""
+msgstr "Sözleşme Dağıtıcıları, Kütüphane Dağıtıcıları ve sistem çağrıları"
 
 #: src/SUMMARY.md:113 src/ch99-01-04-00-other-examples.md:1
 msgid "Other examples"
-msgstr ""
+msgstr "Başka örnekler"
 
 #: src/SUMMARY.md:115 src/ch99-01-04-01-voting-contract.md:1
 msgid "Deploying and Interacting with a Voting contract"
-msgstr ""
+msgstr "Bir Oylama sözleşmesini dağıtma ve onunla etkileşim kurma"
 
 #: src/SUMMARY.md:117
 msgid "L1 \\<\\> L2 Messaging"
-msgstr ""
+msgstr "L1 \\<\\> L2 Mesajlaşma"
 
 #: src/SUMMARY.md:118 src/ch99-03-security-considerations.md:1
 msgid "Security Considerations"
-msgstr ""
+msgstr "Güvenlikle İlgili Hususlar"
 
 #: src/SUMMARY.md:120 src/appendix-00.md:1
 msgid "Appendix"
-msgstr ""
+msgstr "Ek Bilgiler"
 
 #: src/SUMMARY.md:122
 msgid "A - Keywords"
-msgstr ""
+msgstr "A - Anahtar Sözcükler"
 
 #: src/SUMMARY.md:123
 msgid "B - Operators and Symbols"
-msgstr ""
+msgstr "B - Operatörler ve Semboller"
 
 #: src/SUMMARY.md:124
 msgid "C - Derivable Traits"
-msgstr ""
+msgstr "C - Türetilebilir Özellikler"
 
 #: src/SUMMARY.md:125
 msgid "D - Useful Development Tools"
-msgstr ""
+msgstr "D - Faydalı Geliştirme Araçları"
 
 #: src/SUMMARY.md:126
 msgid "E - Common Types & Traits and the Cairo Prelude"
-msgstr ""
+msgstr "E - Yaygın Tipler ve Özellikler ve Cairo Prelüdü"
 
 #: src/SUMMARY.md:127
 msgid "F - Installing Cairo binaries"
-msgstr ""
+msgstr "F - Cairo ikili dosyalarının yüklenmesi"
 
 #: src/SUMMARY.md:128
 msgid "G - System Calls"
-msgstr ""
+msgstr "G - Sistem Çağrıları"
 
 #: src/title-page.md:3
 msgid ""
-"By the Cairo Community and its "
-"[contributors](https://github.com/cairo-book/cairo-book.github.io). Special "
-"thanks to [Starkware](https://starkware.co/) through "
-"[OnlyDust](https://www.onlydust.xyz/), and "
-"[Voyager](https://voyager.online/) for supporting the creation of this book."
+"By the Cairo Community and its [contributors](https://github.com/cairo-book/"
+"cairo-book.github.io). Special thanks to [Starkware](https://starkware.co/) "
+"through [OnlyDust](https://www.onlydust.xyz/), and [Voyager](https://voyager."
+"online/) for supporting the creation of this book."
 msgstr ""
+"Cairo Topluluğu ve [katkıda bulunanlar](https://github.com/cairo-book/"
+"cairo-book.github.io) tarafından. Bu kitabın oluşturulmasını destekleyen [Starkwar'e](https://starkware.co/) "
+" [OnlyDust](https://www.onlydust.xyz/) aracılığıyla ve [Voyager'a](https://voyager."
+"online/) özel teşekkürler."
 
 #: src/title-page.md:5
 msgid ""
-"This version of the text assumes you’re using the [Cairo "
-"Compiler](https://github.com/starkware-libs/cairo) [version "
-"2.5.1](https://github.com/starkware-libs/cairo/releases). See the "
-"“Installation” section of Chapter 1 to install or update Cairo."
+"This version of the text assumes you’re using the [Cairo Compiler](https://"
+"github.com/starkware-libs/cairo) [version 2.5.1](https://github.com/"
+"starkware-libs/cairo/releases). See the “Installation” section of Chapter 1 "
+"to install or update Cairo."
 msgstr ""
+"Bu metin versiyonu, [Cairo Derleyicisi'nin](https://"
+"github.com/starkware-libs/cairo) [2.5.1 sürümünü ](https://github.com/"
+"starkware-libs/cairo/releases) kullandığınızı varsaymaktadır. Cairo'yu yüklemek veya güncellemek için 1. Bölüm'ün "Kurulum" bölümüne bakın."
 
 #: src/ch00-01-foreword.md:1
 msgid "Foreword"
-msgstr ""
+msgstr "Önsöz"
 
 #: src/ch00-01-foreword.md:3
 msgid ""
@@ -345,6 +350,10 @@ msgid ""
 "underlying cryptographic primitives required to build a proof for the "
 "execution of a program."
 msgstr ""
+"2020 yılında, StarkWare, doğrulanabilir hesaplamayı destekleyen Turing-complete bir programlama "
+"dili olan Cairo 0'ı yayımladı. Cairo, bir montaj dili olarak başladı ve giderek daha ifade gücü "
+"yüksek hale geldi. Öğrenme eğrisi başlangıçta dikti, çünkü Cairo 0.x düşük seviyeli bir dil olup, "
+"bir programın yürütülmesi için bir kanıt oluşturmak üzere gerekli olan temel kriptografik primitifleri tamamen soyutlamıyordu."
 
 #: src/ch00-01-foreword.md:5
 msgid ""
@@ -357,6 +366,12 @@ msgid ""
 "execution of Cairo programs is now _blazingly_ fast, allowing you to build "
 "an extensive test suite without compromising on performance."
 msgstr ""
+"Cairo 1'in yayımlanmasıyla birlikte, geliştirici deneyimi önemli ölçüde iyileşti, mümkün olan yerlerde Cairo "
+"mimarisinin altında yatan değişmez bellek modelini soyutlayarak. Rust'tan güçlü bir şekilde esinlenilerek oluşturulan "
+"Cairo 1, altında yatan mimarisinin özel bilgisine ihtiyaç duymadan kanıtlanabilir programlar oluşturmanıza yardımcı olmak "
+"için tasarlanmıştır, böylece programın kendisine odaklanabilir ve Cairo programlarının genel güvenliğini artırabilirsiniz. "
+"Bir Rust VM tarafından desteklenen Cairo programlarının yürütülmesi artık şaşırtıcı derecede hızlıdır, bu da performanstan "
+"ödün vermeden kapsamlı bir test paketi oluşturmanıza olanak tanır."
 
 #: src/ch00-01-foreword.md:7
 msgid ""
@@ -366,6 +381,11 @@ msgid ""
 "prover, which is then verified on Ethereum L1 prior to updating the state "
 "root of Starknet."
 msgstr ""
+"Starknet üzerine sözleşmeler dağıtmak isteyen blockchain geliştiricileri, "
+"akıllı sözleşmelerini kodlamak için Cairo programlama dilini kullanacaklar. "
+"Bu, Starknet OS'nin, işlemler için yürütme izlerini üretmesine olanak tanır ve "
+"ardından bir kanıtlayıcı tarafından kanıtlanır, bu da Ethereum L1 üzerinde doğrulanmadan "
+"önce Starknet'in durum kökünün güncellenmesi için kullanılır."
 
 #: src/ch00-01-foreword.md:9
 msgid ""
@@ -374,6 +394,10 @@ msgid ""
 "from being proved on one computer and verified on other machines with lower "
 "hardware requirements."
 msgstr ""
+"Ancak, Cairo yalnızca blockchain geliştiricileri için değildir. Genel amaçlı "
+"bir programlama dili olarak, bir bilgisayarda kanıtlanması ve daha düşük donanım "
+"gereksinimlerine sahip diğer makinelerde doğrulanması faydalı olacak herhangi bir "
+"hesaplama için kullanılabilir."
 
 #: src/ch00-01-foreword.md:11
 msgid ""
@@ -383,34 +407,23 @@ msgid ""
 "programming skills in general. So, dive in and get ready to learn all there "
 "is to know about Cairo!"
 msgstr ""
+"Bu kitap, programlama konseptlerine temel bir anlayışa sahip geliştiriciler "
+"için tasarlanmıştır. Dostane ve yaklaşılabilir bir metin olarak, sizi Cairo "
+"hakkında bilginizi artırmaya, ancak aynı zamanda genel olarak programlama "
+"becerilerinizi geliştirmeye yardımcı olmayı amaçlamaktadır. Bu yüzden dalın "
+"ve Cairo hakkında bilinmesi gereken her şeyi öğrenmeye hazır olun!"
 
 #: src/ch00-01-foreword.md:13
-msgid "Acknowledgements"
-msgstr ""
-
-#: src/ch00-01-foreword.md:15
-msgid ""
-"This book would not have been possible without the help of the Cairo "
-"community. We would like to thank every contributor for their contributions "
-"to this book!"
-msgstr ""
-
-#: src/ch00-01-foreword.md:17
-msgid ""
-"We would like to thank the Rust community for the [Rust "
-"Book](https://doc.rust-lang.org/book/), which has been a great source of "
-"inspiration for this book. Many examples and explanations have been adapted "
-"from the Rust Book to fit the Cairo programming language, as the two "
-"languages share many similarities."
-msgstr ""
+msgid "— The Cairo community"
+msgstr "— Cairo Topluluğu"
 
 #: src/ch00-00-introduction.md:1
 msgid "Introduction"
-msgstr ""
+msgstr "Giriş"
 
 #: src/ch00-00-introduction.md:3
 msgid "What is Cairo?"
-msgstr ""
+msgstr "Cairo Nedir?"
 
 #: src/ch00-00-introduction.md:5
 msgid ""
@@ -426,10 +439,20 @@ msgid ""
 "CASM. The point of Sierra is to ensure your CASM will always be provable, "
 "even when the computation fails."
 msgstr ""
+"Cairo, aynı adı taşıyan sanal bir CPU için tasarlanmış bir programlama "
+"dilidir. Bu işlemcinin benzersiz yönü, fiziksel dünyamızın kısıtlamaları için "
+"değil, kriptografik olanlar için yaratılmış olmasıdır, bu da herhangi bir programın "
+"üzerinde çalıştığının etkin bir şekilde kanıtlanabilmesini sağlar. Bu, güvenmediğiniz "
+"bir makinede zaman alıcı işlemler gerçekleştirebileceğiniz ve sonucu daha ucuz bir makinede "
+"çok hızlı bir şekilde kontrol edebileceğiniz anlamına gelir. Cairo 0, doğrudan CASM'e, yani "
+"Cairo CPU montajına derlenirken, Cairo 1 daha yüksek seviyeli bir dildir. İlk olarak "
+"Sierra'ya derlenir, bu da Cairo'nun ara bir temsilidir ve daha sonra CASM'in güvenli bir "
+"alt kümesine derlenecektir. Sierra'nın amacı, hesaplama başarısız olduğunda bile CASM'inizin "
+"her zaman kanıtlanabilir olmasını sağlamaktır."
 
 #: src/ch00-00-introduction.md:8
 msgid "What can you do with it?"
-msgstr ""
+msgstr "Bununla ne yapabilirsin?"
 
 #: src/ch00-00-introduction.md:10
 msgid ""
@@ -446,10 +469,21 @@ msgid ""
 "interactions themselves. This approach allows for increased throughput and "
 "reduced transaction costs while preserving Ethereum security."
 msgstr ""
+"Cairo, güvenilmeyen makinelerde güvenilir değerler hesaplamanıza olanak "
+"tanır. Önemli bir kullanım örneği Starknet'tir, bu da Ethereum ölçeklendirme "
+"çözümüdür. Ethereum, her bir kullanıcı ile merkezi olmayan bir uygulama (d-app) "
+"arasındaki her etkileşimin tüm katılımcılar tarafından doğrulanmasını sağlayan "
+"merkezi olmayan bir blockchain platformudur. Starknet, Ethereum'un üzerine inşa "
+"edilmiş bir Katman 2'dir. Ağın tüm katılımcılarının tüm kullanıcı etkileşimlerini "
+"doğrulaması yerine, yalnızca kanıtlayıcı olarak adlandırılan tek bir düğüm, programları "
+"çalıştırır ve hesaplamaların doğru bir şekilde yapıldığına dair kanıtlar üretir. Bu kanıtlar "
+"daha sonra bir Ethereum akıllı sözleşmesi tarafından doğrulanır ve bu, etkileşimlerin kendilerini "
+"gerçekleştirmeye kıyasla önemli ölçüde daha az hesaplama gücü gerektirir. Bu yaklaşım, Ethereum "
+"güvenliğini korurken artırılmış verimlilik ve azaltılmış işlem maliyetleri sağlar."
 
 #: src/ch00-00-introduction.md:12
 msgid "What are the differences with other programming languages?"
-msgstr ""
+msgstr "Diğer programlama dilleri ile arasındaki farklar nelerdir?"
 
 #: src/ch00-00-introduction.md:14
 msgid ""
@@ -457,6 +491,8 @@ msgid ""
 "when it comes to overhead costs and its primary advantages. Your program can "
 "be executed in two different ways:"
 msgstr ""
+"Cairo, özellikle genel maliyetler ve temel avantajlar açısından geleneksel programlama dillerinden "
+"oldukça farklıdır. Programınız iki farklı şekilde çalıştırılabilir:"
 
 #: src/ch00-00-introduction.md:16
 msgid ""
@@ -465,6 +501,10 @@ msgid ""
 "designed for maximum efficiency, this can lead to some performance overhead "
 "but it is not the most relevant part to optimize."
 msgstr ""
+"Kanıtlayıcı tarafından çalıştırıldığında, diğer dillerle benzerdir. Cairo'nun "
+"sanallaştırılmış olması ve işlemlerin özellikle maksimum verimlilik için "
+"tasarlanmamış olması, bazı performans maliyetlerine yol açabilir, ancak bu, "
+"optimize edilmesi gereken en önemli kısım değildir."
 
 #: src/ch00-00-introduction.md:18
 msgid ""
@@ -474,13 +514,22 @@ msgid ""
 "and Cairo has some unique advantages to improve it even more. A notable one "
 "is non-determinism. This is a topic you will cover in more detail later in "
 "this book, but the idea is that you can theoretically use a different "
-"algorithm for verifying than for computing. Currently, writing custom "
-"non-deterministic code is not supported for the developers, but the standard "
+"algorithm for verifying than for computing. Currently, writing custom non-"
+"deterministic code is not supported for the developers, but the standard "
 "library leverages non-determinism for improved performance. For example "
 "sorting an array in Cairo costs the same price as copying it. Because the "
 "verifier doesn't sort the array, it just checks that it is sorted, which is "
 "cheaper."
 msgstr ""
+"Kanıt bir doğrulayıcı tarafından doğrulandığında, durum biraz farklıdır. Bu, potansiyel "
+"olarak birçok küçük makinede doğrulanabileceği için mümkün olduğunca ucuz olmalıdır. Neyse ki, "
+"doğrulama hesaplamadan daha hızlıdır ve Cairo, bunu daha da iyileştirecek bazı benzersiz "
+"avantajlara sahiptir. Önemli bir avantaj, belirsizliktir (non-determinizm). Bu, kitapta daha "
+"sonra daha detaylı ele alacağınız bir konu, ancak fikir, teorik olarak hesaplama için "
+"kullanılandan farklı bir algoritma kullanabilmenizdir. Şu anda, geliştiriciler için özel belirsiz "
+"kod yazma desteklenmiyor, ancak standart kütüphane performansı artırmak için belirsizlikten "
+"yararlanıyor. Örneğin, Cairo'da bir diziyi sıralamanın maliyeti, onu kopyalamakla aynıdır. Çünkü "
+"doğrulayıcı dizi sıralamaz, sadece sıralı olduğunu kontrol eder, bu da daha ucuzdur."
 
 #: src/ch00-00-introduction.md:20
 msgid ""
@@ -491,61 +540,75 @@ msgid ""
 "Therefore, developers must think carefully about how they manage memory and "
 "data structures in their programs to optimize performance."
 msgstr ""
+"Dili ayıran bir diğer yönü, bellek modelidir. Cairo'da, bellek erişimi değişmezdir, yani bir "
+"değer bir kere belleğe yazıldığında, değiştirilemez. Cairo 1, geliştiricilerin bu kısıtlamalarla "
+"çalışmasına yardımcı olan soyutlamalar sağlar, ancak değiştirilebilirliği tam olarak simüle "
+"etmez. Bu nedenle, geliştiriciler performansı optimize etmek için programlarında belleği ve "
+"veri yapılarını nasıl yönettiklerini dikkatlice düşünmelidir."
 
 #: src/ch00-00-introduction.md:22
 msgid "References"
-msgstr ""
+msgstr "Referanslar"
 
 #: src/ch00-00-introduction.md:24
 msgid "Cairo CPU Architecture: <https://eprint.iacr.org/2021/1063>"
-msgstr ""
+msgstr "Cairo CPU Mimarisi"
 
 #: src/ch00-00-introduction.md:25
 msgid ""
-"Cairo, Sierra and Casm: "
-"<https://medium.com/nethermind-eth/under-the-hood-of-cairo-1-0-exploring-sierra-7f32808421f5>"
+"Cairo, Sierra and Casm: <https://medium.com/nethermind-eth/under-the-hood-of-"
+"cairo-1-0-exploring-sierra-7f32808421f5>"
 msgstr ""
+"Cairo, Sierra ve Casm: <https://medium.com/nethermind-eth/under-the-hood-of-"
+"cairo-1-0-exploring-sierra-7f32808421f5>"
 
 #: src/ch00-00-introduction.md:26
 msgid ""
-"State of non determinism: "
-"<https://twitter.com/PapiniShahar/status/1638203716535713798>"
+"State of non determinism: <https://twitter.com/PapiniShahar/"
+"status/1638203716535713798>"
 msgstr ""
+"Determinizm dışı durum: <https://twitter.com/PapiniShahar/"
+"status/1638203716535713798>"
 
 #: src/ch01-00-getting-started.md:3
 msgid ""
 "Let’s start your Cairo journey! There’s a lot to learn, but every journey "
 "starts somewhere. In this chapter, we’ll discuss:"
 msgstr ""
+"Cairo yolculuğunuza başlayalım! Öğrenilecek çok şey var, ama her yolculuk bir yerden başlar. Bu bölümde, şunları tartışacağız:"
 
 #: src/ch01-00-getting-started.md:5
 msgid ""
 "Installing Scarb, which is Cairo's build toolchain and package manager, on "
 "Linux, macOS, and Windows."
 msgstr ""
+"Linux, macOS ve Windows üzerinde Cairo'nun derleme araç zinciri ve paket yöneticisi olan Scarb'ı kurma."
 
 #: src/ch01-00-getting-started.md:6
 msgid "Writing a program that prints `Hello, world!`."
-msgstr ""
+msgstr "`Hello, world!` yazdıran bir program yazma."
 
 #: src/ch01-00-getting-started.md:7
 msgid "Using basic Scarb commands to create a project and execute a program."
-msgstr ""
+msgstr "Bir proje oluşturmak ve bir programı çalıştırmak için temel Scarb komutlarını kullanma."
 
 #: src/ch01-01-installation.md:3
 msgid ""
-"Cairo can be installed by simply downloading "
-"[Scarb](https://docs.swmansion.com/scarb/docs). Scarb bundles the Cairo "
-"compiler and the Cairo language server together in an easy-to-install "
-"package so that you can start writing Cairo code right away."
+"Cairo can be installed by simply downloading [Scarb](https://docs.swmansion."
+"com/scarb/docs). Scarb bundles the Cairo compiler and the Cairo language "
+"server together in an easy-to-install package so that you can start writing "
+"Cairo code right away."
 msgstr ""
+"Cairo, basitçe Scarb'ı indirerek kurulabilir. Scarb, Cairo derleyicisini ve "
+"Cairo dil sunucusunu kolayca kurulabilen bir pakette bir araya getirir, böylece "
+"hemen Cairo kodu yazmaya başlayabilirsiniz."
 
 #: src/ch01-01-installation.md:5
 msgid ""
-"Scarb is also Cairo's package manager and is heavily inspired by "
-"[Cargo](https://doc.rust-lang.org/cargo/), Rust’s build system and package "
-"manager."
+"Scarb is also Cairo's package manager and is heavily inspired by [Cargo]"
+"(https://doc.rust-lang.org/cargo/), Rust’s build system and package manager."
 msgstr ""
+"Scarb ayrıca Cairo'nun paket yöneticisidir ve Rust'ın derleme sistemi ve paket yöneticisi olan Cargo'dan büyük ölçüde ilham alır."
 
 #: src/ch01-01-installation.md:7
 msgid ""
@@ -554,6 +617,8 @@ msgid ""
 "depends on, building those libraries, and provides LSP support for the "
 "VSCode Cairo 1 extension."
 msgstr ""
+"Scarb, kodunuzu derleme (ister saf Cairo ister Starknet sözleşmeleri), kodunuzun bağlı olduğu kütüphaneleri indirme, "
+"bu kütüphaneleri derleme ve VSCode Cairo 1 uzantısı için LSP desteği sağlama gibi birçok görevi sizin için üstlenir."
 
 #: src/ch01-01-installation.md:9
 msgid ""
@@ -561,57 +626,69 @@ msgid ""
 "you start a project using Scarb, managing external code and dependencies "
 "will be a lot easier to do."
 msgstr ""
+"Daha karmaşık Cairo programları yazdıkça, bağımlılıklar ekleyebilir ve eğer bir projeye Scarb kullanarak başlarsanız, "
+"dış kodu ve bağımlılıkları yönetmek çok daha kolay hale gelir."
 
 #: src/ch01-01-installation.md:11
 msgid "Let's start by installing Scarb."
-msgstr ""
+msgstr "Scarb'ı yükleyerek başlayalım."
 
 #: src/ch01-01-installation.md:13
 msgid "Installing Scarb"
-msgstr ""
+msgstr "Scarb'ın Kurulumu"
 
 #: src/ch01-01-installation.md:15
 msgid "Requirements"
-msgstr ""
+msgstr "Gereksinimler"
 
 #: src/ch01-01-installation.md:17
 msgid ""
 "Scarb requires a Git executable to be available in the `PATH` environment "
 "variable."
 msgstr ""
+"Scarb, `PATH` çevre değişkeninde bir Git yürütülebilir dosyasının bulunmasını gerektirir."
 
 #: src/ch01-01-installation.md:21
 msgid ""
-"To install Scarb, please refer to the [installation "
-"instructions](https://docs.swmansion.com/scarb/download). We strongly "
-"recommend that you install Scarb [via "
-"asdf](https://docs.swmansion.com/scarb/download.html#install-via-asdf), a "
-"CLI tool that can manage multiple language runtime versions on a per-project "
-"basis. This will ensure that the version of Scarb you use to work on a "
-"project always matches the one defined in the project settings, avoiding "
-"problems related to version mismatches."
+"To install Scarb, please refer to the [installation instructions](https://"
+"docs.swmansion.com/scarb/download). We strongly recommend that you install "
+"Scarb [via asdf](https://docs.swmansion.com/scarb/download.html#install-via-"
+"asdf), a CLI tool that can manage multiple language runtime versions on a "
+"per-project basis. This will ensure that the version of Scarb you use to "
+"work on a project always matches the one defined in the project settings, "
+"avoiding problems related to version mismatches."
 msgstr ""
+"Scarb'ı kurmak için lütfen [kurulum talimatlarını](https://"
+"docs.swmansion.com/scarb/download) izleyin. Scarb'ı, bir "
+"proje bazında birden fazla dil çalışma zamanı sürümünü yönetebilen bir "
+"CLI aracı olan [asdf aracılığıyla](https://docs.swmansion.com/scarb/download.html#install-via-"
+"asdf) kurmanızı şiddetle tavsiye ederiz. Bu, "
+"bir projede çalışmak için kullandığınız Scarb sürümünün her zaman proje "
+"ayarlarında tanımlanan sürümle eşleşmesini sağlayacak ve sürüm "
+"uyumsuzluklarına bağlı problemleri önleyecektir."
 
 #: src/ch01-01-installation.md:25
 msgid ""
-"Please refer to the [asdf "
-"documentation](https://asdf-vm.com/guide/getting-started.html) to install "
-"all prerequisites."
+"Please refer to the [asdf documentation](https://asdf-vm.com/guide/getting-"
+"started.html) to install all prerequisites."
 msgstr ""
+"Tüm önkoşulları yüklemek için lütfen [asdf belgelerine](https://asdf-vm.com/guide/getting-"
+"started.html) bakın."
 
 #: src/ch01-01-installation.md:27
 msgid ""
 "Once you have asdf installed locally, you can download Scarb plugin with the "
 "following command:"
 msgstr ""
+"Yerel olarak asdf'yi kurduktan sonra, aşağıdaki komutla Scarb eklentisini indirebilirsiniz:"
 
 #: src/ch01-01-installation.md:31
 msgid "This will allow you to download specific versions:"
-msgstr ""
+msgstr "Bu, belirli sürümleri indirmenize olanak sağlayacaktır:"
 
 #: src/ch01-01-installation.md:35
 msgid "and set a global version: "
-msgstr ""
+msgstr "ve genel bir sürüm ayarlayın:"
 
 #: src/ch01-01-installation.md:40
 msgid ""
@@ -619,6 +696,8 @@ msgid ""
 "follow the onscreen instructions. This will install the latest stable "
 "release of Scarb."
 msgstr ""
+"Aksi takdirde, terminalinizde aşağıdaki komutu çalıştırabilir ve ekrandaki "
+"talimatları takip edebilirsiniz. Bu, Scarb'ın en son kararlı sürümünü kuracaktır."
 
 #: src/ch01-01-installation.md:43
 msgid "'=https'"
@@ -630,19 +709,25 @@ msgid ""
 "in a new terminal session, it should print both Scarb and Cairo language "
 "versions, e.g:"
 msgstr ""
+"Her iki durumda da, yeni bir terminal oturumunda aşağıdaki komutu çalıştırarak kurulumu "
+"doğrulayabilirsiniz; bu, hem Scarb hem de Cairo dil sürümlerini yazdırmalıdır, örneğin:"
 
 #: src/ch01-01-installation.md:55
 msgid "Installing the VSCode extension"
-msgstr ""
+msgstr "VSCode uzantısının yükleme"
 
 #: src/ch01-01-installation.md:57
 msgid ""
 "Cairo has a VSCode extension that provides syntax highlighting, code "
 "completion, and other useful features. You can install it from the [VSCode "
-"Marketplace](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1). "
-"Once installed, go into the extension settings, and make sure to tick the "
-"`Enable Language Server` and `Enable Scarb` options."
+"Marketplace](https://marketplace.visualstudio.com/items?itemName=starkware."
+"cairo1). Once installed, go into the extension settings, and make sure to "
+"tick the `Enable Language Server` and `Enable Scarb` options."
 msgstr ""
+"Cairo'nun, sözdizimi vurgulama, kod tamamlama ve diğer yararlı özellikleri "
+"sağlayan bir VSCode uzantısı bulunmaktadır. Bunu VSCode Marketplace'ten "
+"kurabilirsiniz. Kurduktan sonra, uzantı ayarlarına gidin ve `Dil Sunucusunu Etkinleştir` "
+"ve `Scarb'ı Etkinleştir` seçeneklerini işaretlemeyi unutmayın."
 
 #: src/ch01-02-hello-world.md:1
 msgid "Hello, World"
@@ -655,6 +740,9 @@ msgid ""
 "little program that prints the text `Hello, world!` to the screen, so we’ll "
 "do the same here!"
 msgstr ""
+"Scarb aracılığıyla Cairo'yu kurduğunuza göre, ilk Cairo programınızı yazma "
+"zamanı geldi. Yeni bir dil öğrenirken geleneksel olarak ekrana `Hello, world!` metnini "
+"yazdıran küçük bir program yazılır, biz de burada aynısını yapacağız!"
 
 #: src/ch01-02-hello-world.md:7
 msgid ""
@@ -663,13 +751,19 @@ msgid ""
 "so if you prefer to use an integrated development environment (IDE) instead "
 "of the command line, feel free to use your favorite IDE. The Cairo team has "
 "developed a VSCode extension for the Cairo language that you can use to get "
-"the features from the language server and code highlighting. See [Appendix "
-"D](appendix-04-useful-development-tools.md) for more details."
+"the features from the language server and code highlighting. See [Appendix D]"
+"(appendix-04-useful-development-tools.md) for more details."
 msgstr ""
+"Not: Bu kitap, komut satırıyla temel bir aşinalık varsayar. Cairo, düzenleme "
+"veya araç kullanımı ya da kodunuzun nerede bulunduğu konusunda özel taleplerde "
+"bulunmaz, bu yüzden komut satırı yerine bir tümleşik geliştirme ortamı (IDE) "
+"kullanmayı tercih ediyorsanız, favori IDE'nizi kullanmaktan çekinmeyin. Cairo ekibi, "
+"dil sunucusundan özellikler ve kod vurgulama alabilmeniz için Cairo diline özel bir "
+"VSCode uzantısı geliştirmiştir. Daha fazla detay için [Ek D](appendix-04-useful-development-tools.md)'ye bakın."
 
 #: src/ch01-02-hello-world.md:15
 msgid "Creating a Project Directory"
-msgstr ""
+msgstr "Proje Dizini Oluşturma"
 
 #: src/ch01-02-hello-world.md:17
 msgid ""
@@ -678,20 +772,25 @@ msgid ""
 "this book, we suggest making a _cairo_projects_ directory in your home "
 "directory and keeping all your projects there."
 msgstr ""
+"Cairo kodunuzu saklamak için bir dizin oluşturarak başlayacaksınız. Cairo "
+"için kodunuzun nerede bulunduğu önemli değildir, ancak bu kitaptaki alıştırmalar "
+"ve projeler için, ana dizininizde bir _cairo_projects_ dizini oluşturmanızı ve tüm "
+"projelerinizi orada saklamanızı öneririz."
 
 #: src/ch01-02-hello-world.md:22
 msgid ""
 "Open a terminal and enter the following commands to make a _cairo_projects_ "
 "directory."
 msgstr ""
+"Bir terminal açın ve bir _cairo_projects_ dizini oluşturmak için aşağıdaki komutları girin."
 
 #: src/ch01-02-hello-world.md:24
 msgid "For Linux, macOS, and PowerShell on Windows, enter this:"
-msgstr ""
+msgstr "Linux, macOS ve Windows'ta PowerShell için şunu girin:"
 
 #: src/ch01-02-hello-world.md:31
 msgid "For Windows CMD, enter this:"
-msgstr ""
+msgstr "Windows CMD için şunu girin:"
 
 #: src/ch01-02-hello-world.md:34 src/ch01-02-hello-world.md:35
 msgid "\"%USERPROFILE%\\cairo_projects\""
@@ -704,20 +803,26 @@ msgid ""
 "and try to run the examples from a different directory, you might need to "
 "adjust the commands accordingly or create a Scarb project."
 msgstr ""
+"Not: Bundan sonra, kitapta gösterilen her örnek için, bir Scarb proje dizininden "
+"çalışacağınızı varsayıyoruz. Scarb kullanmıyorsanız ve örnekleri farklı bir dizinden "
+"çalıştırmayı denerseniz, komutları buna göre ayarlamanız veya bir Scarb projesi oluşturmanız gerekebilir."
 
 #: src/ch01-02-hello-world.md:41
 msgid "Creating a Project with Scarb"
-msgstr ""
+msgstr "Scarb ile Proje Oluşturma"
 
 #: src/ch01-02-hello-world.md:43
 msgid "Let’s create a new project using Scarb."
-msgstr ""
+msgstr "Scarb kullanarak yeni bir proje oluşturalım."
 
 #: src/ch01-02-hello-world.md:45
 msgid ""
 "Navigate to your _cairo_projects_ directory (or wherever you decided to "
 "store your code). Then run the following:"
 msgstr ""
+"_cairo_projects_ dizininize gidin (veya kodunuzu saklamaya karar verdiğiniz herhangi "
+"bir yere). Sonra aşağıdaki komutu çalıştırın: "
+
 
 #: src/ch01-02-hello-world.md:51
 msgid ""
@@ -725,6 +830,9 @@ msgid ""
 "project _hello_world_, and Scarb creates its files in a directory of the "
 "same name."
 msgstr ""
+"Yeni bir dizin ve _hello_world_ adında bir proje oluşturur. Projemize _hello_world_ adını "
+"verdik ve Scarb, dosyalarını aynı adı taşıyan bir dizinde oluşturur. "
+
 
 #: src/ch01-02-hello-world.md:53
 msgid ""
@@ -732,11 +840,16 @@ msgid ""
 "You’ll see that Scarb has generated two files and one directory for us: a "
 "_Scarb.toml_ file and a _src_ directory with a _lib.cairo_ file inside."
 msgstr ""
+"`cd hello_world` komutu ile _hello_world_ dizinine gidin. Scarb'ın bizim için iki dosya ve bir "
+"dizin oluşturduğunu göreceksiniz: Bir _Scarb.toml_ dosyası ve içinde bir _lib.cairo_ dosyası "
+"bulunan bir _src_ dizini. "
+
 
 #: src/ch01-02-hello-world.md:55
 msgid ""
 "It has also initialized a new Git repository along with a `.gitignore` file"
 msgstr ""
+"Ayrıca bir `.gitignore` dosyası ile birlikte yeni bir Git deposu başlattı"
 
 #: src/ch01-02-hello-world.md:57
 msgid ""
@@ -744,16 +857,21 @@ msgid ""
 "control system by using the `--no-vcs` flag. Run `scarb new -help` to see "
 "the available options."
 msgstr ""
+"Not: Git, yaygın bir versiyon kontrol sistemidir. Versiyon kontrol sistemini kullanmayı `--no-vcs` "
+"bayrağını kullanarak durdurabilirsiniz. Kullanılabilir seçenekleri görmek için `scarb new -help` "
+"komutunu çalıştırın. "
+
 
 #: src/ch01-02-hello-world.md:60
 msgid ""
 "Open _Scarb.toml_ in your text editor of choice. It should look similar to "
 "the code in Listing 1-2."
 msgstr ""
+"_Scarb.toml_ dosyasını tercih ettiğiniz metin düzenleyicisinde açın. Liste 1-2'deki koda benzer görünmelidir."
 
 #: src/ch01-02-hello-world.md:62
 msgid "Filename: Scarb.toml"
-msgstr ""
+msgstr "Dosya Adı: Scarb.toml"
 
 #: src/ch01-02-hello-world.md:64
 msgid ""
@@ -763,23 +881,37 @@ msgid ""
 "version = \"0.1.0\"\n"
 "edition = \"2023_11\"\n"
 "\n"
-"# See more keys and their definitions at "
-"https://docs.swmansion.com/scarb/docs/reference/manifest\n"
+"# See more keys and their definitions at https://docs.swmansion.com/scarb/"
+"docs/reference/manifest\n"
 "\n"
 "[dependencies]\n"
 "# foo = { path = \"vendor/foo\" }\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"hello_world\"\n"
+"version = \"0.1.0\"\n"
+"edition = \"2023_11\"\n"
+"\n"
+"# Daha fazla anahtar ve tanımlarına https://docs.swmansion.com/scarb/docs/reference/manifest adresinden bakın."
+"\n"
+"[dependencies]\n"
+"# foo = { path = \"vendor/foo\" }\n"
+"```"
 
 #: src/ch01-02-hello-world.md:76
 msgid "Listing 1-2: Contents of _Scarb.toml_ generated by `scarb new`"
-msgstr ""
+msgstr "Liste 1-2: `scarb new` tarafından oluşturulan _Scarb.toml_ içeriği"
 
 #: src/ch01-02-hello-world.md:78
 msgid ""
 "This file is in the [TOML](https://toml.io/) (Tom’s Obvious, Minimal "
 "Language) format, which is Scarb’s configuration format."
 msgstr ""
+"Bu dosya, [TOML](https://toml.io/) (Tom's Obvious, Minimal Language) formatındadır, bu da Scarb'ın yapılandırma "
+"formatıdır. "
+
 
 #: src/ch01-02-hello-world.md:80
 msgid ""
@@ -787,6 +919,9 @@ msgid ""
 "following statements are configuring a package. As we add more information "
 "to this file, we’ll add other sections."
 msgstr ""
+"İlk satır olan `[package]`, takip eden ifadelerin bir paketi yapılandırdığını belirten bir "
+"bölüm başlığıdır. Bu dosyaya daha fazla bilgi ekledikçe, diğer bölümleri de ekleyeceğiz. "
+
 
 #: src/ch01-02-hello-world.md:82
 msgid ""
@@ -794,9 +929,14 @@ msgid ""
 "compile your program: the name of the package and the version of Scarb to "
 "use, and the edition of the prelude to use. The prelude is the collection of "
 "the most commonly used items that are automatically imported into every "
-"Cairo program. You can learn more about the prelude in [Appendix "
-"E](./appendix-05-common-types-and-traits-and-cairo-prelude.md)"
+"Cairo program. You can learn more about the prelude in [Appendix E](./"
+"appendix-05-common-types-and-traits-and-cairo-prelude.md)"
 msgstr ""
+"Sonraki üç satır, programınızı derlemek için Scarb'ın ihtiyaç duyduğu yapılandırma bilgilerini "
+"ayarlar: paketin adı, kullanılacak Scarb sürümü ve kullanılacak giriş baskısı. Giriş, her Cairo "
+"programına otomatik olarak ithal edilen en yaygın kullanılan öğelerin koleksiyonudur. Giriş hakkında "
+"daha fazla bilgiyi [Ek E](./appendix-05-common-types-and-traits-and-cairo-prelude.md) bölümünde "
+"öğrenebilirsiniz. "
 
 #: src/ch01-02-hello-world.md:84
 msgid ""
@@ -804,29 +944,42 @@ msgid ""
 "any of your project’s dependencies. In Cairo, packages of code are referred "
 "to as crates. We won’t need any other crates for this project."
 msgstr ""
+"Son satır olan `[dependencies]`, projenizin bağımlılıklarını listelemek için bir bölümün başlangıcıdır. "
+"Cairo'da, kod paketlerine kutu denir. Bu proje için başka hiçbir kutuya ihtiyacımız olmayacak. "
+
 
 #: src/ch01-02-hello-world.md:86
 msgid ""
 "Note: If you're building contracts for Starknet, you will need to add the "
-"`starknet` dependency as mentioned in the [Scarb "
-"documentation](https://docs.swmansion.com/scarb/docs/extensions/starknet/starknet-package.html)."
+"`starknet` dependency as mentioned in the [Scarb documentation](https://docs."
+"swmansion.com/scarb/docs/extensions/starknet/starknet-package.html)."
 msgstr ""
+"Not: Starknet için sözleşmeler oluşturuyorsanız, [Scarb dokümantasyonunda](https://docs."
+"swmansion.com/scarb/docs/extensions/starknet/starknet-package.html) bahsedildiği gibi "
+"`starknet` bağımlılığını eklemeniz gerekecek. "
+
 
 #: src/ch01-02-hello-world.md:88
 msgid ""
 "The other file created by Scarb is _src/lib.cairo_, let's delete all the "
 "content and put in the following content, we will explain the reason later."
 msgstr ""
+"Scarb tarafından oluşturulan diğer dosya _src/lib.cairo_ adını taşıyor, şimdi tüm içeriği "
+"silelim ve aşağıdaki içeriği ekleyelim, nedenini daha sonra açıklayacağız. "
+
 
 #: src/ch01-02-hello-world.md:94
 msgid ""
 "Then create a new file called _src/hello_world.cairo_ and put the following "
 "code in it:"
 msgstr ""
+"Ardından _src/hello_world.cairo_ adında yeni bir dosya oluşturun ve aşağıdaki kodu içine "
+"ekleyin: "
+
 
 #: src/ch01-02-hello-world.md:96
 msgid "Filename: src/hello_world.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/hello_world.cairo"
 
 #: src/ch01-02-hello-world.md:100 src/ch01-02-hello-world.md:179
 msgid "\"Hello, World!\""
@@ -839,11 +992,16 @@ msgid ""
 "file _hello_world.cairo_, containing the implementation details of the "
 "`hello_world` module."
 msgstr ""
+"Şimdi _lib.cairo_ adında bir dosya oluşturduk, bu dosya başka bir `hello_world` adlı modülü referans "
+"alan bir modül bildirimi içeriyor. Ayrıca `hello_world` modülünün uygulama detaylarını içeren _hello_world.cairo_ "
+"dosyasını içeriyor. "
+
 
 #: src/ch01-02-hello-world.md:106
 msgid ""
 "Scarb requires your source files to be located within the _src_ directory."
 msgstr ""
+"Scarb, kaynak dosyalarınızın _src_ dizini içinde bulunmasını gerektirir."
 
 #: src/ch01-02-hello-world.md:108
 msgid ""
@@ -852,6 +1010,10 @@ msgid ""
 "Scarb ensures a designated location for all project components, maintaining "
 "a structured organization."
 msgstr ""
+"Üst düzey proje dizini, README dosyaları, lisans bilgileri, yapılandırma dosyaları ve diğer "
+"tüm kodla ilgili olmayan içerikler için ayrılmıştır. Scarb, tüm proje bileşenleri için "
+"belirlenmiş bir konum sağlar ve yapılandırılmış bir düzeni korur."
+
 
 #: src/ch01-02-hello-world.md:111
 msgid ""
@@ -860,26 +1022,33 @@ msgid ""
 "and create an appropriate _Scarb.toml_ file. You can also use `scarb init` "
 "command to generate the _src_ folder and the _Scarb.toml_ it contains."
 msgstr ""
+"Eğer Scarb kullanmayan bir projeye başladıysanız, onu Scarb kullanan bir projeye dönüştürebilirsiniz. "
+"Proje kodunu _src_ dizinine taşıyın ve uygun bir _Scarb.toml_ dosyası oluşturun. Ayrıca _src_ klasörünü ve "
+"içeriğini içeren _Scarb.toml_ dosyasını oluşturmak için `scarb init` komutunu da kullanabilirsiniz."
+
 
 #: src/ch01-02-hello-world.md:120
 msgid " A sample Scarb project structure"
-msgstr ""
+msgstr "Örnek bir Scarb proje yapısı"
 
 #: src/ch01-02-hello-world.md:122
 msgid "Building a Scarb Project"
-msgstr ""
+msgstr "Bir Scarb Projesi Oluşturmak"
 
 #: src/ch01-02-hello-world.md:124
 msgid ""
 "From your _hello_world_ directory, build your project by entering the "
 "following command:"
 msgstr ""
+"_hello_world_ dizininizden aşağıdaki komutu girerek projenizi oluşturun:"
 
 #: src/ch01-02-hello-world.md:132
 msgid ""
 "This command creates a `sierra` file in _target/dev_, let's ignore the "
 "`sierra` file for now."
 msgstr ""
+"Bu komut, _target/dev_ içinde bir `sierra` dosyası oluşturur, şimdilik `sierra` dosyasını göz ardı edelim."
+
 
 #: src/ch01-02-hello-world.md:134
 msgid ""
@@ -887,28 +1056,36 @@ msgid ""
 "function of your program with the `scarb cairo-run` command and see the "
 "following output:"
 msgstr ""
+"Eğer Cairo'yu doğru bir şekilde kurduysanız, `scarb cairo-run` komutunu kullanarak "
+"programınızın `main` fonksiyonunu çalıştırabilir ve aşağıdaki çıktıyı görmelisiniz:"
+
 
 #: src/ch01-02-hello-world.md:143
 msgid ""
 "Regardless of your operating system, the string `Hello, world!` should print "
 "to the terminal."
 msgstr ""
+"İşletim sisteminiz ne olursa olsun, dize `Merhaba, dünya!` terminalde yazdırılmalıdır."
+
 
 #: src/ch01-02-hello-world.md:146
 msgid ""
 "If `Hello, world!` did print, congratulations! You’ve officially written a "
 "Cairo program. That makes you a Cairo programmer—welcome!"
 msgstr ""
+"Eğer `Merhaba, dünya!` yazdırıldıysa, tebrikler! Resmi olarak bir "
+"Cairo programı yazdınız. Sizi bir Cairo programcısı yapıyor, hoş geldiniz!"
 
 #: src/ch01-02-hello-world.md:149
 msgid "Anatomy of a Cairo Program"
-msgstr ""
+msgstr "Bir Cairo Programının Anatomisi"
 
 #: src/ch01-02-hello-world.md:151
 msgid ""
 "Let’s review this “Hello, world!” program in detail. Here’s the first piece "
 "of the puzzle:"
 msgstr ""
+"Hadi bu "Merhaba, dünya!" programını detaylı bir şekilde inceleyelim. İşte bulmacanın ilk parçası:"
 
 #: src/ch01-02-hello-world.md:160
 msgid ""
@@ -918,6 +1095,11 @@ msgid ""
 "and returns nothing. If there were parameters, they would go inside the "
 "parentheses `()`."
 msgstr ""
+"Bu satırlar, `main` adında bir fonksiyon tanımlar. `main` fonksiyonu "
+"özeldir: her yürütülebilir Cairo programında her zaman çalışan ilk kod "
+"parçasıdır. Burada, ilk satır, parametresiz ve hiçbir değer döndürmeyen `main` "
+"adında bir fonksiyonu tanır. Eğer parametreler olsaydı, parantezlerin içine yerleştirilirdi `()`. "
+
 
 #: src/ch01-02-hello-world.md:165
 msgid ""
@@ -925,30 +1107,42 @@ msgid ""
 "all function bodies. It’s good style to place the opening curly bracket on "
 "the same line as the function declaration, adding one space in between."
 msgstr ""
+"Fonksiyon gövdesi `{}` içine alınmıştır. Cairo, tüm fonksiyon gövdelerinin etrafında "
+"süslü parantezler `{}` gerektirir. İyi bir yazım stili, açılı süslü parantezi fonksiyon "
+"bildirimiyle aynı satıra koymaktır, araya bir boşluk eklenir."
+
 
 #: src/ch01-02-hello-world.md:169
 msgid ""
 "Note: If you want to stick to a standard style across Cairo projects, you "
 "can use the automatic formatter tool available with `scarb fmt` to format "
-"your code in a particular style (more on `scarb fmt` in [Appendix "
-"D](appendix-04-useful-development-tools.md)). The Cairo team has included "
-"this tool with the standard Cairo distribution, as `cairo-run` is, so it "
-"should already be installed on your computer!"
+"your code in a particular style (more on `scarb fmt` in [Appendix D]"
+"(appendix-04-useful-development-tools.md)). The Cairo team has included this "
+"tool with the standard Cairo distribution, as `cairo-run` is, so it should "
+"already be installed on your computer!"
 msgstr ""
+"Not: Eğer Cairo projeleri arasında standart bir stil kullanmak isterseniz, kodunuzu "
+"belirli bir stilde biçimlendirmek için kullanılabilen `scarb fmt` ile gelen otomatik "
+"biçimlendirme aracını kullanabilirsiniz (daha fazlası için [Ek D](appendix-04-useful-development-tools.md)). Cairo "
+"ekibi, bu aracı standart Cairo dağıtımıyla birlikte eklemiştir, bu yüzden muhtemelen "
+"bilgisayarınıza zaten yüklenmiştir!"
+
 
 #: src/ch01-02-hello-world.md:176
 msgid "The body of the `main` function holds the following code:"
-msgstr ""
+msgstr "`main` fonksiyonunun gövdesi aşağıdaki kodu içerir:"
 
 #: src/ch01-02-hello-world.md:182
 msgid ""
 "This line does all the work in this little program: it prints text to the "
 "screen. There are four important details to notice here."
 msgstr ""
+"Bu satır, bu küçük programdaki tüm işi yapar: ekrana "
+"metin yazdırır. Burada dikkat edilmesi gereken dört önemli ayrıntı vardır."
 
 #: src/ch01-02-hello-world.md:185
 msgid "First, Cairo style is to indent with four spaces, not a tab."
-msgstr ""
+msgstr "İlk olarak, Cairo stili sekme ile değil dört boşluk ile girinti yapmaktır."
 
 #: src/ch01-02-hello-world.md:187
 msgid ""
@@ -959,12 +1153,20 @@ msgid ""
 "of a normal function and that macros don’t always follow the same rules as "
 "functions."
 msgstr ""
+"Ikinci olarak, `println!`, bir Cairo makrosunu çağırır. Eğer bir işlevi "
+"çağırsaydı, `println` olarak girilirdi ( `!` olmadan). Cairo makrolarını [Makrolar Bölümü](./ch11-02-macros.md) 'nde "
+"daha detaylı olarak tartışacağız. Şimdilik sadece `!` kullanmanızın bir makro çağırdığınızı ve makroların her zaman "
+"işlevlerle aynı kuralları izlemediğini bilmeniz yeterlidir."
+
 
 #: src/ch01-02-hello-world.md:190
 msgid ""
 "Third, you see the `\"Hello, world!\"` string. We pass this string as an "
 "argument to `println!`, and the string is printed to the screen."
 msgstr ""
+"Üçüncü olarak, `\"Hello, world!\"` dizesini görüyorsunuz. Bu dizesini `println!`'a bir "
+"argüman olarak geçiriyoruz ve dize ekranınıza yazdırılıyor."
+
 
 #: src/ch01-02-hello-world.md:192
 msgid ""
@@ -972,37 +1174,44 @@ msgid ""
 "expression is over and the next one is ready to begin. Most lines of Cairo "
 "code end with a semicolon."
 msgstr ""
+"Dördüncü olarak, satırı bir noktalı virgül (`;`) ile sonlandırıyoruz, bu ifadenin "
+"sona erdiğini ve bir sonrakinin başlamaya hazır olduğunu gösterir. Cairo kodunun "
+"çoğu satırı noktalı virgül ile sonlanır."
+
 
 #: src/ch01-02-hello-world.md:198 src/ch02-05-control-flow.md:302
-#: src/ch03-03-custom-data-structures.md:338 src/ch05-03-method-syntax.md:285
+#: src/ch03-03-custom-data-structures.md:338 src/ch05-03-method-syntax.md:290
 #: src/ch07-05-separating-modules-into-different-files.md:98
 #: src/ch10-02-recoverable-errors.md:190
 msgid "Summary"
-msgstr ""
+msgstr "Özet"
 
 #: src/ch01-02-hello-world.md:200
 msgid "Let’s recap what we’ve learned so far about Scarb:"
-msgstr ""
+msgstr "Scarb hakkında şimdiye kadar öğrendiklerimizi özetleyelim:"
 
 #: src/ch01-02-hello-world.md:202
 msgid ""
 "We can install one or multiple Scarb versions, either the latest stable or a "
 "specific one, using asdf."
 msgstr ""
+"asdf kullanarak en son kararlı veya belirli bir Scarb sürümü olmak üzere "
+"bir veya birden fazla Scarb sürümü yükleyebiliriz."
 
 #: src/ch01-02-hello-world.md:203
 msgid "We can create a project using `scarb new`."
-msgstr ""
+msgstr "`scarb new` kullanarak bir proje oluşturabiliriz"
 
 #: src/ch01-02-hello-world.md:204
 msgid ""
 "We can build a project using `scarb build` to generate the compiled Sierra "
 "code."
 msgstr ""
+"Derlenmiş Sierra kodunu oluşturmak için `scarb build` kullanarak bir proje oluşturabiliriz."
 
 #: src/ch01-02-hello-world.md:205
 msgid "We can execute a Cairo program using the `scarb cairo-run` command."
-msgstr ""
+msgstr "Bir Cairo programını `scarb cairo-run` komutunu kullanarak çalıştırabiliriz."
 
 #: src/ch01-02-hello-world.md:207
 msgid ""
@@ -1010,6 +1219,10 @@ msgid ""
 "matter which operating system you’re working on. So, at this point, we’ll no "
 "longer provide specific instructions for Linux and macOS versus Windows."
 msgstr ""
+"Scarb kullanmanın ek bir avantajı, hangi işletim sistemi üzerinde çalıştığınıza "
+"bakılmaksızın komutların aynı olmasıdır. Bu nedenle, bu noktadan itibaren, Linux ve "
+"macOS ile Windows arasındaki belirli talimatları artık sağlamayacağız."
+
 
 #: src/ch01-02-hello-world.md:209
 msgid ""
@@ -1017,6 +1230,9 @@ msgid ""
 "time to build a more substantial program to get used to reading and writing "
 "Cairo code."
 msgstr ""
+"Cairo yolculuğunuzda harika bir başlangıç yaptınız! Cairo kodu okumaya ve yazmaya "
+"alışmak için daha sağlam bir program oluşturmak için harika bir zaman!"
+
 
 #: src/ch02-00-common-programming-concepts.md:3
 msgid ""
@@ -1026,6 +1242,11 @@ msgid ""
 "unique to Cairo, but we’ll discuss them in the context of Cairo and explain "
 "the conventions around using these concepts."
 msgstr ""
+"Bu bölüm, hemen hemen her programlama dilinde bulunan kavramları ve bunların Cairo'da nasıl "
+"çalıştığını kapsar. Birçok programlama dili, temelde birçok ortak özelliğe sahiptir. Bu bölümde "
+"sunulan hiçbir kavram Cairo'ya özgü değildir, ancak bu kavramları Cairo bağlamında tartışacak ve "
+"bu kavramları kullanma konusundaki gelenekleri açıklayacağız."
+
 
 #: src/ch02-00-common-programming-concepts.md:5
 msgid ""
@@ -1033,6 +1254,10 @@ msgid ""
 "comments, and control flow. These foundations will be in every Cairo "
 "program, and learning them early will give you a strong core to start from."
 msgstr ""
+"Daha spesifik olarak, değişkenler, temel tipler, işlevler, yorumlar ve kontrol "
+"akışı hakkında bilgi edineceksiniz. Bu temeller, her Cairo programında bulunacak ve "
+"erken öğrenmek size güçlü bir başlangıç yapma imkanı sağlayacaktır."
+
 
 #: src/ch02-01-variables-and-mutability.md:3
 msgid ""
@@ -1043,6 +1268,13 @@ msgid ""
 "your variables mutable. Let’s explore how and why Cairo enforces "
 "immutability, and how you can make your variables mutable."
 msgstr ""
+"Cairo, değişmez bir bellek modeli kullanır, yani bir bellek hücresine "
+"yazıldığında üzerine yazılamaz, yalnızca okunabilir. Bu değişmez bellek "
+"modelini yansıtmak için, Cairo'daki değişkenler varsayılan olarak değişmezdir. Bununla "
+"birlikte, dil bu modeli soyutlar ve değişkenlerinizi değişken yapma seçeneği sunar. Cairo'un "
+"neden ve nasıl değişmezliği zorladığını ve değişkenlerinizi nasıl "
+"değiştirilebilir hale getirebileceğinizi keşfetmeye başlayalım."
+
 
 #: src/ch02-01-variables-and-mutability.md:10
 msgid ""
@@ -1051,12 +1283,18 @@ msgid ""
 "_variables_ in your _cairo_projects_ directory by using `scarb new "
 "variables`."
 msgstr ""
+"Bir değişken değişmez olduğunda, bir değer bir isme bağlandığında, o "
+"değeri değiştiremezsiniz. Bu durumu göstermek için, `scarb new variables` komutunu "
+"kullanarak _cairo_projects_ dizininizde _variables_ adlı yeni bir proje oluşturun."
+
 
 #: src/ch02-01-variables-and-mutability.md:14
 msgid ""
 "Then, in your new _variables_ directory, open _src/lib.cairo_ and replace "
 "its code with the following code, which won’t compile just yet:"
 msgstr ""
+"Ardından, yeni _variables_ dizininde, _src/lib.cairo_ dosyasını açın ve aşağıdaki kod ile değiştirin, ancak henüz derlenmeyecektir:"
+
 
 #: src/ch02-01-variables-and-mutability.md:17
 #: src/ch02-01-variables-and-mutability.md:83
@@ -1064,22 +1302,22 @@ msgstr ""
 #: src/ch02-04-comments.md:31 src/ch02-05-control-flow.md:11
 #: src/ch02-05-control-flow.md:51 src/ch02-05-control-flow.md:104
 #: src/ch02-05-control-flow.md:136 src/ch02-05-control-flow.md:173
-#: src/ch04-01-what-is-ownership.md:235 src/ch04-01-what-is-ownership.md:280
+#: src/ch04-01-what-is-ownership.md:237 src/ch04-01-what-is-ownership.md:283
 #: src/ch04-02-references-and-snapshots.md:26
 #: src/ch04-02-references-and-snapshots.md:113
 #: src/ch05-01-defining-and-instantiating-structs.md:7
 #: src/ch05-01-defining-and-instantiating-structs.md:26
-#: src/ch05-01-defining-and-instantiating-structs.md:51
-#: src/ch05-01-defining-and-instantiating-structs.md:87
-#: src/ch05-01-defining-and-instantiating-structs.md:123
+#: src/ch05-01-defining-and-instantiating-structs.md:48
+#: src/ch05-01-defining-and-instantiating-structs.md:84
+#: src/ch05-01-defining-and-instantiating-structs.md:120
 #: src/ch05-02-an-example-program-using-structs.md:7
-#: src/ch05-02-an-example-program-using-structs.md:47
-#: src/ch05-02-an-example-program-using-structs.md:72
-#: src/ch05-02-an-example-program-using-structs.md:99
+#: src/ch05-02-an-example-program-using-structs.md:48
+#: src/ch05-02-an-example-program-using-structs.md:73
+#: src/ch05-02-an-example-program-using-structs.md:100
 #: src/ch05-02-an-example-program-using-structs.md:135
 #: src/ch05-03-method-syntax.md:18 src/ch05-03-method-syntax.md:100
-#: src/ch05-03-method-syntax.md:141 src/ch05-03-method-syntax.md:190
-#: src/ch05-03-method-syntax.md:228
+#: src/ch05-03-method-syntax.md:141 src/ch05-03-method-syntax.md:194
+#: src/ch05-03-method-syntax.md:232
 #: src/ch07-02-defining-modules-to-control-scope.md:78
 #: src/ch07-02-defining-modules-to-control-scope.md:130
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:15
@@ -1099,7 +1337,7 @@ msgstr ""
 #: src/ch09-02-test-organization.md:59
 #: src/ch10-01-unrecoverable-errors-with-panic.md:9
 msgid "Filename: src/lib.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/lib.cairo"
 
 #: src/ch02-01-variables-and-mutability.md:23
 #: src/ch02-01-variables-and-mutability.md:25
@@ -1117,6 +1355,9 @@ msgid ""
 "Save and run the program using `scarb cairo-run`. You should receive an "
 "error message regarding an immutability error, as shown in this output:"
 msgstr ""
+"Programı kaydedin ve `scarb cairo-run` kullanarak çalıştırın. Bu çıktıda "
+"gösterildiği gibi, bir değişmezlik hatası ile ilgili bir hata mesajı almalısınız:"
+
 
 #: src/ch02-01-variables-and-mutability.md:42
 msgid ""
@@ -1125,12 +1366,20 @@ msgid ""
 "safely doing what you want it to do yet; they do _not_ mean that you’re not "
 "a good programmer! Experienced Caironautes still get compiler errors."
 msgstr ""
+"Bu örnek, derleyicinin programlarınızdaki hataları bulmanıza nasıl "
+"yardımcı olduğunu göstermektedir. Derleyici hataları sinir bozucu olabilir, ancak "
+"yalnızca programınızın henüz istediğiniz şekilde güvenli bir şekilde "
+"çalışmadığı anlamına gelir; bunlar sadece programcıların iyi olmadığı "
+"anlamına gelmez! Deneyimli Caironautes hala derleyici hataları alır."
+
 
 #: src/ch02-01-variables-and-mutability.md:47
 msgid ""
 "You received the error message `Cannot assign to an immutable variable.` "
 "because you tried to assign a second value to the immutable `x` variable."
 msgstr ""
+"Değişmez `x` değişkenine ikinci bir değer atamaya çalıştığınız için `Cannot assign to an immutable variable` hata mesajını aldınız."
+
 
 #: src/ch02-01-variables-and-mutability.md:50
 msgid ""
@@ -1143,6 +1392,12 @@ msgid ""
 "the fact, especially when the second piece of code changes the value only "
 "_sometimes_."
 msgstr ""
+"Bir değeri değiştirmeye çalıştığımızda derleme zamanı hataları "
+"almak önemlidir, çünkü bu özel durumlar hatalara yol açabilir. Kodumuzun "
+"bir kısmı, bir değerin asla değişmeyeceği varsayımıyla çalışırken, kodumuzun "
+"başka bir kısmı bu değeri değiştirirse, kodun ilk kısmının tasarlandığı şekilde "
+"çalışmayabileceği bir durum olabilir. Bu tür bir hatanın nedeni, özellikle ikinci "
+"kod parçasının değeri sadece _sometimes_ değiştirdiğinde, sonradan takip etmek zor olabilir."
 
 #: src/ch02-01-variables-and-mutability.md:58
 msgid ""
@@ -1150,6 +1405,10 @@ msgid ""
 "class of bugs impossible, because values will never change unexpectedly. "
 "This makes code easier to reason about."
 msgstr ""
+"Cairo, çoğu diğer dilden farklı olarak değişmez belleğe sahiptir. Bu, beklenmedik "
+"bir şekilde değerlerin asla değişmeyeceği için tüm hata türünü imkansız kılar. Bu, kodun "
+"daha kolay anlaşılmasını sağlar."
+
 
 #: src/ch02-01-variables-and-mutability.md:62
 msgid ""
@@ -1159,6 +1418,11 @@ msgid ""
 "conveys intent to future readers of the code by indicating that other parts "
 "of the code will be changing the value associated to this variable."
 msgstr ""
+"Ancak değişkenler varsayılan olarak değişmez olsalar da, değişken "
+"adının önüne `mut` ekleyerek onları değiştirilebilir hale getirebilirsiniz. `mut` eklemek "
+"aynı zamanda kodun gelecekteki okuyucularına, bu değişkenle ilişkilendirilen "
+"değerin diğer kod parçaları tarafından değiştirileceğini belirterek niyeti iletecektir."
+
 
 #: src/ch02-01-variables-and-mutability.md:70
 msgid ""
@@ -1175,14 +1439,25 @@ msgid ""
 "difference is that at the Cairo level, the variable is not redeclared so its "
 "type cannot change."
 msgstr ""
+"Ancak bu noktada, bir değişkenin `mut` olarak bildirildiğinde tam olarak ne olduğunu "
+"merak ediyor olabilirsiniz, çünkü önceki olarak Cairo'nun belleğinin değişmez olduğunu "
+"belirtmiştik. Cevap, _değerin_ değişmez olduğu, ancak _değişkenin_ değişmez olmadığıdır. Değişkenle ilişkilendirilen "
+"değer değiştirilebilir. Cairo'da bir değişkenin değiştirilebilir bir şekilde atanması, özünde onu başka bir bellek "
+"hücresinde başka bir değere başvuracak şekilde yeniden bildirmekle eşdeğerdir, ancak "
+"derleyici bunu sizin için halleder ve `mut` anahtar kelimesi bu durumu açıkça "
+"belirtir. Düşük seviyeli Cairo Assembly kodunu incelediğinizde, değişken mutasyonunun, mutasyon "
+"işlemlerini değişken gölgesine eşdeğer bir dizi adıma çeviren sözdizimsel şeker olarak "
+"uygulandığı açık hale gelir. Tek fark, Cairo seviyesinde değişkenin yeniden "
+"bildirilmediği ve bu nedenle türünün değişmediği yerdir."
+
 
 #: src/ch02-01-variables-and-mutability.md:81
 msgid "For example, let’s change _src/lib.cairo_ to the following:"
-msgstr ""
+msgstr "Örneğin, _src/lib.cairo_ dosyasını aşağıdaki şekilde değiştirelim"
 
 #: src/ch02-01-variables-and-mutability.md:94
 msgid "When we run the program now, we get this:"
-msgstr ""
+msgstr "Programı şimdi çalıştırdığımızda şunu elde ediyoruz"
 
 #: src/ch02-01-variables-and-mutability.md:103
 msgid ""
@@ -1190,10 +1465,13 @@ msgid ""
 "used. Ultimately, deciding whether to use mutability or not is up to you and "
 "depends on what you think is clearest in that particular situation."
 msgstr ""
+"`mut` kullanıldığında `x`'e bağlanan değeri `5`'ten `6`'ya değiştirmemize izin "
+"verilir. Sonuçta, mutabiliteyi kullanıp kullanmamaya karar vermek size bağlıdır "
+"ve bu, belirli bir durumda neyin daha net olduğuna bağlıdır."
 
 #: src/ch02-01-variables-and-mutability.md:107
 msgid "Constants"
-msgstr ""
+msgstr "Sabitler"
 
 #: src/ch02-01-variables-and-mutability.md:109
 msgid ""
@@ -1201,6 +1479,9 @@ msgid ""
 "and are not allowed to change, but there are a few differences between "
 "constants and variables."
 msgstr ""
+"Değişmez değişkenler gibi, _sabitler_ bir isme bağlanan ve değiştirilmesine izin verilmeyen "
+"değerlerdir, ancak sabitler ile değişkenler arasında birkaç fark vardır."
+
 
 #: src/ch02-01-variables-and-mutability.md:113
 msgid ""
@@ -1211,12 +1492,20 @@ msgid ""
 "section, [“Data Types”](ch02-02-data-types.md), so don’t worry about the "
 "details right now. Just know that you must always annotate the type."
 msgstr ""
+"İlk olarak, sabitlerle `mut` kullanmanıza izin verilmez. Sabitler sadece varsayılan olarak değişmez "
+"değildir - her zaman değişmezdirler. Sabitleri `let` anahtar kelimesi yerine `const` anahtar kelimesini "
+"kullanarak bildirirsiniz ve değerin türü _mutlaka_ belirtilmelidir. Türleri ve tür açıklamalarını "
+"bir sonraki bölüm olan [“Veri Tipleri”](ch02-02-data-types.md) bölümünde ele alacağız, bu nedenle "
+"şu anda ayrıntıları düşünmeyin. Sadece türün her zaman açıklanması gerektiğini bilin."
+
 
 #: src/ch02-01-variables-and-mutability.md:120
 msgid ""
 "Constants can only be declared in the global scope, which makes them useful "
 "for values that many parts of code need to know about."
 msgstr ""
+"Sabitler yalnızca global kapsamda bildirilebilir, bu da onları kodun birçok "
+"kısmının bilmesi gereken değerler için kullanışlı hale getirir."
 
 #: src/ch02-01-variables-and-mutability.md:123
 msgid ""
@@ -1224,28 +1513,37 @@ msgid ""
 "expression, not the result of a value that could only be computed at "
 "runtime. Only literal constants are currently supported."
 msgstr ""
+"Son fark, sabitlerin yalnızca bir sabit ifadeye ayarlanabilmesidir, çalışma zamanında "
+"hesaplanabilen bir değerin sonucu değil. Şu anda yalnızca literal sabitler desteklenmektedir."
+
 
 #: src/ch02-01-variables-and-mutability.md:127
 msgid "Here’s an example of a constant declaration:"
-msgstr ""
+msgstr "İşte bir sabit bildirim örneği"
 
 #: src/ch02-01-variables-and-mutability.md:133
 msgid ""
 "Nonetheless, it is possible to use the `consteval_int!` macro to create a "
 "`const` variable that is the result of some computation:"
 msgstr ""
+"Yine de, `consteval_int!` macrosunu kullanarak bazı hesaplamanın sonucu olan bir `const` değişkeni oluşturmak mümkündür:"
+
 
 #: src/ch02-01-variables-and-mutability.md:139
 msgid ""
-"We will dive into more detail about macros in the [dedicated "
-"section](./ch11-02-macros.md)."
+"We will dive into more detail about macros in the [dedicated section](./"
+"ch11-02-macros.md)."
 msgstr ""
+"Daha fazla ayrıntıya [özel bölümde](./ch11-02-macros.md) macro'lar hakkında daha fazla ayrıntıya gireceğiz."
+
 
 #: src/ch02-01-variables-and-mutability.md:141
 msgid ""
 "Cairo's naming convention for constants is to use all uppercase with "
 "underscores between words."
 msgstr ""
+"Cairo'nun sabitler için isimlendirme kuralı, tüm harfleri büyük harf ve kelimeler arasında alt çizgi kullanmaktır."
+
 
 #: src/ch02-01-variables-and-mutability.md:144
 msgid ""
@@ -1255,6 +1553,10 @@ msgid ""
 "know about, such as the maximum number of points any player of a game is "
 "allowed to earn, or the speed of light."
 msgstr ""
+"Sabitler, programın çalıştığı süre boyunca, bildirildikleri kapsam içinde geçerlidir. Bu özellik, sabitleri "
+"programınızın birçok kısmının bilmesi gereken uygulama alanınızdaki değerler için kullanışlı hale "
+"getirir, örneğin bir oyuncunun kazanabileceği maksimum puan sayısı veya ışığın hızı gibi."
+
 
 #: src/ch02-01-variables-and-mutability.md:150
 msgid ""
@@ -1263,10 +1565,14 @@ msgid ""
 "also helps to have only one place in your code you would need to change if "
 "the hardcoded value needed to be updated in the future."
 msgstr ""
+"Programınız boyunca kullanılan sabit değerlere sabitler olarak isim vermek, bu değerin anlamını "
+"kodun gelecekteki bakımını yapacak kişilere iletmek için kullanışlıdır. Ayrıca, eğer "
+"sabit değeri gelecekte güncellenmesi gerekiyorsa, kodunuzda değiştirmeniz gereken tek bir yer olmasına yardımcı olur."
+
 
 #: src/ch02-01-variables-and-mutability.md:155
 msgid "Shadowing"
-msgstr ""
+msgstr "Gölgeleme"
 
 #: src/ch02-01-variables-and-mutability.md:157
 msgid ""
@@ -1279,6 +1585,13 @@ msgid ""
 "shadow a variable by using the same variable’s name and repeating the use of "
 "the `let` keyword as follows:"
 msgstr ""
+"Değişken gölgesi, önceki bir değişkenle aynı ada sahip yeni bir değişkenin bildirilmesini "
+"ifade eder. Caironautes, ilk değişkenin ikinci tarafından _gölgelediğini_ söyler, bu da ikinci "
+"değişkenin, değişkenin adını kullandığınızda derleyicinin göreceği şey olduğu anlamına gelir. Etkide, ikinci "
+"değişken birinciyi gölgeleyerek, değişken adının kullanıldığı herhangi bir kullanımı kendisine alır, ya kendisi "
+"gölgelenir ya da kapsam sona erene kadar. Bir değişkeni, aynı değişken adını kullanarak ve `let` anahtar kelimesini "
+"kullanımını tekrarlayarak gölgeleyebiliriz, aşağıdaki gibi:"
+
 
 #: src/ch02-01-variables-and-mutability.md:174
 msgid "\"Inner scope x value is: {}\""
@@ -1298,6 +1611,13 @@ msgid ""
 "value of `12`. When that scope is over, the inner shadowing ends and `x` "
 "returns to being `6`. When we run this program, it will output the following:"
 msgstr ""
+"Bu program önce `x`'i `5` değerine bağlar. Sonra, `let x =`'yi tekrarlayarak yeni bir değişken `x` oluşturur "
+"ve orijinal değeri alır ve `1` ekler, böylece `x`'in değeri `6` olur. Ardından, "
+"süslü parantezlerle oluşturulan iç içe kapsamda, üçüncü `let` ifadesi de `x`'i "
+"gölgeleyerek yeni bir değişken oluşturur, önceki değeri `2` ile çarparak `x`'e `12` değerini "
+"verir. Bu kapsam sona erdiğinde, iç içe gölgeleme sona erer ve `x` tekrar `6` olur. Bu "
+"programı çalıştırdığımızda, aşağıdaki çıktıyı verecektir:"
+
 
 #: src/ch02-01-variables-and-mutability.md:195
 msgid ""
@@ -1307,6 +1627,11 @@ msgid ""
 "transformations on a value but have the variable be immutable after those "
 "transformations have been completed."
 msgstr ""
+"Gölgeleme, bir değişkeni `mut` olarak işaretlemeden farklıdır çünkü bu değişkeni "
+"yanlışlıkla `let` anahtar kelimesini kullanmadan yeniden atamaya çalışırsak "
+"derleme zamanı hatası alırız. `let` kullanarak bir değeri birkaç dönüşüm "
+"yapabiliriz, ancak bu dönüşümler tamamlandıktan sonra değişken değiştirilemez olur."
+
 
 #: src/ch02-01-variables-and-mutability.md:201
 msgid ""
@@ -1318,6 +1643,14 @@ msgid ""
 "compiler will not complain if you change its type. For example, say our "
 "program performs a type conversion between the `u64` and `felt252` types."
 msgstr ""
+"`mut` ve gölgeleme arasındaki bir başka fark, `let` anahtar kelimesini "
+"tekrar kullandığımızda etkili bir şekilde yeni bir değişken oluşturuyor "
+"olmamızdır, bu da aynı adı yeniden kullanarak değerin türünü değiştirmemize "
+"olanak tanır. Daha önce belirtildiği gibi, değişken gölgeleme ve değişkenler "
+"de düşük düzeyde eşdeğerdir. Tek fark, bir değişkeni gölgelediğinizde derleyici, "
+"türünü değiştirirseniz şikayet etmez. Örneğin, programımız `u64` "
+"ve `felt252` türleri arasında bir tür dönüşümü gerçekleştirirse."
+
 
 #: src/ch02-01-variables-and-mutability.md:212
 msgid "\"The value of x is {} of type u64\""
@@ -1339,18 +1672,26 @@ msgid ""
 "simpler `x` name. However, if we try to use `mut` for this, as shown here, "
 "we’ll get a compile-time error:"
 msgstr ""
+"Ilk `x` değişkeni `u64` türüne sahipken ikinci `x` değişkeni `felt252` türüne "
+"sahiptir. Bu nedenle, gölgeleme bize `x_u64` ve `x_felt252` gibi farklı isimler "
+"bulma zorunluluğundan kurtarır; bunun yerine daha basit `x` adını yeniden "
+"kullanabiliriz. Ancak, bunun için `mut` kullanmaya çalışırsak, burada "
+"gösterildiği gibi derleme zamanı hatası alırız:"
+
 
 #: src/ch02-01-variables-and-mutability.md:233
 msgid ""
 "The error says we were expecting a `u64` (the original type) but we got a "
 "different type:"
 msgstr ""
+"Hata, bir `u64` (orijinal tür) beklediğimizi ancak farklı bir tür elde ettiğimizi söylüyor:"
 
 #: src/ch02-01-variables-and-mutability.md:246
 msgid ""
 "Now that we’ve explored how variables work, let’s look at more data types "
 "they can have."
 msgstr ""
+"Artık değişkenlerin nasıl çalıştığını keşfettiğimize göre, sahip olabilecekleri daha fazla veri türüne bakalım."
 
 #: src/ch02-02-data-types.md:3
 msgid ""
@@ -1358,6 +1699,10 @@ msgid ""
 "kind of data is being specified so it knows how to work with that data. This "
 "section covers two subsets of data types: scalars and compounds."
 msgstr ""
+"Her Cairo değeri belirli bir veri türüne sahiptir, bu da Cairo'ya "
+"hangi tür verinin belirtildiğini söyler, böylece o veriyle nasıl "
+"çalışması gerektiğini bilir. Bu bölüm, veri türlerinin iki alt "
+"kümesini kapsar: skalerler ve bileşenler."
 
 #: src/ch02-02-data-types.md:6
 msgid ""
@@ -1367,14 +1712,19 @@ msgid ""
 "when many types are possible, we can use a cast method where we specify the "
 "desired output type."
 msgstr ""
+"Cairo'nun statik tipli bir dil olduğunu unutmayın; bu, derleme anında "
+"tüm değişkenlerin tiplerini bilmesi gerektiği anlamına gelir. Derleyici, genellikle "
+"değerin ve kullanımının istenen türünü, değer ve kullanımına dayalı olarak "
+"çıkarabilir. Birden çok türün mümkün olduğu durumlarda, istenen çıktı "
+"türünü belirttiğimiz bir dönüşüm yöntemi kullanabiliriz."
 
 #: src/ch02-02-data-types.md:17
 msgid "You’ll see different type annotations for other data types."
-msgstr ""
+msgstr "Diğer veri türleri için farklı tür ek açıklamaları göreceksiniz."
 
 #: src/ch02-02-data-types.md:19
 msgid "Scalar Types"
-msgstr ""
+msgstr "Skaler Tipler"
 
 #: src/ch02-02-data-types.md:21
 msgid ""
@@ -1382,10 +1732,13 @@ msgid ""
 "types: felts, integers, and booleans. You may recognize these from other "
 "programming languages. Let’s jump into how they work in Cairo."
 msgstr ""
+"Bir skaler tip tek bir değeri temsil eder. Cairo'nun üç temel skaler "
+"tipi vardır: felt, tamsayılar ve booleanlar. Bunları diğer programlama dillerinden "
+"tanıyor olabilirsiniz. Cairo'da nasıl çalıştıklarına geçelim"
 
 #: src/ch02-02-data-types.md:25
 msgid "Felt Type"
-msgstr ""
+msgstr "Felt Tipi"
 
 #: src/ch02-02-data-types.md:27
 msgid ""
@@ -1399,34 +1752,56 @@ msgid ""
 "an appropriate multiple of P is added or subtracted to bring the result back "
 "within the range (i.e., the result is computed modulo P)."
 msgstr ""
+"Cairo'da, bir değişkenin veya argümanın türünü belirtmezseniz, türü varsayılan olarak ``felt252`` "
+"anahtar sözcüğü ile temsil edilen bir alan öğesi olur. Cairo "
+"bağlamında, "bir alan elemanı" dediğimizde \\\\( 0 \\leq x \\< P \\\\) aralığındaki bir tamsayıyı kastediyoruz "
+"Burada `P`, şu anda \\\\( {2^{251}} + 17 \\cdot {2^{192}} + 1 \\\\)'e eşit olan çok büyük bir asal sayıdır. "
+"Toplama, çıkarma veya çarpma sırasında, sonuç asal sayının belirtilen aralığının dışında "
+"kalırsa, bir taşma (veya düşük taşma) meydana gelir ve sonucu aralığa geri getirmek için P'nin "
+"uygun bir katı eklenir veya çıkarılır. "
 
 #: src/ch02-02-data-types.md:30
 msgid ""
 "The most important difference between integers and field elements is "
 "division: Division of field elements (and therefore division in Cairo) is "
-"unlike regular CPUs division, where integer division \\\\( \\frac{x}{y} "
-"\\\\) is defined as \\\\( \\left\\lfloor \\frac{x}{y} \\right\\rfloor \\\\) "
-"where the integer part of the quotient is returned (so you get \\\\( "
-"\\frac{7}{3} = 2 \\\\)) and it may or may not satisfy the equation \\\\( "
-"\\frac{x}{y} \\cdot y == x \\\\), depending on the divisibility of `x` by "
-"`y`."
+"unlike regular CPUs division, where integer division \\\\( \\frac{x}{y} \\"
+"\\) is defined as \\\\( \\left\\lfloor \\frac{x}{y} \\right\\rfloor \\\\) "
+"where the integer part of the quotient is returned (so you get \\"
+"\\( \\frac{7}{3} = 2 \\\\)) and it may or may not satisfy the equation \\"
+"\\( \\frac{x}{y} \\cdot y == x \\\\), depending on the divisibility of `x` "
+"by `y`."
 msgstr ""
+"En önemli fark, tam sayılar ile alan elemanları arasında bölmedir: Alan " 
+"elemanlarının bölünmesi (ve dolayısıyla Cairo'daki bölme) normal CPU bölmesinden " 
+"farklıdır, burada tam sayı bölmesi \\\\( \\frac{x}{y} \\\\) \\\\( \\left\\lfloor " 
+"\\frac{x}{y} \\right\\rfloor \\\\) olarak tanımlanır ve bölenin tam kısmı geri " 
+"döndürülür (bu yüzden \\( \\frac{7}{3} = 2 \\\\) alırsınız) ve bu denklem \\( " 
+"\\frac{x}{y} \\cdot y == x \\\\) bağlı olarak `x`'in `y`'e bölünebilirliğine " 
+"göre tatmin edilir veya edilmez. "
+
 
 #: src/ch02-02-data-types.md:35
 msgid ""
 "In Cairo, the result of \\\\( \\frac{x}{y} \\\\) is defined to always "
 "satisfy the equation \\\\( \\frac{x}{y} \\cdot y == x \\\\). If y divides x "
-"as integers, you will get the expected result in Cairo (for example \\\\( "
-"\\frac{6}{2} \\\\) will indeed result in `3`). But when y does not divide x, "
-"you may get a surprising result: for example, since \\\\( 2 \\cdot \\frac{P "
-"+ 1}{2} = P + 1 \\equiv 1 \\mod P \\\\), the value of \\\\( \\frac{1}{2} "
-"\\\\) in Cairo is \\\\( \\frac{P + 1}{2} \\\\) (and not 0 or 0.5), as it "
-"satisfies the above equation."
+"as integers, you will get the expected result in Cairo (for example \\"
+"\\( \\frac{6}{2} \\\\) will indeed result in `3`). But when y does not "
+"divide x, you may get a surprising result: for example, since \\\\( 2 \\cdot "
+"\\frac{P + 1}{2} = P + 1 \\equiv 1 \\mod P \\\\), the value of \\"
+"\\( \\frac{1}{2} \\\\) in Cairo is \\\\( \\frac{P + 1}{2} \\\\) (and not 0 "
+"or 0.5), as it satisfies the above equation."
 msgstr ""
+"Cairo'da, \\\\( \\frac{x}{y} \\\\) sonucu her zaman \\\\( \\frac{x}{y} \\cdot y " 
+"== x \\\\) denklemini tatmin edecek şekilde tanımlanır. Eğer y, x'i tam sayılar " 
+"olarak bölerse, Cairo'da beklenen sonucu alırsınız (örneğin \\( \\frac{6}{2} \\) " 
+"gerçekten `3` sonucunu verir). Ancak y, x'i bölmüyorsa, şaşırtıcı bir sonuç alabilirsiniz: " 
+"örneğin, \\\\( 2 \\cdot \\frac{P + 1}{2} = P + 1 \\equiv 1 \\mod P \\\\) olduğundan, " 
+"Cairo'daki \\( \\frac{1}{2} \\) değeri \\\\( \\frac{P + 1}{2} \\\\) (ve 0 veya 0.5 " 
+"değil) olarak tanımlanır, çünkü bu yukarıdaki denklemi tatmin eder. "
 
 #: src/ch02-02-data-types.md:38
 msgid "Integer Types"
-msgstr ""
+msgstr "Tamsayı Türleri"
 
 #: src/ch02-02-data-types.md:40
 msgid ""
@@ -1443,10 +1818,21 @@ msgid ""
 "integer types in Cairo. We can use any of these variants to declare the type "
 "of an integer value."
 msgstr ""
+"felt252 türü, temel kütüphanedeki tüm türlerin oluşturulması için temel olarak hizmet veren temel bir türdür. Ancak, programcıların mümkün "
+"olduğunda `felt252` türünün yerine `integer` türlerini kullanmaları şiddetle tavsiye edilir, çünkü "
+"`integer` türleri, kodda potansiyel zafiyetlere karşı ekstra koruma sağlayan 
+"ek güvenlik özellikleri ile gelir, örneğin taşma ve taşma altı kontrolleri. Bu  
+"integer türlerini kullanarak, programcılar programlarının daha güvenli ve saldırılara  
+"veya diğer güvenlik tehditlerine karşı daha az hassas olduğundan emin olabilirler. Bir  
+"`integer`, kesirli bir bileşeni olmayan bir sayıdır. Bu tür bildirimi, programcının  
+"integer'ı depolamak için kullanabileceği bit sayısını gösterir. Tablo 3-1, Cairo'daki 
+"yerleşik integer türlerini gösterir. Bu çeşitlerden herhangi birini kullanarak integer  
+"değerinin türünü beyan edebiliriz."
+
 
 #: src/ch02-02-data-types.md:47
 msgid "Table 3-1: Integer Types in Cairo"
-msgstr ""
+msgstr "Cairo'da Tamsayı Türleri"
 
 #: src/ch02-02-data-types.md:49
 msgid "Length"
@@ -1515,6 +1901,10 @@ msgid ""
 "Cairo can be compiled to MLIR. As variables are unsigned, they can't contain "
 "a negative number. This code will cause the program to panic:"
 msgstr ""
+"Her çeşidin açık bir boyutu vardır. Şimdilik, `usize` türü sadece `u32` için bir  
+"takma addır; ancak, gelecekte Cairo MLIR'ye derlenebilecek olduğunda faydalı  
+"olabilir. Değişkenler işaretsiz olduğundan, negatif bir sayı içeremezler. Bu kod  
+"programın paniklemesine neden olacaktır: "
 
 #: src/ch02-02-data-types.md:72
 msgid ""
@@ -1522,6 +1912,10 @@ msgid ""
 "`u256` which needs 4 more bits to be stored. Under the hood, `u256` is "
 "basically a struct with 2 fields: `u256 {low: u128, high: u128}`."
 msgstr ""
+"Tüm önceden bahsedilen tam sayı  
+"türleri bir `felt252` içine sığar, ancak `u256` saklanmak için 4 fazladan bit  
+"ihtiyacı var. Kaputun altında, `u256` temelde 2 alana sahip bir yapıdır: `u256 
+"{low: u128, high: u128}`. "
 
 #: src/ch02-02-data-types.md:74
 msgid ""
@@ -1533,6 +1927,14 @@ msgid ""
 "numbers from \\\\( -({2^7}) \\\\) to \\\\( {2^7} - 1 \\\\), which equals "
 "`-128` to `127`."
 msgstr ""
+"Cairo ayrıca, `i` öneki ile başlayan işaretli tam sayılar için de destek  
+"sağlar. Bu tam sayılar hem pozitif hem de negatif değerleri temsil edebilir,  
+"boyutları `i8`'den `i128`'e kadar değişir. Her işaretli çeşit \\\\( -({2^{n -  
+"1}}) \\\\) ile \\\\( {2^{n - 1}} - 1 \\\\) arasında sayıları depolayabilir,  
+"burada `n`, o çeşidin kullandığı bit sayısıdır. Yani bir i8 \\\\( -({2^7}) \\\\)  
+"ile \\\\( {2^7} - 1 \\\\) arasında sayıları depolayabilir, bu da `-128` ile  
+"`127`'ye eşittir."
+
 
 #: src/ch02-02-data-types.md:77
 msgid ""
@@ -1541,10 +1943,15 @@ msgid ""
 "such as `57_u8`, to designate the type. It is also possible to use a visual "
 "separator `_` for number literals, in order to improve code readability."
 msgstr ""
+"Tam sayı sabitlerini, Tablo 3-2'de gösterilen herhangi bir formatta yazabilirsiniz. 
+"Not edin ki, birden fazla sayısal tür olabilen sayı sabitleri, türü belirtmek için  
+"`57_u8` gibi bir tür soneki kullanmaya izin verir. Ayrıca, kod okunurluğunu artırmak  
+"için sayı sabitlerinde görsel bir ayırıcı `_` kullanmak da mümkündür."
+
 
 #: src/ch02-02-data-types.md:82
 msgid "Table 3-2: Integer Literals in Cairo"
-msgstr ""
+msgstr "Cairo'da Tamsayı Değişmezleri"
 
 #: src/ch02-02-data-types.md:84
 msgid "Numeric literals"
@@ -1594,10 +2001,14 @@ msgid ""
 "value your int can have and choose the good size. The primary situation in "
 "which you’d use `usize` is when indexing some sort of collection."
 msgstr ""
+"Bir tam sayının hangi türünü kullanacağınızı nasıl anlarsınız? Tam sayınızın  
+"alabileceği maksimum değeri tahmin etmeye çalışın ve uygun boyutu seçin.  
+"`usize` kullanmanın başlıca durumu, bir tür koleksiyonu dizinlendiğinde olur.
+
 
 #: src/ch02-02-data-types.md:94
 msgid "Numeric Operations"
-msgstr ""
+msgstr "Sayısal İşlemler"
 
 #: src/ch02-02-data-types.md:96
 msgid ""
@@ -1607,6 +2018,11 @@ msgid ""
 "The following code shows how you’d use each numeric operation in a `let` "
 "statement:"
 msgstr ""
+"Cairo, tüm tam sayı türleri için beklediğiniz temel matematik işlemlerini  
+"destekler: toplama, çıkarma, çarpma, bölme ve kalan. Tam sayı bölmesi sıfıra  
+"doğru kesirli kısmı atarak en yakın tam sayıya yuvarlar. Aşağıdaki kod, bir  
+"`let` ifadesinde her bir sayısal işlemi nasıl kullanacağınızı gösterir:"
+
 
 #: src/ch02-02-data-types.md:103
 msgid "// addition\n"
@@ -1645,16 +2061,22 @@ msgid ""
 "Each expression in these statements uses a mathematical operator and "
 "evaluates to a single value, which is then bound to a variable."
 msgstr ""
+"Bu ifadelerdeki her bir ifade, matematiksel bir operatör kullanır ve tek bir  
+"değere değerlendirilir, ardından bu değer bir değişkene bağlanır.
+
 
 #: src/ch02-02-data-types.md:124
 msgid ""
 "[Appendix B](appendix-02-operators-and-symbols.md#operators) contains a list "
 "of all operators that Cairo provides."
 msgstr ""
+"[Ek B](appendix-02-operators-and-symbols.md#operators), Cairo'nun sağladığı  
+"tüm operatörlerin bir listesini içerir."
+
 
 #: src/ch02-02-data-types.md:126
 msgid "The Boolean Type"
-msgstr ""
+msgstr "Boolean Türü"
 
 #: src/ch02-02-data-types.md:128
 msgid ""
@@ -1662,6 +2084,10 @@ msgid ""
 "possible values: `true` and `false`. Booleans are one `felt252` in size. The "
 "Boolean type in Cairo is specified using `bool`. For example:"
 msgstr ""
+"Diğer çoğu programlama dilinde olduğu gibi, Cairo'daki bir Boolean türünün  
+"iki olası değeri vardır: `true` ve `false`. Booleanlar bir `felt252` boyutundadır.  
+"Cairo'da Boolean türü `bool` kullanılarak belirtilir. Örneğin:"
+
 
 #: src/ch02-02-data-types.md:136
 msgid "// with explicit type annotation\n"
@@ -1673,6 +2099,10 @@ msgid ""
 "`false` literals as value. Hence, it is not allowed to use integer literals "
 "(i.e. `0` instead of false) for `bool` declarations. "
 msgstr ""
+"Bir `bool` değişkeni tanımlarken, değer olarak ya `true` ya da `false`  
+"sabitlerinin kullanılması zorunludur. Dolayısıyla, `bool` tanımlamaları için  
+"tam sayı sabitleri (yani `0` yerine false) kullanmak mümkün değildir. "
+
 
 #: src/ch02-02-data-types.md:142
 msgid ""
@@ -1680,10 +2110,14 @@ msgid ""
 "expression. We’ll cover how `if` expressions work in Cairo in the [“Control "
 "Flow”](ch02-05-control-flow.md) section."
 msgstr ""
+"Boolean değerlerini kullanmanın ana yolu, bir `if` ifadesi gibi koşullulardır.  
+"Cairo'da `if` ifadelerinin nasıl çalıştığı [“Kontrol Akışı”](ch02-05-control-flow.md)  
+"bölümünde ele alınacaktır."
+
 
 #: src/ch02-02-data-types.md:146
 msgid "The Short String Type"
-msgstr ""
+msgstr "Kısa Dize Türü"
 
 #: src/ch02-02-data-types.md:148
 msgid ""
@@ -1693,6 +2127,12 @@ msgid ""
 "felt (a felt is 252 bits, one ASCII char is 8 bits). Here are some examples "
 "of declaring values by putting them between single quotes:"
 msgstr ""
+"Cairo, yerleşik bir string türüne sahip değildir, ancak `felt252` içinde  
+"\"kısa string\" olarak adlandırdığımız karakterleri saklayabilirsiniz. Bir kısa  
+"stringin maksimum uzunluğu 31 karakterdir. Bu, tek bir felt içine sığdırılabilmesini  
+"sağlamak içindir (bir felt 252 bit, bir ASCII karakteri 8 bittir). İşte tek tırnak  
+"arasına değerleri koyarak değer tanımlama örnekleri:"
+
 
 #: src/ch02-02-data-types.md:153
 msgid "'C'"
@@ -1700,7 +2140,7 @@ msgstr ""
 
 #: src/ch02-02-data-types.md:158
 msgid "Type casting"
-msgstr ""
+msgstr "Tip döküm"
 
 #: src/ch02-02-data-types.md:160
 msgid ""
@@ -1708,6 +2148,10 @@ msgid ""
 "`try_into` and `into` methods provided by the `TryInto` and `Into` traits "
 "from the core library."
 msgstr ""
+"Cairo'da, temel kütüphaneden sağlanan `TryInto` ve `Into` traitlerinin  
+"`try_into` ve `into` yöntemlerini kullanarak skaler türleri birbirine  
+"çevirebilirsiniz."
+
 
 #: src/ch02-02-data-types.md:162
 msgid ""
@@ -1715,6 +2159,10 @@ msgid ""
 "might not fit the source value. Keep in mind that `try_into` returns an "
 "`Option<T>` type, which you'll need to unwrap to access the new value."
 msgstr ""
+"`try_into` yöntemi, hedef tür kaynak değere sığmayabileceği durumlarda güvenli  
+"tür dönüşümü sağlar. `try_into`'nun bir `Option<T>` türü döndürdüğünü ve yeni  
+"değere erişmek için bunun açılması gerektiğini unutmayın."
+
 
 #: src/ch02-02-data-types.md:164
 msgid ""
@@ -1722,6 +2170,9 @@ msgid ""
 "success is guaranteed, such as when the source type is smaller than the "
 "destination type."
 msgstr ""
+"Diğer yandan, `into` yöntemi, kaynak tür hedef türden daha küçük olduğu gibi, 
+"başarının garanti edildiği tür dönüşümleri için kullanılabilir."
+
 
 #: src/ch02-02-data-types.md:166
 msgid ""
@@ -1729,6 +2180,10 @@ msgid ""
 "source value to cast it to another type. The new variable's type must be "
 "explicitly defined, as demonstrated in the example below."
 msgstr ""
+"Dönüşümü gerçekleştirmek için, kaynak değeri başka bir türe dönüştürmek için  
+"`var.into()` veya `var.try_into()` çağırın. Yeni değişkenin türü, aşağıdaki 
+"örnekte gösterildiği gibi açıkça tanımlanmalıdır."
+
 
 #: src/ch02-02-data-types.md:171
 msgid ""
@@ -1742,7 +2197,7 @@ msgstr ""
 
 #: src/ch02-02-data-types.md:185
 msgid "The Tuple Type"
-msgstr ""
+msgstr "Tuple Türü"
 
 #: src/ch02-02-data-types.md:187
 msgid ""
@@ -1750,6 +2205,10 @@ msgid ""
 "variety of types into one compound type. Tuples have a fixed length: once "
 "declared, they cannot grow or shrink in size."
 msgstr ""
+"Bir _tuple_, çeşitli türlerdeki bir dizi değeri tek bir bileşik tür olarak  
+"bir araya getirmenin genel bir yoludur. Tupleların sabit bir uzunluğu vardır:  
+"bir kez tanımlandıktan sonra, boyutları büyüyemez veya küçülemez."
+
 
 #: src/ch02-02-data-types.md:191
 msgid ""
@@ -1758,6 +2217,11 @@ msgid ""
 "different values in the tuple don’t have to be the same. We’ve added "
 "optional type annotations in this example:"
 msgstr ""
+"Bir tuple'ı, parantez içinde virgülle ayrılmış bir değer listesi yazarak  
+"oluştururuz. Tupledaki her pozisyonun bir türü vardır ve tupledaki farklı  
+"değerlerin türleri aynı olmak zorunda değildir. Bu örnekte isteğe bağlı tür  
+"annotasyonları ekledik:"
+
 
 #: src/ch02-02-data-types.md:202
 msgid ""
@@ -1765,6 +2229,10 @@ msgid ""
 "single compound element. To get the individual values out of a tuple, we can "
 "use pattern matching to destructure a tuple value, like this:"
 msgstr ""
+"`tup` değişkeni, bir tuple'ın tek bir bileşik eleman olarak kabul edilmesi  
+"nedeniyle tüm tuple'ı bağlar. Bir tupledan tekil değerleri çıkarmak için, bir  
+"tuple değerini yapılandırmak için kalıp eşleştirmeyi kullanabiliriz, şöyle ki:"
+
 
 #: src/ch02-02-data-types.md:213
 msgid "\"y is 6!\""
@@ -1778,16 +2246,25 @@ msgid ""
 "breaks the single tuple into three parts. Finally, the program prints `y is "
 "six` as the value of `y` is `6`."
 msgstr ""
+"Bu program ilk olarak bir tuple oluşturur ve onu `tup` değişkenine bağlar.  
+"Ardından `let` ile bir kalıp kullanarak `tup`'ı alır ve onu `x`, `y` ve `z` 
+"olmak üzere üç ayrı değişkene dönüştürür. Bu, tek bir tuple'ı üç parçaya  
+"ayırması nedeniyle _yapılandırma_ olarak adlandırılır. Son olarak, program  
+"`y is six` olarak `y`'nin değerinin `6` olduğunu yazdırır."
+
 
 #: src/ch02-02-data-types.md:224
 msgid ""
 "We can also declare the tuple with value and types, and destructure it at "
 "the same time. For example:"
 msgstr ""
+"Aynı zamanda değer ve türlerle tuple'ı bildirebilir ve onu yapılandırabiliriz. 
+"Örneğin:"
+
 
 #: src/ch02-02-data-types.md:233
 msgid "The unit type ()"
-msgstr ""
+msgstr "Birim tipi ()"
 
 #: src/ch02-02-data-types.md:235
 msgid ""
@@ -1795,6 +2272,10 @@ msgid ""
 "a tuple with no elements. Its size is always zero, and it is guaranteed to "
 "not exist in the compiled code."
 msgstr ""
+"Bir _birim türü_, yalnızca bir değeri `()` olan bir türdür. Hiçbir elemanı  
+"olmayan bir tuple temsil edilir. Boyutu her zaman sıfırdır ve derlenmiş  
+"kodda var olmadığı garanti edilir."
+
 
 #: src/ch02-03-functions.md:3
 msgid ""
@@ -1803,6 +2284,10 @@ msgid ""
 "point of many programs. You’ve also seen the `fn` keyword, which allows you "
 "to declare new functions."
 msgstr ""
+"Fonksiyonlar Cairo kodunda yaygındır. Dilin en önemli fonksiyonlarından birini  
+"zaten gördünüz: birçok programın giriş noktası olan `main` fonksiyonu. Ayrıca yeni  
+"fonksiyonlar bildirmenize izin veren `fn` anahtar kelimesini de gördünüz."
+
 
 #: src/ch02-03-functions.md:8
 msgid ""
@@ -1810,6 +2295,10 @@ msgid ""
 "variable names, in which all letters are lowercase and underscores separate "
 "words. Here’s a program that contains an example function definition:"
 msgstr ""
+"Cairo kodu, fonksiyon ve değişken adları için geleneksel stil olarak _snake case_  
+"kullanır, burada tüm harfler küçük harftir ve alt çizgiler kelimeleri ayırır. İşte bir  
+"fonksiyon tanımı içeren bir program örneği:"
+
 
 #: src/ch02-03-functions.md:14
 msgid "\"Another function.\""
@@ -1825,6 +2314,10 @@ msgid ""
 "and a set of parentheses. The curly brackets tell the compiler where the "
 "function body begins and ends."
 msgstr ""
+"Bir fonksiyonu Cairo'da `fn`'yi takiben bir fonksiyon adı ve bir parantez kümesi  
+"girerek tanımlarız. Süslü parantezler, fonksiyon gövdesinin nerede başlayıp  
+"bittiğini derleyiciye söyler."
+
 
 #: src/ch02-03-functions.md:27
 msgid ""
@@ -1836,6 +2329,13 @@ msgid ""
 "functions, only that they’re defined somewhere in a scope that can be seen "
 "by the caller."
 msgstr ""
+"Tanımladığımız herhangi bir fonksiyonu, adını takiben bir parantez kümesi girerek  
+"çağırabiliriz. Programda `another_function` tanımlandığından, `main` fonksiyonunun  
+"içinden çağrılabilir. Kaynak kodda `another_function`'ı `main` fonksiyonundan  
+"_önce_ tanımladığımızı unutmayın; bunu sonrasında da tanımlayabilirdik. Cairo,  
+"fonksiyonlarınızı nerede tanımladığınızı umursamaz, yeter ki çağıran tarafından  
+"görülebilecek bir kapsamda tanımlansınlar."
+
 
 #: src/ch02-03-functions.md:34
 msgid ""
@@ -1843,6 +2343,10 @@ msgid ""
 "further. Place the `another_function` example in _src/lib.cairo_ and run it. "
 "You should see the following output:"
 msgstr ""
+"Fonksiyonları daha fazla keşfetmek için Scarb ile _functions_ adında yeni bir  
+"proje başlatalım. `another_function` örneğini _src/lib.cairo_ içine yerleştirin ve  
+"çalıştırın. Aşağıdaki çıktıyı görmelisiniz:"
+
 
 #: src/ch02-03-functions.md:45
 msgid ""
@@ -1850,10 +2354,14 @@ msgid ""
 "First the “Hello, world!” message prints, and then `another_function` is "
 "called and its message is printed."
 msgstr ""
+"Satırlar, `main` fonksiyonunda göründükleri sırayla çalışır. İlk olarak “Hello,  
+"world!” mesajı yazdırılır ve ardından `another_function` çağrılır ve onun mesajı  
+"yazdırılır."
+
 
 #: src/ch02-03-functions.md:49
 msgid "Parameters"
-msgstr ""
+msgstr "Parametreler"
 
 #: src/ch02-03-functions.md:51
 msgid ""
@@ -1865,14 +2373,21 @@ msgid ""
 "the variables in a function’s definition or the concrete values passed in "
 "when you call a function."
 msgstr ""
+"Fonksiyonları, fonksiyonun imzasının bir parçası olan özel değişkenler olan _parametreler_  
+"ile tanımlayabiliriz. Bir fonksiyonun parametreleri olduğunda, bu parametreler için somut  
+"değerler sağlayabilirsiniz. Teknik olarak, somut değerlere _argümanlar_ denir, ancak  
+"günlük konuşmada, insanlar genellikle fonksiyonun tanımındaki değişkenler veya fonksiyonu  
+"çağırdığınızda geçirilen somut değerler için _parametre_ ve _argüman_ kelimelerini birbirinin  
+"yerine kullanır."
+
 
 #: src/ch02-03-functions.md:59
 msgid "In this version of `another_function` we add a parameter:"
-msgstr ""
+msgstr "`another_function`'un bu versiyonunda bir parametre ekliyoruz"
 
 #: src/ch02-03-functions.md:71
 msgid "Try running this program; you should get the following output:"
-msgstr ""
+msgstr "Bu programı çalıştırmayı deneyin; aşağıdaki çıktıyı almalısınız"
 
 #: src/ch02-03-functions.md:79
 msgid ""
@@ -1881,6 +2396,10 @@ msgid ""
 "the `println!` macro puts `5` where the pair of curly brackets containing "
 "`x` was in the format string."
 msgstr ""
+"`another_function`'ın bildirimi `x` adında bir parametreye sahiptir. `x`'in türü  
+"`felt252` olarak belirtilmiştir. `another_function`'a `5` geçirdiğimizde, `println!` makrosu  
+"`x`'i içeren süslü parantez çiftinin olduğu yere format dizgisinde `5` koyar."
+
 
 #: src/ch02-03-functions.md:83
 msgid ""
@@ -1891,12 +2410,19 @@ msgid ""
 "able to give more helpful error messages if it knows what types the function "
 "expects."
 msgstr ""
+"Fonksiyon imzalarında, her parametrenin türünü _mutlaka_ belirtmelisiniz. Bu, Cairo’nun  
+"tasarımında bilinçli bir karardır: fonksiyon tanımlarında tür annotasyonları gerektirmek,  
+"kodun geri kalanında ne tür bir şey kastettiğinizi anlamak için derleyicinin neredeyse hiç  
+"sizin tarafınızdan bunları kullanmanızı gerektirmez. Derleyici, fonksiyonun hangi türleri  
+"beklediğini bildiğinde daha yardımcı hata mesajları verebilir."
+
 
 #: src/ch02-03-functions.md:89
 msgid ""
 "When defining multiple parameters, separate the parameter declarations with "
 "commas, like this:"
 msgstr ""
+"Birden fazla parametre tanımlarken, parametre bildirimlerini aşağıdaki gibi virgülle ayırın:"
 
 #: src/ch02-03-functions.md:94
 msgid "\"h\""
@@ -1914,6 +2440,11 @@ msgid ""
 "represent string literals. The function then prints text containing both the "
 "`value` and the `unit_label`."
 msgstr ""
+"Bu örnek, `value` ve `unit_label` adında iki parametre ile `print_labeled_measurement` adında  
+"bir fonksiyon oluşturur. İlk parametre `value` adını taşır ve bir `u128`'dir. İkincisi `unit_label`  
+"adında ve `ByteArray` türündedir - Cairo'nun string literallerini temsil etmek için içsel türü.  
+"Fonksiyon daha sonra hem `value` hem de `unit_label` içeren bir metin yazdırır."
+
 
 #: src/ch02-03-functions.md:106
 msgid ""
@@ -1921,35 +2452,49 @@ msgid ""
 "_functions_ project’s _src/lib.cairo_ file with the preceding example and "
 "run it using `scarb cairo-run`:"
 msgstr ""
+"Bu kodu çalıştırmayı deneyelim. _functions_ projesinin _src/lib.cairo_ dosyasındaki mevcut  
+"programı önceki örnekle değiştirin ve `scarb cairo-run` kullanarak çalıştırın:"
+
 
 #: src/ch02-03-functions.md:115
 msgid ""
 "Because we called the function with `5` as the value for value and `\"h\"` "
 "as the value for `unit_label`, the program output contains those values."
 msgstr ""
+"Fonksiyonu `value` için `5` değeriyle ve `unit_label` için `\"h\"` değeriyle çağırdığımız için,  
+"program çıktısı bu değerleri içerir."
+
 
 #: src/ch02-03-functions.md:117
 msgid "Named parameters"
-msgstr ""
+msgstr "Adlandırılmış parametreler"
 
 #: src/ch02-03-functions.md:119
 msgid ""
 "In Cairo, named parameters allow you to specify the names of arguments when "
-"you call a function. This makes the function calls more readable and "
-"self-descriptive. If you want to use named parameters, you need to specify "
-"the name of the parameter and the value you want to pass to it. The syntax "
-"is `parameter_name: value`. If you pass a variable that has the same name as "
+"you call a function. This makes the function calls more readable and self-"
+"descriptive. If you want to use named parameters, you need to specify the "
+"name of the parameter and the value you want to pass to it. The syntax is "
+"`parameter_name: value`. If you pass a variable that has the same name as "
 "the parameter, you can simply write `:parameter_name` instead of "
 "`parameter_name: variable_name`."
 msgstr ""
+"Cairo'da, adlandırılmış parametreler bir fonksiyonu çağırırken argümanların  
+"isimlerini belirtmenize olanak tanır. Bu, fonksiyon çağrılarını daha okunabilir  
+"ve kendini açıklayıcı hale getirir. Eğer adlandırılmış parametreleri kullanmak  
+"istiyorsanız, parametrenin adını ve ona geçirmek istediğiniz değeri belirtmeniz  
+"gereklidir. Sözdizimi şöyledir: `parameter_name: value`. Eğer parametre ile aynı  
+"ada sahip bir değişken geçirirseniz, `parameter_name: variable_name` yerine  
+"sadece `:parameter_name` yazabilirsiniz."
+
 
 #: src/ch02-03-functions.md:122
 msgid "Here is an example:"
-msgstr ""
+msgstr "İşte bir örnek"
 
 #: src/ch02-03-functions.md:137
 msgid "Statements and Expressions"
-msgstr ""
+msgstr "Statements ve Expressions"
 
 #: src/ch02-03-functions.md:139
 msgid ""
@@ -1961,17 +2506,24 @@ msgid ""
 "so let’s look at what statements and expressions are and how their "
 "differences affect the bodies of functions."
 msgstr ""
+"Fonksiyon gövdeleri, isteğe bağlı olarak bir expression ile sonlanan bir dizi statement'tan  
+"oluşur. Şu ana kadar ele aldığımız fonksiyonlar, bir sonlandırma expression'ı içermemişti,  
+"ancak bir statement içinde bir expression görmüşsünüzdür. Cairo bir expression tabanlı dil  
+"olduğundan, bu önemli bir ayrımı anlamak önemlidir. Diğer diller aynı ayrımlara sahip değildir,  
+"bu yüzden statement'lar ve expression'lar neyi ifade eder ve farklılıkları fonksiyon gövdelerini  
+"nasıl etkiler, bunlara bakalım."
+
 
 #: src/ch02-03-functions.md:147
 msgid ""
 "**Statements** are instructions that perform some action and do not return a "
 "value."
-msgstr ""
+msgstr "**Statements**, bazı eylemleri gerçekleştiren ve bir değer döndürmeyen talimatlardır."
 
 #: src/ch02-03-functions.md:149
 msgid ""
 "**Expressions** evaluate to a resultant value. Let’s look at some examples."
-msgstr ""
+msgstr "**Expressions** bir sonuç değerine göre değerlendirilir. Şimdi bazı örneklere bakalım."
 
 #: src/ch02-03-functions.md:151
 msgid ""
@@ -1979,16 +2531,21 @@ msgid ""
 "and assigning a value to it with the `let` keyword is a statement. In "
 "Listing 2-1, `let y = 6;` is a statement."
 msgstr ""
+"Biz aslında zaten statement'lar ve expression'lar kullanmışızdır. Bir değişken oluşturmak ve  
+"`let` anahtar kelimesi ile ona bir değer atamak bir statement'dır. Listing 2-1'de, `let y = 6;`  
+"bir statement'dır."
+
 
 #: src/ch02-03-functions.md:161
 msgid "Listing 2-1: A `main` function declaration containing one statement"
-msgstr ""
+msgstr "Liste 2-1: Bir deyim içeren bir `main` fonksiyonu bildirimi"
 
 #: src/ch02-03-functions.md:163
 msgid ""
 "Function definitions are also statements; the entire preceding example is a "
 "statement in itself."
 msgstr ""
+"Fonksiyon tanımları da ifadelerdir; önceki örneğin tamamı kendi içinde bir ifadedir."
 
 #: src/ch02-03-functions.md:166
 msgid ""
@@ -1996,10 +2553,13 @@ msgid ""
 "statement to another variable, as the following code tries to do; you’ll get "
 "an error:"
 msgstr ""
+"Statement'lar değer döndürmez. Bu nedenle, bir `let` statement'ını başka bir değişkene  
+"atayamazsınız, aşağıdaki kodun yapmaya çalıştığı gibi; bir hata alırsınız:"
+
 
 #: src/ch02-03-functions.md:175
 msgid "When you run this program, the error you’ll get looks like this:"
-msgstr ""
+msgstr "Bu programı çalıştırdığınızda alacağınız hata şuna benzer:"
 
 #: src/ch02-03-functions.md:199
 msgid ""
@@ -2009,6 +2569,11 @@ msgid ""
 "assignment. In those languages, you can write `x = y = 6` and have both `x` "
 "and `y` have the value `6`; that is not the case in Cairo."
 msgstr ""
+"`let y = 6` statement'ı bir değer döndürmez, bu yüzden `x`'in bağlanacak bir şeyi yoktur. Bu, C  
+"ve Ruby gibi diğer dillerde olanlardan farklıdır, bu dillerde atama, atamanın değerini döndürür.  
+"Bu dillerde `x = y = 6` yazabilir ve hem `x` hem de `y`'nin değeri `6` olur; bu Cairo'da söz  
+"konusu değildir."
+ 
 
 #: src/ch02-03-functions.md:205
 msgid ""
@@ -2018,6 +2583,11 @@ msgid ""
 "part of statements: in Listing 2-1, the `6` in the statement `let y = 6;` is "
 "an expression that evaluates to the value `6`."
 msgstr ""
+"Expression'lar bir değere değerlendirilir ve Cairo'da yazacağınız kodun çoğunu oluşturur. Örneğin,  
+"`5 + 6` gibi bir matematik işlemi, değeri `11` olarak değerlendirilen bir expression'dır.  
+"Expression'lar statement'ların bir parçası olabilir: Listing 2-1'de, `let y = 6;` statement'ındaki  
+"`6`, değeri `6` olarak değerlendirilen bir expression'dır."
+
 
 #: src/ch02-03-functions.md:211
 msgid ""
@@ -2025,11 +2595,15 @@ msgid ""
 "the function's explicit return value, if specified, or the 'unit' type `()` "
 "otherwise."
 msgstr ""
+"Bir fonksiyonu çağırmak bir expression'dır çünkü her zaman bir değere değerlendirilir: belirtilmişse  
+"fonksiyonun açık dönüş değeri, aksi takdirde 'unit' türü `()`."
+
 
 #: src/ch02-03-functions.md:213
 msgid ""
 "A new scope block created with curly brackets is an expression, for example:"
 msgstr ""
+"Örneğin, küme parantezleriyle oluşturulan yeni bir kapsam bloğu bir ifadedir:"
 
 #: src/ch02-03-functions.md:223
 msgid "\"The value of y is: {}\""
@@ -2037,7 +2611,7 @@ msgstr ""
 
 #: src/ch02-03-functions.md:227
 msgid "This expression:"
-msgstr ""
+msgstr "Bu expression:"
 
 #: src/ch02-03-functions.md:236
 msgid ""
@@ -2049,10 +2623,16 @@ msgid ""
 "return a value. Keep this in mind as you explore function return values and "
 "expressions next."
 msgstr ""
+"bu durumda `4` olarak değerlendirilen bir bloktur. Bu değer, `let` statement'ının bir parçası olarak  
+"`y`'e bağlanır. `x + 1` satırının sonunda, şimdiye kadar gördüğünüz çoğu satırdan farklı olarak bir  
+"noktalı virgül yoktur. Expression'lar sonunda noktalı virgül içermez. Bir expression'ın sonuna  
+"noktalı virgül eklerseniz, onu bir statement'a dönüştürürsünüz ve o zaman bir değer döndürmez.  
+"Bunu, fonksiyon dönüş değerlerini ve expression'ları keşfederken aklınızda bulundurun."
+
 
 #: src/ch02-03-functions.md:244
 msgid "Functions with Return Values"
-msgstr ""
+msgstr "Dönüş Değerleri Olan Fonksiyonlar"
 
 #: src/ch02-03-functions.md:246
 msgid ""
@@ -2064,14 +2644,27 @@ msgid ""
 "but most functions return the last expression implicitly. Here’s an example "
 "of a function that returns a value:"
 msgstr ""
+"Fonksiyonlar, onları çağıran koda değerler döndürebilir. Dönüş değerlerini  
+"isimlendirmeyiz, ancak türlerini bir ok (`->`) sonrasında belirtmeliyiz.  
+"Cairo'da, fonksiyonun dönüş değeri, fonksiyonun gövde bloğundaki son  
+"expression ile eşanlamlıdır. `return` anahtar kelimesini kullanarak ve bir  
+"değer belirterek bir fonksiyondan erken dönüş yapabilirsiniz, ancak çoğu  
+"fonksiyon son expression'ı dolaylı olarak döndürür. İşte bir değer döndüren  
+"bir fonksiyonun örneği:"
+
 
 #: src/ch02-03-functions.md:265
 msgid ""
-"There are no function calls, or even `let` statements in the `five` "
-"function—just the number `5` by itself. That’s a perfectly valid function in "
-"Cairo. Note that the function’s return type is specified too, as `-> u32`. "
-"Try running this code; the output should look like this:"
+"There are no function calls, or even `let` statements in the `five` function—"
+"just the number `5` by itself. That’s a perfectly valid function in Cairo. "
+"Note that the function’s return type is specified too, as `-> u32`. Try "
+"running this code; the output should look like this:"
 msgstr ""
+"`five` fonksiyonunda fonksiyon çağrıları veya hatta `let` statement'ları  
+"yoktur—sadece tek başına `5` numarası vardır. Bu, Cairo'da geçerli bir  
+"fonksiyondur. Fonksiyonun dönüş türünün de `-> u32` olarak belirtildiğine  
+"dikkat edin. Bu kodu çalıştırmayı deneyin; çıktı şöyle görünmelidir:"
+
 
 #: src/ch02-03-functions.md:276
 msgid ""
@@ -2081,6 +2674,12 @@ msgid ""
 "value of a function to initialize a variable. Because the function `five` "
 "returns a `5`, that line is the same as the following:"
 msgstr ""
+"`five` içindeki `5`, fonksiyonun dönüş değeridir, bu yüzden dönüş türü  
+"`u32`'dir. Bunu daha detaylı inceleyelim. İki önemli nokta var: ilk olarak,  
+"`let x = five();` satırı, bir fonksiyonun dönüş değerini bir değişkeni  
+"başlatmak için kullandığımızı gösterir. Çünkü `five` fonksiyonu bir `5`  
+"döndürür, bu satır aşağıdakiyle aynıdır:"
+
 
 #: src/ch02-03-functions.md:286
 msgid ""
@@ -2089,6 +2688,11 @@ msgid ""
 "because it’s an expression whose value we want to return. Let’s look at "
 "another example:"
 msgstr ""
+"İkincisi, `five` fonksiyonunun parametreleri yoktur ve dönüş değerinin  
+"türünü tanımlar, ancak fonksiyonun gövdesi, döndürmek istediğimiz değerin  
+"bir expression'ı olduğu için noktalı virgül olmadan yalnız bir `5`'tir.  
+"Bir başka örneğe bakalım:"
+
 
 #: src/ch02-03-functions.md:303
 msgid ""
@@ -2096,6 +2700,10 @@ msgid ""
 "of the line containing `x + 1`, changing it from an expression to a "
 "statement, we’ll get an error:"
 msgstr ""
+"Bu kodu çalıştırmak `x = 6` yazdıracaktır. Ancak, `x + 1` satırının sonuna  
+"noktalı virgül koyarsak, bunu bir expression'dan bir statement'a çevirirsek,  
+"bir hata alırız:"
+
 
 #: src/ch02-03-functions.md:320
 msgid ""
@@ -2104,6 +2712,11 @@ msgid ""
 "\"()\".\n"
 "```"
 msgstr ""
+"```shell\n"
+"error: Unexpected return type. Expected: \"core::integer::u32\", found: 
+"\"()\".\n"
+"```"
+
 
 #: src/ch02-03-functions.md:324
 msgid ""
@@ -2113,6 +2726,12 @@ msgid ""
 "expressed by `()`, the unit type. Therefore, nothing is returned, which "
 "contradicts the function definition and results in an error."
 msgstr ""
+"Ana hata mesajı olan `Unexpected return type`, bu kodla ilgili temel sorunu  
+"ortaya koyar. `plus_one` fonksiyonunun tanımı, bir `u32` döndüreceğini  
+"söyler, ancak statement'lar bir değere değerlendirilmez, bu `()`, yani unit  
+"türü ile ifade edilir. Dolayısıyla, hiçbir şey döndürülmez, bu da fonksiyonun  
+"tanımı ile çelişir ve bir hataya neden olur. "
+
 
 #: src/ch02-04-comments.md:3
 msgid ""
@@ -2121,14 +2740,19 @@ msgid ""
 "in their source code that the compiler will ignore but people reading the "
 "source code may find useful."
 msgstr ""
+"Tüm programcılar kodlarını anlaşılır kılmaya çalışır, ancak bazen ek açıklama  
+"gerekebilir. Bu durumlarda, programcılar kaynak kodlarında derleyicinin  
+"yoksayacağı ancak kaynak kodunu okuyanların faydalı bulabileceği yorumlar  
+"bırakır."
+
 
 #: src/ch02-04-comments.md:5
 msgid "Here’s a simple comment:"
-msgstr ""
+msgstr "İşte basit bir yorum:"
 
 #: src/ch02-04-comments.md:8
 msgid "// hello, world\n"
-msgstr ""
+msgstr "// Merhaba, dünya\n"
 
 #: src/ch02-04-comments.md:11
 msgid ""
@@ -2136,6 +2760,10 @@ msgid ""
 "the comment continues until the end of the line. For comments that extend "
 "beyond a single line, you’ll need to include `//` on each line, like this:"
 msgstr ""
+"Cairo'da, özdeş yorum stili bir yorumu iki eğik çizgi ile başlatır ve yorum  
+"satırın sonuna kadar devam eder. Tek bir satırın ötesine uzanan yorumlar için,  
+"her satırda `//` eklemeniz gerekir, şöyle ki:"
+
 
 #: src/ch02-04-comments.md:14
 msgid ""
@@ -2146,7 +2774,7 @@ msgstr ""
 
 #: src/ch02-04-comments.md:19
 msgid "Comments can also be placed at the end of lines containing code:"
-msgstr ""
+msgstr "Yorumlar, kod içeren satırların sonuna da yerleştirilebilir:"
 
 #: src/ch02-04-comments.md:25
 msgid "// return the sum of 1 and 4\n"
@@ -2157,6 +2785,9 @@ msgid ""
 "But you’ll more often see them used in this format, with the comment on a "
 "separate line above the code it’s annotating:"
 msgstr ""
+"Ancak onları daha sık bu formatta, yorumunun açıkladığı kodun üzerinde ayrı bir  
+"satırda göreceksiniz:"
+
 
 #: src/ch02-04-comments.md:35
 msgid "// this function performs a simple addition\n"
@@ -2169,10 +2800,15 @@ msgid ""
 "in most programming languages. The most common constructs that let you "
 "control the flow of execution of Cairo code are if expressions and loops."
 msgstr ""
+"Bir koşul doğru olduğunda bazı kodların çalıştırılması ve bir koşul doğru  
+"olduğu sürece bazı kodların tekrar tekrar çalıştırılması, çoğu programlama  
+"dilinde temel yapı taşlarıdır. Cairo kodunun yürütme akışını kontrol etmenize  
+"izin veren en yaygın yapılar if ifadeleri ve döngülerdir."
+
 
 #: src/ch02-05-control-flow.md:5
 msgid "`if` Expressions"
-msgstr ""
+msgstr "`if` İfadesi"
 
 #: src/ch02-05-control-flow.md:7
 msgid ""
@@ -2180,6 +2816,10 @@ msgid ""
 "provide a condition and then state, “If this condition is met, run this "
 "block of code. If the condition is not met, do not run this block of code.”"
 msgstr ""
+"Bir if ifadesi, koşullara bağlı olarak kodunuzu dallandırmanıza olanak tanır.  
+"Bir koşul sağlarsınız ve ardından, “Bu koşul karşılanırsa, bu kod bloğunu  
+"çalıştır. Koşul karşılanmazsa, bu kod bloğunu çalıştırma.” dersiniz."
+
 
 #: src/ch02-05-control-flow.md:9
 msgid ""
@@ -2187,6 +2827,9 @@ msgid ""
 "explore the `if` expression. In the _src/lib.cairo_ file, input the "
 "following:"
 msgstr ""
+"_cairo_projects_ dizininizde _branches_ adında yeni bir proje oluşturun ve  
+"`if` ifadesini keşfedin. _src/lib.cairo_ dosyasına aşağıdakileri girin:"
+
 
 #: src/ch02-05-control-flow.md:18
 msgid "\"condition was true and number = {}\""
@@ -2203,6 +2846,11 @@ msgid ""
 "a value equal to 5. We place the block of code to execute if the condition "
 "is `true` immediately after the condition inside curly brackets."
 msgstr ""
+"Tüm `if` ifadeleri `if` anahtar kelimesiyle başlar, ardından bir koşul gelir.  
+"Bu durumda, koşul `number` değişkeninin değerinin 5'e eşit olup olmadığını  
+"kontrol eder. Koşul `true` ise yürütülecek kod bloğunu koşulun hemen ardından  
+"süslü parantezler içine yerleştiririz."
+
 
 #: src/ch02-05-control-flow.md:27
 msgid ""
@@ -2212,16 +2860,24 @@ msgid ""
 "the condition is `false`, the program will just skip the `if` block and move "
 "on to the next bit of code."
 msgstr ""
+"İsteğe bağlı olarak, koşul `false` olarak değerlendirilirse programın  
+"yürüteceği alternatif bir kod bloğu vermek için burada yaptığımız gibi bir  
+"`else` ifadesi de ekleyebiliriz. Bir `else` ifadesi sağlamazsanız ve koşul  
+"`false` ise, program `if` bloğunu atlayıp kodun bir sonraki kısmına geçer."
+
 
 #: src/ch02-05-control-flow.md:29
 msgid "Try running this code; you should see the following output:"
-msgstr ""
+msgstr "Bu kodu çalıştırmayı deneyin; aşağıdaki çıktıyı görmelisiniz:"
 
 #: src/ch02-05-control-flow.md:37
 msgid ""
 "Let’s try changing the value of `number` to a value that makes the condition "
 "`true` to see what happens:"
 msgstr ""
+"Koşulun `true` olmasını sağlayacak bir değere `number` değerini değiştirip  
+"ne olacağını görelim:"
+
 
 #: src/ch02-05-control-flow.md:49
 msgid ""
@@ -2229,6 +2885,10 @@ msgid ""
 "the condition isn’t a `bool`, we’ll get an error. For example, try running "
 "the following code:"
 msgstr ""
+"Bu kodda koşulun bir `bool` olması gerektiğini belirtmek de önemlidir.  
+"Koşul bir `bool` değilse, bir hata alırız. Örneğin, aşağıdaki kodu  
+"çalıştırmayı deneyin:"
+
 
 #: src/ch02-05-control-flow.md:59
 msgid "\"number was three\""
@@ -2238,7 +2898,7 @@ msgstr ""
 msgid ""
 "The `if` condition evaluates to a value of 3 this time, and Cairo throws an "
 "error:"
-msgstr ""
+msgstr "`if` koşulu bu kez 3 değerini değerlendirir ve Cairo bir hata atar:"
 
 #: src/ch02-05-control-flow.md:78
 msgid ""
@@ -2251,6 +2911,15 @@ msgid ""
 "the `if` code block to run only when a number is not equal to 0, for "
 "example, we can change the if expression to the following:"
 msgstr ""
+"Hata, `number`'ın daha sonra `if` ifadesinin koşulu olarak kullanılmasına  
+"dayanarak Cairo'nun `number` için `bool` türünü çıkardığını gösterir. Değer  
+"`3`'ten bir `bool` oluşturmaya çalışır, ancak Cairo zaten bir sayısal  
+"literalden `bool` oluşturmayı desteklemez - bir `bool` oluşturmak için sadece  
+"`true` veya `false` kullanabilirsiniz. Ruby ve JavaScript gibi dillerin  
+"aksine, Cairo otomatik olarak Boolean olmayan türleri Boolean'a dönüştürmeye  
+"çalışmaz. Örneğin, bir sayı 0'a eşit olmadığında `if` kod bloğunun yalnızca  
+"çalışmasını istiyorsak, if ifadesini şu şekilde değiştirebiliriz:"
+
 
 #: src/ch02-05-control-flow.md:92
 msgid "\"number was something other than zero\""
@@ -2258,17 +2927,20 @@ msgstr ""
 
 #: src/ch02-05-control-flow.md:98
 msgid "Running this code will print `number was something other than zero`."
-msgstr ""
+msgstr "Bu kodu çalıştırmak, `number was something other than zero` yazdıracaktır."
 
 #: src/ch02-05-control-flow.md:100
 msgid "Handling Multiple Conditions with `else if`"
-msgstr ""
+msgstr "Birden Fazla Koşulu `else if` ile İşleme"
 
 #: src/ch02-05-control-flow.md:102
 msgid ""
 "You can use multiple conditions by combining `if` and `else` in an `else if` "
 "expression. For example:"
 msgstr ""
+"`if` ve `else`'i bir `else if` ifadesinde birleştirerek birden fazla koşulu  
+"kullanabilirsiniz. Örneğin:"
+
 
 #: src/ch02-05-control-flow.md:111
 msgid "\"number is 12\""
@@ -2291,6 +2963,9 @@ msgid ""
 "This program has four possible paths it can take. After running it, you "
 "should see the following output:"
 msgstr ""
+"Bu programın alabileceği dört olası yolu vardır. Çalıştırdıktan sonra,  
+"şu çıktıyı görmelisiniz:"
+
 
 #: src/ch02-05-control-flow.md:130
 msgid ""
@@ -2301,20 +2976,33 @@ msgid ""
 "`else` block. That’s because Cairo only executes the block for the first "
 "true condition, and once it finds one, it doesn’t even check the rest. Using "
 "too many `else if` expressions can clutter your code, so if you have more "
-"than one, you might want to refactor your code. [Chapter "
-"6](./ch06-02-the-match-control-flow-construct.md) describes a powerful Cairo "
-"branching construct called `match` for these cases."
+"than one, you might want to refactor your code. [Chapter 6](./ch06-02-the-"
+"match-control-flow-construct.md) describes a powerful Cairo branching "
+"construct called `match` for these cases."
 msgstr ""
+"Bu program çalıştırıldığında, sırayla her `if` ifadesini kontrol eder ve  
+"koşul `true` olarak değerlendirilen ilk gövdeyi yürütür. `number - 2 == 1`  
+"`true` olsa da, çıktı olarak `number minus 2 is 1` ya da `else` bloğundan  
+"`number not found` metnini görmeyiz. Çünkü Cairo, ilk `true` koşulunun  
+"bloğunu yürütür ve bir tane bulduğunda, geri kalanını bile kontrol etmez.  
+"Çok fazla `else if` ifadesi kullanmak kodunuzu karışık hale getirebilir, bu  
+"yüzden birden fazla varsa kodunuzu yeniden düzenlemek isteyebilirsiniz.  
+"[6. Bölüm](./ch06-02-the-match-control-flow-construct.md) bu durumlar için  
+"`match` adında güçlü bir Cairo dallanma yapısını tanımlar."
+
 
 #: src/ch02-05-control-flow.md:132
 msgid "Using `if` in a `let` statement"
-msgstr ""
+msgstr "`let` içinde `if` kullanmak"
 
 #: src/ch02-05-control-flow.md:134
 msgid ""
 "Because `if` is an expression, we can use it on the right side of a `let` "
 "statement to assign the outcome to a variable."
 msgstr ""
+"`if` bir ifade olduğu için, sonucu bir değişkene atamak için bir `let`  
+"ifadesinin sağ tarafında kullanabiliriz."
+
 
 #: src/ch02-05-control-flow.md:148
 msgid "\"condition was true and number is {}\""
@@ -2325,10 +3013,13 @@ msgid ""
 "The `number` variable will be bound to a value based on the outcome of the "
 "`if` expression, which will be 5 here."
 msgstr ""
+"`number` değişkeni, `if` ifadesinin sonucuna bağlı olarak bir değere bağlanır,  
+"burada bu değer 5 olacaktır."
+
 
 #: src/ch02-05-control-flow.md:161
 msgid "Repetition with Loops"
-msgstr ""
+msgstr "Döngülerle Tekrarlama"
 
 #: src/ch02-05-control-flow.md:163
 msgid ""
@@ -2337,26 +3028,37 @@ msgid ""
 "the loop body to the end and then start immediately back at the beginning. "
 "To experiment with loops, let’s create a new project called _loops_."
 msgstr ""
+"Bir kod bloğunu birden fazla kez çalıştırmak sıklıkla faydalıdır. Bu görev için,  
+"Cairo, döngü gövdesi içindeki kodun sonuna kadar çalıştırıp ardından hemen başa  
+"dönecek basit bir döngü sözdizimi sağlar. Döngülerle deney yapmak için _loops_  
+"adında yeni bir proje oluşturalım."
+
 
 #: src/ch02-05-control-flow.md:165
 msgid "Cairo has two kinds of loops: `loop` and `while`."
-msgstr ""
+msgstr "Cairo'da iki tür döngü vardır: `loop` ve `while`."
 
 #: src/ch02-05-control-flow.md:167
 msgid "Repeating Code with `loop`"
-msgstr ""
+msgstr "Döngü ile Kod Tekrarı"
 
 #: src/ch02-05-control-flow.md:169
 msgid ""
 "The `loop` keyword tells Cairo to execute a block of code over and over "
 "again forever or until you explicitly tell it to stop."
 msgstr ""
+"`loop` anahtar kelimesi, Cairo'ya bir kod bloğunu sürekli olarak ya da siz  
+"açıkça durmasını söyleyene kadar tekrar tekrar çalıştırmasını söyler."
+
 
 #: src/ch02-05-control-flow.md:171
 msgid ""
 "As an example, change the _src/lib.cairo_ file in your _loops_ directory to "
 "look like this:"
 msgstr ""
+"Örnek olarak, _loops_ dizininizdeki _src/lib.cairo_ dosyasını şu şekilde  
+"değiştirin:"
+
 
 #: src/ch02-05-control-flow.md:177
 msgid "\"again!\""
@@ -2368,6 +3070,10 @@ msgid ""
 "purpose of the example, we added a `break` statement that will never be "
 "reached, but satisfies the compiler."
 msgstr ""
+"Not: Bu program, bir kırılma koşulu olmadan derlenmez. Örneğin amacıyla,  
+"hiç ulaşılmayacak bir `break` ifadesi ekledik, ancak bu derleyiciyi  
+"tatmin eder."
+
 
 #: src/ch02-05-control-flow.md:187
 msgid ""
@@ -2376,6 +3082,11 @@ msgid ""
 "manually. Most terminals support the keyboard shortcut ctrl-c to interrupt a "
 "program that is stuck in a continual loop. Give it a try:"
 msgstr ""
+"Bu programı çalıştırdığımızda, program ya gazı tükenene kadar ya da biz  
+"programı manuel olarak durdurana kadar sürekli olarak tekrar yazdırıldığını  
+"göreceğiz. Çoğu terminal, sürekli bir döngüde takılıp kalan bir programı  
+"kesmek için ctrl-c klavye kısayolunu destekler. Bir deneyin:"
+
 
 #: src/ch02-05-control-flow.md:188
 msgid ""
@@ -2397,18 +3108,30 @@ msgid ""
 "the word `again!` printed after the ^C, depending on where the code was in "
 "the loop when it received the interrupt signal."
 msgstr ""
+"`^C` sembolü, ctrl-c'ye bastığınız yeri temsil eder. Kod döngüde kesme  
+"sinyalini aldığında neredeyse bağlı olarak, ^C'den sonra `again!` yazılıp  
+"yazılmadığını görebilir veya göremeyebilirsiniz."
+
 
 #: src/ch02-05-control-flow.md:200
 msgid ""
 "Note: Cairo prevents us from running program with infinite loops by "
 "including a gas meter. The gas meter is a mechanism that limits the amount "
-"of computation that can be done in a program. By setting a value to the "
-"`--available-gas` flag, we can set the maximum amount of gas available to "
-"the program. Gas is a unit of measurement that expresses the computation "
-"cost of an instruction. When the gas meter runs out, the program will stop. "
-"In the previous case, we set the gas limit high enough for the the program "
-"to run for quite some time."
+"of computation that can be done in a program. By setting a value to the `--"
+"available-gas` flag, we can set the maximum amount of gas available to the "
+"program. Gas is a unit of measurement that expresses the computation cost of "
+"an instruction. When the gas meter runs out, the program will stop. In the "
+"previous case, we set the gas limit high enough for the the program to run "
+"for quite some time."
 msgstr ""
+"Not: Cairo, gaz sayacı içeren bir programın sonsuz döngülerle çalışmasını  
+"önler. Gaz sayacı, bir programda yapılabilecek hesaplamanın miktarını sınırlayan  
+"bir mekanizmadır. `--available-gas` bayrağına bir değer ayarlayarak, programa  
+"müsait maksimum gaz miktarını ayarlayabiliriz. Gaz, bir talimatın hesaplama  
+"maliyetini ifade eden bir ölçüm birimidir. Gaz sayacı tükendiğinde, program  
+"durur. Önceki durumda, programın oldukça uzun bir süre çalışması için gaz  
+"limitini yeterince yüksek ayarladık."
+
 
 #: src/ch02-05-control-flow.md:202
 msgid ""
@@ -2418,14 +3141,25 @@ msgid ""
 "it with the `--available-gas` flag set to a value that is large enough to "
 "run the program."
 msgstr ""
+"Akıllı kontratların Starknet üzerinde dağıtılması bağlamında, ağda sonsuz  
+"döngülerin çalışmasını önlemek özellikle önemlidir. Eğer bir döngü  
+"çalıştırması gereken bir program yazıyorsanız, programı çalıştırmak için  
+"yeterince büyük bir değere sahip `--available-gas` bayrağı ile çalıştırmanız  
+"gerekecek."
+
 
 #: src/ch02-05-control-flow.md:205
 msgid ""
-"Now, try running the same program again, but this time with the "
-"`--available-gas` flag set to `200000` instead of `2000000000000`. You will "
-"see the program only prints `again!` 3 times before it stops, as it ran out "
-"of gas to keep executing the loop."
+"Now, try running the same program again, but this time with the `--available-"
+"gas` flag set to `200000` instead of `2000000000000`. You will see the "
+"program only prints `again!` 3 times before it stops, as it ran out of gas "
+"to keep executing the loop."
 msgstr ""
+"Şimdi, aynı programı tekrar çalıştırın, ancak bu sefer `--available-gas`  
+"bayrağını `2000000000000` yerine `200000` olarak ayarlayın. Programın yalnızca  
+"3 kez `tekrar!` yazdırdığını ve döngüyü sürdürmek için gazı tükendiği için  
+"durduğunu göreceksiniz."
+
 
 #: src/ch02-05-control-flow.md:207
 msgid ""
@@ -2433,6 +3167,10 @@ msgid ""
 "You can place the `break` keyword within the loop to tell the program when "
 "to stop executing the loop."
 msgstr ""
+"Şans eseri, Cairo ayrıca kod kullanarak bir döngüden çıkmanın bir yolunu da  
+"sağlar. Programa döngüyü ne zaman durdurması gerektiğini söylemek için döngü  
+"içine `break` anahtar kelimesini yerleştirebilirsiniz."
+
 
 #: src/ch02-05-control-flow.md:216 src/ch02-05-control-flow.md:236
 msgid "\"i = {}\""
@@ -2445,16 +3183,21 @@ msgid ""
 "`continue` statement to our loop to skip the `print` statement when `i` is "
 "equal to `5`."
 msgstr ""
+"`continue` anahtar kelimesi, programın döngünün bir sonraki yinelemesine  
+"gitmesini ve bu yinelemedeki kodun geri kalanını atlamasını söyler. Döngümüze  
+"`i` `5`e eşit olduğunda `print` ifadesini atlamak için bir `continue`  
+"ifadesi ekleyelim."
+
 
 #: src/ch02-05-control-flow.md:242
 msgid ""
 "Executing this program will not print the value of `i` when it is equal to "
 "`5`."
-msgstr ""
+msgstr "Bu program çalıştırıldığında, `i` değeri `5`'e eşit olduğunda yazdırılmayacaktır."
 
 #: src/ch02-05-control-flow.md:244
 msgid "Returning Values from Loops"
-msgstr ""
+msgstr "Döngülerden Değer Döndürme"
 
 #: src/ch02-05-control-flow.md:246
 msgid ""
@@ -2465,6 +3208,13 @@ msgid ""
 "expression you use to stop the loop; that value will be returned out of the "
 "loop so you can use it, as shown here:"
 msgstr ""
+"`loop` kullanımının yollarından biri, başarılı olup olmadığını kontrol etmek  
+"gibi, başarısız olabileceğini bildiğiniz bir işlemi tekrar denemektir. Ayrıca,  
+"bu işlemin sonucunu döngüden kodunuzun geri kalanına aktarmanız gerekebilir.  
+"Bunu yapmak için, döngüyü durdurmak için kullandığınız `break` ifadesinin  
+"ardından döndürmek istediğiniz değeri ekleyebilirsiniz; bu değer döngüden  
+"döndürülecek ve aşağıda gösterildiği gibi kullanabilirsiniz:"
+
 
 #: src/ch02-05-control-flow.md:264
 msgid "\"The result is {}\""
@@ -2481,10 +3231,19 @@ msgid ""
 "value to `result`. Finally, we print the value in `result`, which in this "
 "case is `20`."
 msgstr ""
+"Döngüden önce, `counter` adında bir değişken tanımlarız ve onu `0` olarak  
+"başlatırız. Sonra döngüden dönen değeri tutacak `result` adında bir değişken  
+"tanımlarız. Döngünün her yinelemesinde, `counter`'ın `10`'a eşit olup  
+"olmadığını kontrol eder ve sonra `counter` değişkenine `1` ekleriz. Koşul  
+"karşılandığında, `counter * 2` değeri ile `break` anahtar kelimesini  
+"kullanırız. Döngüden sonra, `result`'a değeri atayan ifadeyi sonlandırmak için  
+"bir noktalı virgül kullanırız. Sonunda, bu durumda `20` olan `result`  
+"değerini yazdırırız."
+
 
 #: src/ch02-05-control-flow.md:275
 msgid "Conditional Loops with `while`"
-msgstr ""
+msgstr "`while` ile Koşullu Döngüler"
 
 #: src/ch02-05-control-flow.md:277
 msgid ""
@@ -2496,6 +3255,14 @@ msgid ""
 "so common that Cairo has a built-in language construct for it, called a "
 "`while` loop."
 msgstr ""
+"Bir program sıklıkla döngü içinde bir koşulu değerlendirmeye ihtiyaç duyar.  
+"Koşul `true` olduğu sürece döngü çalışır. Koşul artık `true` olmadığında,  
+"program `break`'i çağırır, döngüyü durdurur. Bu tür bir davranışı `loop`,  
+"`if`, `else` ve `break` kombinasyonunu kullanarak uygulamak mümkündür;  
+"isterseniz şimdi bir programda bunu deneyebilirsiniz. Ancak, bu desen o kadar  
+"yaygındır ki, Cairo bunun için yerleşik bir dil yapısı sunar, buna `while`  
+"döngüsü denir."
+
 
 #: src/ch02-05-control-flow.md:283
 msgid ""
@@ -2503,6 +3270,10 @@ msgid ""
 "down each time after printing the value of `number`, and then, after the "
 "loop, print a message and exit."
 msgstr ""
+"Listing 2-3'te, programı üç kez döngüye almak için `while` kullanırız, her  
+"seferinde `number` değerini yazdırdıktan sonra sayımı azaltırız ve sonra,  
+"döngüden sonra, bir mesaj yazdırır ve çıkarız."
+
 
 #: src/ch02-05-control-flow.md:290
 msgid "\"{number}!\""
@@ -2516,6 +3287,7 @@ msgstr ""
 msgid ""
 "Listing 2-3: Using a `while` loop to run code while a condition holds `true`"
 msgstr ""
+"Liste 2-3: Bir koşul `true` olduğu sürece kodu çalıştırmak için `while` döngüsü kullanma"
 
 #: src/ch02-05-control-flow.md:299
 msgid ""
@@ -2523,6 +3295,10 @@ msgid ""
 "used `loop`, `if`, `else`, and `break`, and it’s clearer. While a condition "
 "evaluates to `true`, the code runs; otherwise, it exits the loop."
 msgstr ""
+"Bu yapı, `loop`, `if`, `else` ve `break` kullanıldığında gerekli olacak  
+"çok fazla iç içe geçmeyi ortadan kaldırır ve daha açıktır. Bir koşul `true`  
+"olarak değerlendirildiğinde, kod çalışır; aksi takdirde, döngüden çıkar."
+
 
 #: src/ch02-05-control-flow.md:304
 msgid ""
@@ -2531,19 +3307,25 @@ msgid ""
 "concepts discussed in this chapter, try building programs to do the "
 "following:"
 msgstr ""
+"Başardınız! Oldukça büyük bir bölümdü: değişkenler, veri tipleri, fonksiyonlar,  
+"yorumlar, `if` ifadeleri ve döngüler hakkında öğrendiniz! Bu bölümde  
+"tartışılan kavramlarla pratik yapmak için, aşağıdaki programları  
+"oluşturmayı deneyin"
+
 
 #: src/ch02-05-control-flow.md:308
 msgid "Generate the _n_\\-th Fibonacci number."
-msgstr ""
+msgstr "_n_'inci Fibonacci sayısını oluşturun."
 
 #: src/ch02-05-control-flow.md:309
 msgid "Compute the factorial of a number _n_."
-msgstr ""
+msgstr "Bir _n_ sayısının faktöriyelini hesaplayın."
 
 #: src/ch02-05-control-flow.md:311
 msgid ""
 "Now, we’ll review the common collection types in Cairo in the next chapter."
 msgstr ""
+"Şimdi, bir sonraki bölümde Cairo'daki yaygın koleksiyon türlerini inceleyeceğiz."
 
 #: src/ch03-00-common-collections.md:3
 msgid ""
@@ -2552,12 +3334,21 @@ msgid ""
 "flexible, and easy to use. This section introduces the primary collection "
 "types available in Cairo: Arrays and Dictionaries."
 msgstr ""
+"Cairo, verileri saklamak ve manipüle etmek için kullanılabilecek ortak  
+"koleksiyon tipleri sunar. Bu koleksiyonlar verimli, esnek ve kullanımı kolay  
+"olarak tasarlanmıştır. Bu bölüm, Cairo'da mevcut olan temel koleksiyon  
+"tiplerini tanıtır: Diziler ve Sözlükler."
+
 
 #: src/ch03-01-arrays.md:3
 msgid ""
 "An array is a collection of elements of the same type. You can create and "
 "use array methods by using the `ArrayTrait` trait from the core library."
 msgstr ""
+"Bir dizi, aynı türden elemanların bir koleksiyonudur. `ArrayTrait` trait'ini  
+"çekirdek kütüphaneden kullanarak dizi metodları oluşturabilir ve  
+"kullanabilirsiniz."
+
 
 #: src/ch03-01-arrays.md:5
 msgid ""
@@ -2567,16 +3358,25 @@ msgid ""
 "overwritten, but only read from it. You can only append items to the end of "
 "an array and remove items from the front."
 msgstr ""
+"Dikkat edilmesi gereken önemli bir nokta, dizilerin sınırlı modifikasyon  
+"seçeneklerine sahip olmasıdır. Diziler, aslında değerleri değiştirilemeyen  
+"kuyruklardır. Bu, bir bellek yuvasına yazıldıktan sonra, üzerine yazılamayacağı  
+"ancak ondan okunabileceği gerçeğiyle ilgilidir. Bir dizinin sonuna yalnızca  
+"eleman ekleyebilir ve önünden eleman çıkarabilirsiniz."
+
 
 #: src/ch03-01-arrays.md:8
 msgid "Creating an Array"
-msgstr ""
+msgstr "Dizi Oluşturma"
 
 #: src/ch03-01-arrays.md:10
 msgid ""
 "Creating an array is done with the `ArrayTrait::new()` call. Here is an "
 "example of the creation of an array to which we append 3 elements:"
 msgstr ""
+"Bir dizi oluşturmak, `ArrayTrait::new()` çağrısı ile yapılır. İşte 3 eleman  
+"eklediğimiz bir dizi oluşturma örneği:"
+
 
 #: src/ch03-01-arrays.md:21
 msgid ""
@@ -2584,23 +3384,27 @@ msgid ""
 "instantiating the array like this, or explicitly define the type of the "
 "variable."
 msgstr ""
+"Gerekirse, dizi örneğini oluştururken dizinin içindeki elemanların beklenen  
+"türünü bu şekilde geçirebilir veya değişkenin türünü açıkça tanımlayabilirsiniz."
+
 
 #: src/ch03-01-arrays.md:31
 msgid "Updating an Array"
-msgstr ""
+msgstr "Bir Diziyi Güncelleme"
 
 #: src/ch03-01-arrays.md:33
 msgid "Adding Elements"
-msgstr ""
+msgstr "Elemanları Ekleme"
 
 #: src/ch03-01-arrays.md:35
 msgid ""
 "To add an element to the end of an array, you can use the `append()` method:"
 msgstr ""
+"Bir dizinin sonuna bir eleman eklemek için `append()` yöntemini kullanabilirsiniz:"
 
 #: src/ch03-01-arrays.md:46
 msgid "Removing Elements"
-msgstr ""
+msgstr "Elemanları Kaldırma"
 
 #: src/ch03-01-arrays.md:48
 msgid ""
@@ -2608,6 +3412,10 @@ msgid ""
 "`pop_front()` method. This method returns an `Option` that can be unwrapped, "
 "containing the removed element, or `Option::None` if the array is empty."
 msgstr ""
+"`pop_front()` metodunu kullanarak bir diziden yalnızca ön taraftaki elemanları  
+"çıkarabilirsiniz. Bu metod, kaldırılan elemanı içeren bir `Option` veya dizi  
+"boşsa `Option::None` döndürür."
+
 
 #: src/ch03-01-arrays.md:59
 msgid "\"The first value is {}\""
@@ -2618,6 +3426,9 @@ msgid ""
 "The above code will print `The first value is 10` as we remove the first "
 "element that was added."
 msgstr ""
+"Yukarıdaki kod, eklenen ilk elemanı çıkardığımız için `The first value is 10`  
+"yazdıracaktır."
+
 
 #: src/ch03-01-arrays.md:65
 msgid ""
@@ -2627,10 +3438,16 @@ msgid ""
 "operations do not require memory mutation, as they involve updating pointers "
 "rather than directly modifying the memory cells."
 msgstr ""
+"Cairo'da, bellek değişmezdir, bu da ekledikten sonra bir dizinin elemanlarını  
+"değiştirmenin mümkün olmadığı anlamına gelir. Bir dizinin sonuna yalnızca  
+"eleman ekleyebilir ve bir dizinin önünden eleman çıkarabilirsiniz. Bu  
+"işlemler, bellek hücrelerini doğrudan değiştirmek yerine işaretçileri  
+"güncellemeyi içerdiğinden, bellek mutasyonu gerektirmez."
+
 
 #: src/ch03-01-arrays.md:67
 msgid "Reading Elements from an Array"
-msgstr ""
+msgstr "Bir Diziden Eleman Okuma"
 
 #: src/ch03-01-arrays.md:69
 msgid ""
@@ -2638,10 +3455,14 @@ msgid ""
 "return different types. Using `arr.at(index)` is equivalent to using the "
 "subscripting operator `arr[index]`."
 msgstr ""
+"Dizi elemanlarına erişmek için, farklı türler döndüren `get()` veya `at()`  
+"dizi metodlarını kullanabilirsiniz. `arr.at(index)` kullanmak, alt dizin  
+"operatörü `arr[index]` kullanmakla eşdeğerdir."
+
 
 #: src/ch03-01-arrays.md:71
 msgid "`get()` method"
-msgstr ""
+msgstr "`get()` methodu"
 
 #: src/ch03-01-arrays.md:73
 msgid ""
@@ -2651,13 +3472,22 @@ msgid ""
 "the element doesn't exist, `get` returns `None`. This method is useful when "
 "you expect to access indices that may not be within the array's bounds and "
 "want to handle such cases gracefully without panics. Snapshots will be "
-"explained in more detail in the [References and "
-"Snapshots](ch04-02-references-and-snapshots.md) chapter."
+"explained in more detail in the [References and Snapshots](ch04-02-"
+"references-and-snapshots.md) chapter."
 msgstr ""
+"`get` fonksiyonu bir `Option<Box<@T>>` döndürür, bu da belirtilen indeksteki  
+"eleman dizi içinde varsa, o elemana ait bir kutu türüne (Cairo'nun akıllı  
+"işaretçi türü) bir seçenek döndürdüğü anlamına gelir. Eleman mevcut değilse,  
+"`get` `None` döndürür. Bu yöntem, dizinin sınırları içinde olmayabilecek  
+"indekslere erişmeyi beklediğiniz ve böyle durumları panik olmadan zarif bir  
+"şekilde ele almak istediğinizde kullanışlıdır. Snapshot'lar [Referanslar ve  
+"Snapshot'lar](ch04-02-references-and-snapshots.md) bölümünde daha detaylı  
+"bir şekilde açıklanacaktır."
+
 
 #: src/ch03-01-arrays.md:75
 msgid "Here is an example with the `get()` method:"
-msgstr ""
+msgstr "İşte `get()` yöntemiyle bir örnek:"
 
 #: src/ch03-01-arrays.md:82
 msgid ""
@@ -2678,7 +3508,7 @@ msgid "\"out of bounds\""
 msgstr ""
 
 #: src/ch03-01-arrays.md:94
-msgid "`at()` method"
+msgid "`at()` methodu"
 msgstr ""
 
 #: src/ch03-01-arrays.md:96
@@ -2689,9 +3519,15 @@ msgid ""
 "You should only use `at` when you want the program to panic if the provided "
 "index is out of the array's bounds, which can prevent unexpected behavior."
 msgstr ""
+"`at` fonksiyonu ise, `unbox()` operatörünü kullanarak belirtilen indeksteki  
+"elemana doğrudan bir snapshot döndürür. İndeks sınırların dışındaysa bir  
+"panik hatası oluşur. Yalnızca sağlanan indeks dizinin sınırlarının dışında  
+"olduğunda programın paniklemesini istiyorsanız `at` kullanmalısınız, bu  
+"beklenmeyen davranışları önleyebilir."
+ 
 
 #: src/ch03-01-arrays.md:98
-msgid "Here is an example with the `at()` method:"
+msgid "İşte `at()` methodu ile bir örnek:"
 msgstr ""
 
 #: src/ch03-01-arrays.md:111
@@ -2700,6 +3536,10 @@ msgid ""
 "that is the value at index `0` in the array. The variable named `second` "
 "will get the value `1` from index `1` in the array."
 msgstr ""
+"Bu örnekte, `first` adlı değişken `0` değerini alacak çünkü bu, dizide `0`  
+"indeksindeki değerdir. `second` adlı değişken, dizide `1` indeksinden `1` 
+"değerini alacak."
+
 
 #: src/ch03-01-arrays.md:115
 msgid ""
@@ -2707,6 +3547,10 @@ msgid ""
 "explicitly define the type of the elements of the array, otherwise it will "
 "not compile. For example:"
 msgstr ""
+"Eğer alt dizin operatörü `arr[index]` kullanmak istiyorsanız, dizinin  
+"elemanlarının türünü açıkça tanımlamanız gerekecektir, aksi takdirde  
+"derlenmeyecektir. Örneğin:"
+
 
 #: src/ch03-01-arrays.md:128
 msgid ""
@@ -2714,16 +3558,23 @@ msgid ""
 "attempts, and use `get` when you prefer to handle such cases gracefully "
 "without panicking."
 msgstr ""
+"Özetle, sınırların dışındaki erişim girişimlerinde paniklemek istiyorsanız  
+"`at` kullanın ve bu tür durumları panik olmadan zarif bir şekilde ele almak  
+"istiyorsanız `get` kullanın."
+
 
 #: src/ch03-01-arrays.md:130
 msgid "Size related methods"
-msgstr ""
+msgstr "Boyutla ilgili methodlar"
 
 #: src/ch03-01-arrays.md:132
 msgid ""
 "To determine the number of elements in an array, use the `len()` method. The "
 "return value is of type `usize`."
 msgstr ""
+"Bir dizideki eleman sayısını belirlemek için `len()` metodunu kullanın.  
+"Dönüş değeri `usize` türündedir."
+
 
 #: src/ch03-01-arrays.md:134
 msgid ""
@@ -2731,9 +3582,13 @@ msgid ""
 "`is_empty()` method, which returns `true` if the array is empty and `false` "
 "otherwise."
 msgstr ""
+"Bir dizinin boş olup olmadığını kontrol etmek istiyorsanız, `is_empty()`  
+"metodunu kullanabilirsiniz, bu metod dizi boşsa `true`, aksi takdirde `false`  
+"döndürür."
+
 
 #: src/ch03-01-arrays.md:136 src/ch11-02-macros.md:27
-msgid "`array!` macro"
+msgid "`array!` makrosu"
 msgstr ""
 
 #: src/ch03-01-arrays.md:138
@@ -2745,26 +3600,37 @@ msgid ""
 "the compiler will expand the macro to generate the code that appends the "
 "items sequentially."
 msgstr ""
+"Bazen, derleme zamanında zaten bilinen değerlere sahip diziler oluşturmamız  
+"gerekiyor. Bunun temel yolu fazlalıklıdır. İlk olarak diziyi tanımlar ve  
+"sonra her bir değeri tek tek eklerdiniz. `array!` bu görevi iki adımı  
+"birleştirerek daha basit bir şekilde yapmanın yoludur. Derleme zamanında,  
+"derleyici makroyu genişleterek öğeleri sırayla ekleyen kodu oluşturacaktır."
+
 
 #: src/ch03-01-arrays.md:141
-msgid "Without `array!`:"
+msgid "`array!` olmadan:"
 msgstr ""
 
 #: src/ch03-01-arrays.md:152
-msgid "With `array!`:"
+msgid "`array!` ile:"
 msgstr ""
 
 #: src/ch03-01-arrays.md:158
 msgid "Storing multiple types with Enums"
-msgstr ""
+msgstr "Enum'lar ile birden fazla türün saklanması"
 
 #: src/ch03-01-arrays.md:160
 msgid ""
 "If you want to store elements of different types in an array, you can use an "
 "`Enum` to define a custom data type that can hold multiple types. Enums will "
-"be explained in more detail in the [Enums and Pattern "
-"Matching](ch06-00-enums-and-pattern-matching.md) chapter."
+"be explained in more detail in the [Enums and Pattern Matching](ch06-00-"
+"enums-and-pattern-matching.md) chapter."
 msgstr ""
+"Farklı türlerdeki elemanları bir dizide saklamak istiyorsanız, birden fazla  
+"türü tutabilen özel bir veri türü tanımlamak için bir `Enum` kullanabilirsiniz.  
+"Enumlar [Enumlar ve Desen Eşleştirme](ch06-00-enums-and-pattern-matching.md)  
+"bölümünde daha detaylı bir şekilde açıklanacaktır."
+
 
 #: src/ch03-01-arrays.md:178
 msgid "Span"
@@ -2779,20 +3645,30 @@ msgid ""
 "functions or when performing read-only operations (cf. [References and "
 "Snapshots](ch04-02-references-and-snapshots.md))"
 msgstr ""
+"`Span`, bir `Array`'in bir snapshot'ını temsil eden bir yapıdır. Orijinal  
+"diziyi değiştirmeden bir dizinin elemanlarına güvenli ve kontrollü erişim  
+"sağlamak için tasarlanmıştır. Span, özellikle veri bütünlüğünü sağlamak ve  
+"fonksiyonlar arasında diziler geçirirken veya salt okunur işlemler  
+"gerçekleştirirken ödünç alma sorunlarını önlemek için faydalıdır (bkz.  
+"[Referanslar ve Snapshot'lar](ch04-02-references-and-snapshots.md))"
+
 
 #: src/ch03-01-arrays.md:182
 msgid ""
 "All methods provided by `Array` can also be used with `Span`, with the "
 "exception of the `append()` method."
 msgstr ""
+"`Array` tarafından sağlanan tüm metodlar `Span` ile de kullanılabilir,  
+"`append()` metodunun istisnası dışında."
+
 
 #: src/ch03-01-arrays.md:184
 msgid "Turning an Array into span"
-msgstr ""
+msgstr "Array'i span'a dönüştürme"
 
 #: src/ch03-01-arrays.md:186
 msgid "To create a `Span` of an `Array`, call the `span()` method:"
-msgstr ""
+msgstr "Bir `Array`'in `Span`'ini oluşturmak için `span()` yöntemini çağırın:"
 
 #: src/ch03-02-dictionaries.md:3
 msgid ""
@@ -2802,6 +3678,12 @@ msgid ""
 "data structure is known differently across different programming languages "
 "such as maps, hash tables, associative arrays and many others."
 msgstr ""
+"Cairo, çekirdek kütüphanesinde bir sözlük benzeri tür sunar. `Felt252Dict<T>`  
+"veri türü, her bir anahtarın benzersiz olduğu ve karşılık gelen bir değerle  
+"ilişkilendirildiği anahtar-değer çiftlerinin bir koleksiyonunu temsil eder. Bu  
+"tür veri yapıları, farklı programlama dillerinde haritalar, karma tablolar, " 
+"ilişkisel diziler ve daha birçok farklı isimle bilinir."
+
 
 #: src/ch03-02-dictionaries.md:5
 msgid ""
@@ -2810,10 +3692,15 @@ msgid ""
 "Cairo dictionaries also allow the programmer to easily simulate the "
 "existence of mutable memory when there is none."
 msgstr ""
+"`Felt252Dict<T>` türü, verilerinizi belirli bir şekilde düzenlemek istediğinizde  
+"ve bir `Array<T>` kullanmanın ve indekslemenin yetersiz kaldığı durumlar için  
+"faydalıdır. Cairo sözlükleri, ayrıca programcıya, mevcut olmayan değiştirilebilir  
+"belleğin varlığını kolayca simüle etme imkanı da tanır."
+
 
 #: src/ch03-02-dictionaries.md:7
 msgid "Basic Use of Dictionaries"
-msgstr ""
+msgstr "Sözlüklerin Temel Kullanımı"
 
 #: src/ch03-02-dictionaries.md:9
 msgid ""
@@ -2822,6 +3709,11 @@ msgid ""
 "`felt252`, leaving only the possibility to specify the value data type, "
 "represented by `T` in `Felt252Dict<T>`."
 msgstr ""
+"Diğer dillerde yeni bir sözlük oluştururken genellikle anahtar ve değerin veri  
+"türlerini tanımlamak normaldir. Cairo'da, anahtar türü `felt252` ile sınırlıdır,  
+"bu da sadece değer veri türünü belirtme olasılığını bırakır, `Felt252Dict<T>`'de  
+"bu `T` ile temsil edilir."
+
 
 #: src/ch03-02-dictionaries.md:11
 msgid ""
@@ -2829,14 +3721,17 @@ msgid ""
 "`Felt252DictTrait` which includes all basic operations. Among them we can "
 "find:"
 msgstr ""
+"`Felt252Dict<T>`'nin temel işlevselliği, tüm temel işlemleri içeren  
+"`Felt252DictTrait` trait'inde uygulanmıştır. Bunlar arasında şunları bulabiliriz:"
+
 
 #: src/ch03-02-dictionaries.md:13
 msgid "`insert(felt252, T) -> ()` to write values to a dictionary instance and"
-msgstr ""
+msgstr "`insert(felt252, T) -> ()` bir sözlük örneğine değer yazmak için ve"
 
 #: src/ch03-02-dictionaries.md:14
 msgid "`get(felt252) -> T` to read values from it."
-msgstr ""
+msgstr "`get(felt252) -> T` içinden değerleri okumak için."
 
 #: src/ch03-02-dictionaries.md:16
 msgid ""
@@ -2844,6 +3739,10 @@ msgid ""
 "language. In the following example, we create a dictionary to represent a "
 "mapping between individuals and their balance:"
 msgstr ""
+"Bu fonksiyonlar, diğer dillerdeki gibi sözlükleri manipüle etmemize olanak tanır.  
+"Aşağıdaki örnekte, bireyler ve bakiyeleri arasındaki eşlemeyi temsil eden bir  
+"sözlük oluşturuyoruz:"
+
 
 #: src/ch03-02-dictionaries.md:26
 msgid "\"Balance is not 100\""
@@ -2861,6 +3760,12 @@ msgid ""
 "users with the `get` method. These methods are defined in the "
 "`Felt252DictTrait` trait in the core library."
 msgstr ""
+"`Felt252Dict<u64>`'ün yeni bir örneğini, `Default` trait'inin `default` metodu  
+"kullanılarak oluşturabilir ve `insert` metodu kullanarak her biri kendi bakiyesine  
+"sahip iki birey ekleyebiliriz. Son olarak, `get` metodu ile kullanıcılarımızın  
+"bakiyelerini kontrol ederiz. Bu metodlar çekirdek kütüphanedeki `Felt252DictTrait`  
+"trait'inde tanımlanmıştır."
+
 
 #: src/ch03-02-dictionaries.md:35
 msgid ""
@@ -2869,12 +3774,20 @@ msgid ""
 "type represents a way to overcome this obstacle. We will explain how this is "
 "implemented later on in [Dictionaries Underneath](#dictionaries-underneath)."
 msgstr ""
+"Kitap boyunca, Cairo'nun belleğinin değişmez olduğundan, yani bir bellek hücresine  
+"yalnızca bir kez yazılabileceğinden bahsettik, ancak `Felt252Dict<T>` türü, bu  
+"engelin üstesinden gelmenin bir yolunu temsil eder. Bunun nasıl uygulandığını daha  
+"sonra [Sözlüklerin Altında](#dictionaries-underneath) bölümünde açıklayacağız."
+
 
 #: src/ch03-02-dictionaries.md:37
 msgid ""
 "Building upon our previous example, let us show a code example where the "
 "balance of the same user changes:"
 msgstr ""
+"Önceki örneğimizi temel alarak, aynı kullanıcının bakiyesinin nasıl değiştiğini  
+"gösteren bir kod örneği sunalım:"
+
 
 #: src/ch03-02-dictionaries.md:43
 msgid "// Insert Alex with 100 balance\n"
@@ -2907,6 +3820,11 @@ msgid ""
 "had the last value inserted! `Felt252Dict<T>` effectively allows us to "
 "\"rewrite\" the stored value for any given key."
 msgstr ""
+"Bu örnekte 'Alex' kişisini iki kez eklediğimize dikkat edin, her seferinde farklı bir  
+"bakiye kullanıldı ve bakiyesi kontrol edildiğinde her zaman son eklenen değeri aldı!  
+"`Felt252Dict<T>` bize verilen herhangi bir anahtar için saklanan değeri \"yeniden yazma\"  
+"imkanı sağlar."
+
 
 #: src/ch03-02-dictionaries.md:59
 msgid ""
@@ -2918,6 +3836,13 @@ msgid ""
 "is no way to delete data from a dictionary. Something to take into account "
 "when incorporating this structure into your code."
 msgstr ""
+"Sözlüklerin nasıl uygulandığını açıklamadan önce, bir `Felt252Dict<T>` örneği  
+"oluşturduğunuzda, perde arkasında tüm anahtarların ilişkili değerlerinin sıfır olarak  
+"başlatıldığını belirtmek önemlidir. Bu, örneğin, mevcut olmayan bir kullanıcının bakiyesini  
+"almaya çalıştığınızda bir hata veya tanımsız bir değer yerine 0 alacağınız anlamına gelir.  
+"Bu aynı zamanda bir sözlükten veri silmenin mümkün olmadığı anlamına gelir. Bu yapının  
+"kodunuza dahil ederken göz önünde bulundurulması gereken bir noktadır."
+
 
 #: src/ch03-02-dictionaries.md:61
 msgid ""
@@ -2928,6 +3853,12 @@ msgid ""
 "any other popular language in existence, which as a consequence means that "
 "dictionaries are implemented very differently as well!"
 msgstr ""
+"Bu noktaya kadar, `Felt252Dict<T>`'nin tüm temel özelliklerini ve diğer dillerdeki  
+"karşılık gelen veri yapılarının aynı davranışını nasıl taklit ettiğini gördük, tabii ki  
+"dışarıdan. Cairo, temelde belirsiz bir Turing-tam programlama dilidir, var olan diğer  
+"popüler dillerden çok farklıdır, bu da sözlüklerin de çok farklı şekilde uygulandığı  
+"anlamına gelir!"
+
 
 #: src/ch03-02-dictionaries.md:63
 msgid ""
@@ -2937,35 +3868,50 @@ msgid ""
 "dictionaries with other data structures as well as use the `entry` method as "
 "another way to interact with them."
 msgstr ""
+"Takip eden bölümlerde, `Felt252Dict<T>` iç mekanizmaları ve onları çalışır hale getirmek  
+"için yapılan kompromisler hakkında bazı içgörüler sunacağız. Bundan sonra, sözlükleri diğer  
+"veri yapılarıyla nasıl kullanacağımıza ve onlarla etkileşimde bulunmanın başka bir yolu  
+"olarak `entry` metodunu nasıl kullanacağımıza bakacağız."
+
 
 #: src/ch03-02-dictionaries.md:65
 msgid "Dictionaries Underneath"
-msgstr ""
+msgstr "Sözlükler Altında"
 
 #: src/ch03-02-dictionaries.md:67
 msgid ""
 "One of the constraints of Cairo's non-deterministic design is that its "
 "memory system is immutable, so in order to simulate mutability, the language "
 "implements `Felt252Dict<T>` as a list of entries. Each of the entries "
-"represents a time when a dictionary was accessed for "
-"reading/updating/writing purposes. An entry has three fields:"
+"represents a time when a dictionary was accessed for reading/updating/"
+"writing purposes. An entry has three fields:"
 msgstr ""
+"Cairo'nun belirsiz tasarımının kısıtlamalarından biri, bellek sisteminin değişmez olmasıdır,  
+"bu nedenle değiştirilebilirliği simüle etmek için dil, `Felt252Dict<T>`'yi girişlerin bir  
+"listesi olarak uygular. Girişlerin her biri, bir sözlüğün okuma/güncelleme/yazma amaçları için  
+"erişildiği bir zamanı temsil eder. Bir girişin üç alanı vardır:"
+
 
 #: src/ch03-02-dictionaries.md:69
 msgid ""
 "A `key` field that identifies the key for this key-value pair of the "
 "dictionary."
 msgstr ""
+"Bir sözlükteki bu anahtar-değer çifti için anahtarı tanımlayan bir `key` alanı."
+
 
 #: src/ch03-02-dictionaries.md:70
 msgid ""
 "A `previous_value` field that indicates which previous value was held at "
 "`key`."
 msgstr ""
+"`key`'de hangi önceki değerin tutulduğunu belirten bir `previous_value` alanı."
+
 
 #: src/ch03-02-dictionaries.md:71
 msgid "A `new_value` field that indicates the new value that is held at `key`."
-msgstr ""
+msgstr "`key`'de tutulan yeni değeri belirten bir `new_value` alanı."
+
 
 #: src/ch03-02-dictionaries.md:73
 msgid ""
@@ -2974,18 +3920,28 @@ msgid ""
 "information about what key-value pair it represents and the previous and new "
 "values it holds. The definition of `Entry<T>` would be:"
 msgstr ""
+"Eğer `Felt252Dict<T>`'yi yüksek seviye yapılar kullanarak uygulamaya çalışırsak,  
+"içsel olarak onu `Array<Entry<T>>` olarak tanımlarız, burada her `Entry<T>`,  
+"temsil ettiği anahtar-değer çifti hakkında bilgi ve tuttuğu önceki ve yeni değerleri içerir.  
+"`Entry<T>`'nin tanımı şu şekilde olurdu:"
+
 
 #: src/ch03-02-dictionaries.md:83
 msgid ""
 "For each time we interact with a `Felt252Dict<T>`, a new `Entry<T>` will be "
 "registered:"
 msgstr ""
+"Bir `Felt252Dict<T>` ile her etkileşimde, yeni bir `Entry<T>` kaydedilecektir:"
+
 
 #: src/ch03-02-dictionaries.md:85
 msgid ""
 "A `get` would register an entry where there is no change in state, and "
 "previous and new values are stored with the same value."
 msgstr ""
+"`get`, durumda bir değişiklik olmadığı ve önceki ile yeni değerlerin aynı değerle  
+"kaydedildiği bir giriş kaydeder."
+
 
 #: src/ch03-02-dictionaries.md:86
 msgid ""
@@ -2994,6 +3950,10 @@ msgid ""
 "inserted before this. In case it is the first entry for a certain key, then "
 "the previous value will be zero."
 msgstr ""
+"`insert`, `new_value`'nun eklenen eleman ve `previous_value`'nun bu öncesi eklenen  
+"son eleman olduğu yeni bir `Entry<T>` kaydeder. Belirli bir anahtar için bu ilk giriş  
+"ise, önceki değer sıfır olacaktır."
+
 
 #: src/ch03-02-dictionaries.md:88
 msgid ""
@@ -3002,10 +3962,15 @@ msgid ""
 "example of this using the `balances` dictionary from the previous section "
 "and inserting the users 'Alex' and 'Maria':"
 msgstr ""
+"Bu giriş listesinin kullanımı, herhangi bir yeniden yazımın olmadığını, sadece  
+"`Felt252Dict<T>` etkileşimi başına yeni bellek hücrelerinin oluşturulduğunu gösterir.  
+"Bunu, önceki bölümden `balances` sözlüğünü kullanarak 'Alex' ve 'Maria' kullanıcılarını  
+"ekleyerek gösterelim:"
+
 
 #: src/ch03-02-dictionaries.md:106
 msgid "These instructions would then produce the following list of entries:"
-msgstr ""
+msgstr "Bu talimatlar daha sonra aşağıdaki giriş listesini üretecektir:"
 
 #: src/ch03-02-dictionaries.md:108 src/ch03-02-dictionaries.md:130
 #: src/ch03-02-dictionaries.md:143
@@ -3048,7 +4013,6 @@ msgid "Maria"
 msgstr ""
 
 #: src/ch03-02-dictionaries.md:111 src/ch03-02-dictionaries.md:113
-#: src/ch03-02-dictionaries.md:113
 msgid "50"
 msgstr ""
 
@@ -3062,17 +4026,27 @@ msgid ""
 "`previous` and `current` values are set properly. Also reading from 'Maria' "
 "registered an entry with no change from previous to current values."
 msgstr ""
+"'Alex' iki kez eklendiğinden, iki kez görünür ve `previous` ile `current` değerleri  
+"doğru şekilde ayarlanmıştır. Ayrıca, 'Maria'dan okuma, önceki ile mevcut değerler arasında  
+"bir değişiklik olmadan bir giriş kaydetti."
+
 
 #: src/ch03-02-dictionaries.md:117
 msgid ""
-"This approach to implementing `Felt252Dict<T>` means that for each "
-"read/write operation, there is a scan for the whole entry list in search of "
-"the last entry with the same `key`. Once the entry has been found, its "
+"This approach to implementing `Felt252Dict<T>` means that for each read/"
+"write operation, there is a scan for the whole entry list in search of the "
+"last entry with the same `key`. Once the entry has been found, its "
 "`new_value` is extracted and used on the new entry to be added as the "
 "`previous_value`. This means that interacting with `Felt252Dict<T>` has a "
 "worst-case time complexity of `O(n)` where `n` is the number of entries in "
 "the list."
 msgstr ""
+"`Felt252Dict<T>`'yi bu şekilde uygulamanın anlamı, her okuma/yazma işlemi için, aynı  
+"`key` ile son girişi aramak üzere tüm giriş listesinin taranmasıdır. Giriş bulunduğunda,  
+"`new_value`'si çıkarılır ve yeni eklenen girişte `previous_value` olarak kullanılır. Bu, 
+"`Felt252Dict<T>` ile etkileşimin en kötü durum zaman karmaşıklığının `O(n)` olduğu anlamına  
+"geliyor, burada `n` liste içindeki girişlerin sayısıdır."
+
 
 #: src/ch03-02-dictionaries.md:119
 msgid ""
@@ -3086,10 +4060,17 @@ msgid ""
 "of \"dictionary squashing\" and that requires information on both previous "
 "and new values for every entry."
 msgstr ""
+"`Felt252Dict<T>`'yi uygulamanın alternatif yollarını düşünürseniz, muhtemelen `previous_value`  
+"alanının tamamen gereksiz olduğu yöntemler bulabilirsiniz, yine de, Cairo normal bir dil  
+"olmadığı için bu işe yaramaz. Cairo'nun amaçlarından biri, STARK ispat sistemi ile, hesaplama  
+"bütünlüğünün kanıtlarını üretmektir. Bu, programın doğru ve Cairo kısıtlamaları içinde  
+"çalıştığını doğrulamanız gerektiği anlamına gelir. Bu sınır kontrollerinden biri  
+"\"sözlük sıkıştırması\"dır ve bu, her giriş için önceki ve yeni değerler hakkında bilgi gerektirir."
+
 
 #: src/ch03-02-dictionaries.md:122
 msgid "Squashing Dictionaries"
-msgstr ""
+msgstr "Sözlükleri Ezmek"
 
 #: src/ch03-02-dictionaries.md:124
 msgid ""
@@ -3099,6 +4080,11 @@ msgid ""
 "`squash_dict` that reviews each entry of the entry list and checks that "
 "access to the dictionary remains coherent throughout the execution."
 msgstr ""
+"`Felt252Dict<T>` kullanan bir Cairo programının yürütmesiyle üretilen kanıtın doğru olduğunu  
+"doğrulamak için, sözlükle herhangi bir yasa dışı oynama yapılmadığını kontrol etmemiz gerekir.  
+"Bu, her girişi gözden geçiren ve yürütme boyunca sözlüğe erişimin tutarlı kaldığını kontrol eden  
+"`squash_dict` adlı bir yöntem aracılığıyla yapılır."
+
 
 #: src/ch03-02-dictionaries.md:126
 msgid ""
@@ -3106,10 +4092,14 @@ msgid ""
 "`k`, taken in the same order as they were inserted, verify that the ith "
 "entry `new_value` is equal to the ith + 1 entry `previous_value`."
 msgstr ""
+"Sıkıştırma işlemi şu şekildedir: belirli bir anahtar `k` ile tüm girişler, eklenme sıraları  
+"göz önünde bulundurularak alınır, i'nci girişin `new_value`'si i+1'inci girişin `previous_value`  
+"ile eşit olduğu doğrulanır."
+
 
 #: src/ch03-02-dictionaries.md:128
 msgid "For example, given the following entry list:"
-msgstr ""
+msgstr "Örneğin, aşağıdaki giriş listesi göz önüne alındığında:"
 
 #: src/ch03-02-dictionaries.md:132 src/ch03-02-dictionaries.md:136
 msgid "150"
@@ -3145,28 +4135,34 @@ msgstr ""
 
 #: src/ch03-02-dictionaries.md:141
 msgid "After squashing, the entry list would be reduced to:"
-msgstr ""
+msgstr "Ezme işleminden sonra giriş listesi şu şekle indirgenecektir:"
 
 #: src/ch03-02-dictionaries.md:149
 msgid ""
 "In case of a change on any of the values of the first table, squashing would "
 "have failed during runtime."
 msgstr ""
+"İlk tablonun herhangi bir değerinde bir değişiklik olması durumunda, ezme işlemi çalışma sırasında başarısız olurdu."
 
 #: src/ch03-02-dictionaries.md:151
 msgid "Dictionary Destruction"
-msgstr ""
+msgstr "Sözlük İmhası"
 
 #: src/ch03-02-dictionaries.md:153
 msgid ""
-"If you run the examples from [Basic Use of "
-"Dictionaries](#basic-use-of-dictionaries), you'd notice that there was never "
-"a call to squash dictionary, but the program compiled successfully "
-"nonetheless. What happened behind the scene was that squash was called "
-"automatically via the `Felt252Dict<T>` implementation of the `Destruct<T>` "
-"trait. This call occurred just before the `balance` dictionary went out of "
-"scope."
+"If you run the examples from [Basic Use of Dictionaries](#basic-use-of-"
+"dictionaries), you'd notice that there was never a call to squash "
+"dictionary, but the program compiled successfully nonetheless. What happened "
+"behind the scene was that squash was called automatically via the "
+"`Felt252Dict<T>` implementation of the `Destruct<T>` trait. This call "
+"occurred just before the `balance` dictionary went out of scope."
 msgstr ""
+"[Sözlüklerin Temel Kullanımı](#basic-use-of-dictionaries) bölümündeki örnekleri çalıştırdığınızda,  
+"sözlük sıkıştırma çağrısının yapılmadığını ancak programın yine de başarıyla derlendiğini fark  
+"etmiş olabilirsiniz. Perde arkasında olan şey, `Felt252Dict<T>`'nin `Destruct<T>` trait'inin 
+"uygulanması aracılığıyla squash'ın otomatik olarak çağrıldığıydı. Bu çağrı, `balance` sözlüğü  
+"kapsam dışına çıkmadan hemen önce gerçekleşti."
+
 
 #: src/ch03-02-dictionaries.md:155
 msgid ""
@@ -3176,9 +4172,17 @@ msgid ""
 "CASM while `Destruct<T>` does not have this restriction. The only type which "
 "actively uses the `Destruct<T>` trait is `Felt252Dict<T>`, for every other "
 "type `Destruct<T>` and `Drop<T>` are synonyms. You can read more about these "
-"traits in [Drop and "
-"Destruct](/appendix-03-derivable-traits.md#drop-and-destruct)."
+"traits in [Drop and Destruct](/appendix-03-derivable-traits.md#drop-and-"
+"destruct)."
 msgstr ""
+"`Destruct<T>` trait'i, `Drop<T>`'den farklı olarak, nesneleri kapsam dışına çıkarma  
+"yöntemlerinden birini temsil eder. Bu ikisi arasındaki ana fark, `Drop<T>`'nin bir  
+"no-op işlemi olarak ele alınması, yani yeni CASM üretmemesi, `Destruct<T>`'nin bu  
+"kısıtlamaya sahip olmamasıdır. Aktif olarak `Destruct<T>` trait'ini kullanan tek tür  
+"`Felt252Dict<T>`'dir, diğer her tür için `Destruct<T>` ve `Drop<T>` eşanlamlıdır. Bu  
+"trait'ler hakkında daha fazla bilgiyi [Drop ve Destruct](/appendix-03-derivable-traits.md#drop-and-destruct)  
+"bölümünde okuyabilirsiniz."
+
 
 #: src/ch03-02-dictionaries.md:157
 msgid ""
@@ -3186,10 +4190,13 @@ msgid ""
 "we will have a hands-on example where we implement the `Destruct<T>` trait "
 "for a custom type."
 msgstr ""
+"[Yapı Üyeleri Olarak Sözlükler](#dictionaries-as-struct-members) bölümünde, özel bir tür için  
+"`Destruct<T>` trait'ini uyguladığımız uygulamalı bir örneğe sahip olacağız."
+
 
 #: src/ch03-02-dictionaries.md:159
 msgid "More Dictionaries"
-msgstr ""
+msgstr "Daha Fazla Sözlük"
 
 #: src/ch03-02-dictionaries.md:161
 msgid ""
@@ -3198,6 +4205,10 @@ msgid ""
 "in a certain way. If you haven't understood all of it, don't worry because "
 "in this section we will have some more examples using dictionaries."
 msgstr ""
+"Bu noktaya kadar, `Felt252Dict<T>`'nin işlevselliğine ve belirli bir şekilde nasıl ve neden  
+"uygulandığına dair kapsamlı bir genel bakış verdik. Hepsini anlamadıysanız endişelenmeyin,  
+"çünkü bu bölümde sözlükleri kullanarak daha fazla örneğe sahip olacağız."
+
 
 #: src/ch03-02-dictionaries.md:163
 msgid ""
@@ -3205,14 +4216,18 @@ msgid ""
 "basic functionality included in `Felt252DictTrait<T>` which we didn't "
 "mention at the beginning. Soon after, we will see examples of how "
 "`Felt252Dict<T>` [interacts](#dictionaries-of-types-not-supported-natively) "
-"with other complex types such as `Array<T>` and how to "
-"[implement](#dictionaries-as-struct-members) a struct with a dictionary as a "
-"member."
+"with other complex types such as `Array<T>` and how to [implement]"
+"(#dictionaries-as-struct-members) a struct with a dictionary as a member."
 msgstr ""
+"`Felt252DictTrait<T>`'nin temel işlevselliğinin bir parçası olan ve başta bahsetmediğimiz  
+"`entry` metodunu açıklayarak başlayacağız. Hemen ardından, `Felt252Dict<T>`'nin [doğal olarak  
+"desteklenmeyen türlerle etkileşimi](#dictionaries-of-types-not-supported-natively) hakkında  
+"örnekler göreceğiz, örneğin `Array<T>` ve bir yapıyı sözlük üyesi olarak [uygulama](#dictionaries-as-struct-members)."
+
 
 #: src/ch03-02-dictionaries.md:165
 msgid "Entry and Finalize"
-msgstr ""
+msgstr "Giriş ve Sonuçlandırma"
 
 #: src/ch03-02-dictionaries.md:167
 msgid ""
@@ -3223,6 +4238,11 @@ msgid ""
 "whatever operation it was executing. The Cairo language gives us the tools "
 "to replicate this ourselves through the `entry` and `finalize` methods."
 msgstr ""
+"[Sözlüklerin Alt Yapısı](#dictionaries-underneath) bölümünde, `Felt252Dict<T>`'nin iç  
+"çalışmasını açıkladık. Her sözlüğe erişimde, herhangi bir şekilde, belirli bir `key` için son  
+"girişi bulup onu uygun operasyona göre güncelleyerek bir girişler listesiydi. Cairo dilinde,  
+"`entry` ve `finalize` metodları aracılığıyla bunu kendimiz tekrarlamak için gereken araçları elde ederiz."
+
 
 #: src/ch03-02-dictionaries.md:169
 msgid ""
@@ -3231,6 +4251,10 @@ msgid ""
 "ownership of the dictionary and returns the entry to update. The method "
 "signature is as follows:"
 msgstr ""
+"`entry` metodu, belirli bir anahtar için yeni bir giriş oluşturma amacıyla `Felt252DictTrait<T>`  
+"ile gelir. Çağrıldığında, bu metod sözlüğün sahipliğini alır ve güncellenecek girişi döndürür.  
+"Metod imzası şöyle:"
+
 
 #: src/ch03-02-dictionaries.md:175
 msgid ""
@@ -3241,6 +4265,11 @@ msgid ""
 "`nopanic` notation simply indicates that the function is guaranteed to never "
 "panic."
 msgstr ""
+"İlk giriş parametresi, sözlüğün sahipliğini alırken, ikincisi uygun girişi oluşturmak için kullanılır.  
+"Bir `Felt252DictEntry<T>`, Cairo'nun sözlük girişlerini temsil etmek için kullandığı tür, ve  
+"önceden tutulan bir `T` değeri içeren bir demet döndürür. `nopanic` notasyonu, fonksiyonun  
+"asla panik olmayacağının garantilendiğini belirtir."
+
 
 #: src/ch03-02-dictionaries.md:178
 msgid ""
@@ -3248,12 +4277,16 @@ msgid ""
 "use the `finalize` method which inserts the entry and returns ownership of "
 "the dictionary:"
 msgstr ""
+"Bir sonraki adım, girişi yeni değerle güncellemektir. Bunun için, girişi ekleyen ve sözlüğün  
+"sahipliğini geri döndüren `finalize` metodunu kullanırız:"
+
 
 #: src/ch03-02-dictionaries.md:184
 msgid ""
 "This method receives the entry and the new value as parameters, and returns "
 "the updated dictionary."
 msgstr ""
+"Bu metod, girişi ve yeni değeri parametre olarak alır ve güncellenmiş sözlüğü döndürür."
 
 #: src/ch03-02-dictionaries.md:186
 msgid ""
@@ -3261,22 +4294,28 @@ msgid ""
 "implement our own version of the `get` method from a dictionary. We should "
 "then do the following:"
 msgstr ""
+"`entry` ve `finalize` kullanarak bir örneği inceleyelim. Sözlükten `get`  
+"metodunun kendi versiyonumuzu uygulamak istediğimizi hayal edelim. O zaman " 
+"şunu yapmalıyız:"
+
 
 #: src/ch03-02-dictionaries.md:188
 msgid "Create the new entry to add using the `entry` method."
-msgstr ""
+msgstr "`entry` metodu kullanarak eklemek için yeni girişi oluşturun."
+
 
 #: src/ch03-02-dictionaries.md:189
-msgid "Insert back the entry where the `new_value` equals the `previous_value`."
-msgstr ""
+msgid ""
+"Insert back the entry where the `new_value` equals the `previous_value`."
+msgstr "`new_value` `previous_value`'a eşit olduğu yerde girişi geri ekleyin."
 
 #: src/ch03-02-dictionaries.md:190
 msgid "Return the value."
-msgstr ""
+msgstr "Değeri döndür."
 
 #: src/ch03-02-dictionaries.md:192
 msgid "Implementing our custom get would look like this:"
-msgstr ""
+msgstr "Özel get uygulamamız şu şekilde görünecektir:"
 
 #: src/ch03-02-dictionaries.md:200 src/ch03-02-dictionaries.md:244
 msgid "// Get the new entry and the previous value held at `key`\n"
@@ -3300,9 +4339,13 @@ msgstr ""
 msgid ""
 "The `ref` keyword means that the ownership of the variable will be given "
 "back at the end of the function. This concept will be explained in more "
-"detail in the [References and "
-"Snapshots](ch04-02-references-and-snapshots.md) section."
+"detail in the [References and Snapshots](ch04-02-references-and-snapshots."
+"md) section."
 msgstr ""
+"`ref` anahtar kelimesi, değişkenin sahipliğinin fonksiyonun sonunda geri  
+"verileceği anlamına gelir. Bu kavram, [Referanslar ve Snapshot'lar](ch04-02-references-and-snapshots.md)  
+"bölümünde daha detaylı açıklanacaktır."
+
 
 #: src/ch03-02-dictionaries.md:217
 msgid ""
@@ -3310,6 +4353,10 @@ msgid ""
 "inserting a new value when finalizing. If we were to implement it, it would "
 "look like the following:"
 msgstr ""
+"`insert` metodunu uygulamak benzer bir iş akışını takip eder, sadece  
+"sonlandırırken yeni bir değer eklenir. Uygulayacak olsaydık, şöyle  
+"görünecekti:"
+
 
 #: src/ch03-02-dictionaries.md:225
 msgid ""
@@ -3330,6 +4377,10 @@ msgid ""
 "how `insert` and `get` are implemented for `Felt252Dict<T>`. This code shows "
 "some example usage:"
 msgstr ""
+"Son bir not olarak, bu iki metod, `Felt252Dict<T>` için `insert` ve `get`  
+"nasıl uygulandıysa benzer bir şekilde uygulanır. Bu kod, bazı örnek  
+"kullanımları gösterir:"
+
 
 #: src/ch03-02-dictionaries.md:260
 msgid "// Get the last entry associated with `key`\n"
@@ -3361,7 +4412,7 @@ msgstr ""
 
 #: src/ch03-02-dictionaries.md:283
 msgid "Dictionaries of types not supported natively"
-msgstr ""
+msgstr "Yerel olarak desteklenmeyen türlerin sözlükleri"
 
 #: src/ch03-02-dictionaries.md:285
 msgid ""
@@ -3377,6 +4428,15 @@ msgid ""
 "valid dictionary value type. To compensate this, you can wrap your type "
 "inside a `Nullable<T>`."
 msgstr ""
+"`Felt252Dict<T>`'nin konuşmadığımız bir kısıtlaması, `Felt252DictValue<T>`  
+"trait'idir. Bu trait, sözlükte bir değer mevcut değilken çağrılan `zero_default`  
+"metodunu tanımlar. Bu, çoğu işaretsiz tamsayı, `bool` ve `felt252` gibi bazı yaygın  
+"veri türleri tarafından uygulanır - ancak diziler, yapılar ( `u256` dahil) ve çekirdek  
+"kütüphaneden diğer türler gibi daha karmaşık türler için uygulanmaz. Bu, doğal olarak  
+"desteklenmeyen türlerin sözlüğünü yapmanın basit bir iş olmadığı anlamına gelir, çünkü  
+"veri türünü geçerli bir sözlük değer türü yapmak için birkaç trait uygulaması yazmanız  
+"gerekecektir. Bunu telafi etmek için, türünüzü `Nullable<T>` içine sarabilirsiniz."
+
 
 #: src/ch03-02-dictionaries.md:291
 msgid ""
@@ -3388,6 +4448,14 @@ msgid ""
 "allocate a new memory segment for our type, and access this segment using a "
 "pointer that can only be manipulated in one place at a time."
 msgstr ""
+"`Nullable<T>`, bir değere işaret edebilen veya değer yokluğunda `null`  
+"olabilen akıllı bir işaretçi türüdür. Genellikle, bir referansın hiçbir yere  
+"işaret etmediği Nesne Yönelimli Programlama Dillerinde kullanılır. `Option` ile  
+"farkı, sarılı değerin `Box<T>` veri türü içinde depolanmasıdır. Rust'tan esinlenilen  
+"`Box<T>` türü, türümüz için yeni bir bellek segmenti tahsis etmemize ve bu segmente  
+"bir seferde yalnızca bir yerden manipüle edilebilen bir işaretçi kullanarak erişmemize  
+"olanak tanır."
+
 
 #: src/ch03-02-dictionaries.md:293
 msgid ""
@@ -3397,6 +4465,11 @@ msgid ""
 "implement the `Copy<T>` trait which is required for reading from a "
 "dictionary."
 msgstr ""
+"Bir örnekle kullanımını gösterelim. Bir sözlük içinde `Span<felt252>`  
+"saklamayı deneyeceğiz. Bunun için `Nullable<T>` ve `Box<T>` kullanacağız. Ayrıca,  
+"`Array<T>` yerine bir `Span<T>` saklıyoruz çünkü sonuncusu, bir sözlükten okuma için  
+"gerekli olan `Copy<T>` trait'ini uygulamaz."
+
 
 #: src/ch03-02-dictionaries.md:299 src/ch03-02-dictionaries.md:353
 msgid "// Create the dictionary\n"
@@ -3420,27 +4493,36 @@ msgid ""
 "`d`. We want it to hold a `Nullable<Span>`. After that, we created an array "
 "and filled it with values."
 msgstr ""
+"Bu kod parçacığında, ilk olarak `d` adında yeni bir sözlük oluşturduk. Onun  
+"`Nullable<Span>` tutmasını istiyoruz. Bunun ardından, bir dizi oluşturduk ve  
+"değerlerle doldurduk."
+
 
 #: src/ch03-02-dictionaries.md:313
 msgid ""
 "The last step is inserting the array as a span inside the dictionary. Notice "
 "that we didn't do that directly, but instead, we took some steps in between:"
 msgstr ""
+"Son adım, diziyi sözlük içinde bir span olarak eklemek. Bunu doğrudan yapmadık,  
+"ancak arada bazı adımlar attık:"
+
 
 #: src/ch03-02-dictionaries.md:315
 msgid ""
 "We wrapped the array inside a `Box` using the `new` method from `BoxTrait`."
 msgstr ""
+"Diziyi `BoxTrait`'ten `new` metodu kullanarak bir `Box` içine sardık."
 
 #: src/ch03-02-dictionaries.md:316
 msgid ""
 "We wrapped the `Box` inside a nullable using the `nullable_from_box` "
 "function."
 msgstr ""
+"`Box`'ı `nullable_from_box` fonksiyonu kullanarak nullable içine sardık."
 
 #: src/ch03-02-dictionaries.md:317
 msgid "Finally, we inserted the result."
-msgstr ""
+msgstr "Son olarak, sonucu ekledik."
 
 #: src/ch03-02-dictionaries.md:319
 msgid ""
@@ -3448,6 +4530,9 @@ msgid ""
 "the same steps but in reverse order. The following code shows how to achieve "
 "that:"
 msgstr ""
+"Eleman bir kez sözlük içine girdiğinde ve onu almak istediğimizde, aynı adımları  
+"ters sırada takip ediyoruz. Aşağıdaki kod, bunun nasıl yapılabileceğini gösterir:"
+
 
 #: src/ch03-02-dictionaries.md:324 src/ch03-02-dictionaries.md:362
 msgid "// Get value back\n"
@@ -3479,23 +4564,23 @@ msgstr ""
 
 #: src/ch03-02-dictionaries.md:340
 msgid "Here we:"
-msgstr ""
+msgstr "İşte geldik:"
 
 #: src/ch03-02-dictionaries.md:342
 msgid "Read the value using `get`."
-msgstr ""
+msgstr "`get` kullanarak değeri okuyun."
 
 #: src/ch03-02-dictionaries.md:343
 msgid "Verified it is non-null using the `match_nullable` function."
-msgstr ""
+msgstr "`match_nullable` işlevini kullanarak null olmadığını doğrulayın."
 
 #: src/ch03-02-dictionaries.md:344
 msgid "Unwrapped the value inside the box and asserted it was correct."
-msgstr ""
+msgstr "Kutunun içindeki değeri açtı ve doğru olduğunu onayladı."
 
 #: src/ch03-02-dictionaries.md:346
 msgid "The complete script would look like this:"
-msgstr ""
+msgstr "Senaryonun tamamı şu şekilde görünecektir:"
 
 #: src/ch03-03-custom-data-structures.md:3
 msgid ""
@@ -3504,6 +4589,12 @@ msgid ""
 "that arrays have one big limitation - the data stored in them is immutable. "
 "Once you append a value to an array, you can't modify it."
 msgstr ""
+"Cairo'da programlamaya başladığınızda, veri koleksiyonlarını saklamak için  
+"dizileri (`Array<T>`) kullanmak isteyeceksiniz. Ancak, dizilerin bir büyük  
+"kısıtlaması olduğunu hızlıca fark edeceksiniz - içlerinde saklanan veriler  
+"değiştirilemez. Bir dizinin sonuna bir değer ekledikten sonra, bu değeri  
+"modifiye edemezsiniz."
+
 
 #: src/ch03-03-custom-data-structures.md:8
 msgid ""
@@ -3511,6 +4602,11 @@ msgid ""
 "example, say you're making a game where the players have a level, and they "
 "can level up. You might try to store the level of the players in an array:"
 msgstr ""
+"Bu, değiştirilebilir bir veri yapısı kullanmak istediğinizde sinir bozucu  
+"olabilir. Örneğin, oyuncuların bir seviyesi olduğu ve seviye atlayabildikleri  
+"bir oyun yapıyorsunuz diyelim. Oyuncuların seviyelerini bir diziye saklamayı  
+"deneyebilirsiniz:"
+
 
 #: src/ch03-03-custom-data-structures.md:19
 msgid ""
@@ -3518,28 +4614,41 @@ msgid ""
 "it's set. If a player dies, you cannot remove it from the array unless he "
 "happens to be in the first position."
 msgstr ""
+"Ancak daha sonra, belirli bir indeksteki seviyeyi ayarlandıktan sonra  
+"artıramayacağınızı fark edersiniz. Bir oyuncu ölürse, ilk pozisyonda değilse,  
+"onu diziden çıkaramazsınız."
+
 
 #: src/ch03-03-custom-data-structures.md:23
 msgid ""
-"Fortunately, Cairo provides a handy built-in [dictionary "
-"type](./ch03-02-dictionaries.md) called `Felt252Dict<T>` that allows us to "
-"simulate the behavior of mutable data structures. Let's first explore how to "
-"create a struct that contains, among others, a `Felt252Dict<T>`."
+"Fortunately, Cairo provides a handy built-in [dictionary type](./ch03-02-"
+"dictionaries.md) called `Felt252Dict<T>` that allows us to simulate the "
+"behavior of mutable data structures. Let's first explore how to create a "
+"struct that contains, among others, a `Felt252Dict<T>`."
 msgstr ""
+"Şans eseri, Cairo değiştirilebilir veri yapılarının davranışını simüle  
+"etmemize izin veren `Felt252Dict<T>` adında kullanışlı yerleşik bir [sözlük  
+"türü](./ch03-02-dictionaries.md) sunar. Önce, aralarında bir `Felt252Dict<T>`  
+"içeren bir yapı oluşturmayı inceleyelim."
+
 
 #: src/ch03-03-custom-data-structures.md:27
 msgid ""
 "Note: Several concepts used in this chapter are presented in later parts of "
 "the book. We recommend you to check out the following chapter first: "
-"[Structs](ch05-00-using-structs-to-structure-related-data.md), "
-"[Methods](./ch05-03-method-syntax.md), [Generic "
-"types](./ch08-00-generic-types-and-traits.md), "
-"[Traits](./ch08-02-traits-in-cairo.md)."
+"[Structs](ch05-00-using-structs-to-structure-related-data.md), [Methods](./"
+"ch05-03-method-syntax.md), [Generic types](./ch08-00-generic-types-and-"
+"traits.md), [Traits](./ch08-02-traits-in-cairo.md)."
 msgstr ""
+"Not: Bu bölümde kullanılan bazı kavramlar kitabın sonraki kısımlarında  
+"sunulmuştur. Önce şu bölümlere göz atmanızı öneririz: [Yapılar](ch05-00-using-structs-to-structure-related-data.md),  
+"[Metodlar](./ch05-03-method-syntax.md), [Genel türler](./ch08-00-generic-types-and-traits.md),  
+"[Özellikler](./ch08-02-traits-in-cairo.md)."
+
 
 #: src/ch03-03-custom-data-structures.md:34
 msgid "Dictionaries as Struct Members"
-msgstr ""
+msgstr "Struct Üyeleri Olarak Sözlükler"
 
 #: src/ch03-03-custom-data-structures.md:36
 msgid ""
@@ -3549,6 +4658,12 @@ msgid ""
 "will need to define a struct to represent the new type and a trait to define "
 "its functionality:"
 msgstr ""
+"Cairo'da yapı üyeleri olarak sözlükleri tanımlamak mümkündür ancak onlarla  
+"doğru şekilde etkileşim kurmak tamamen sorunsuz olmayabilir. Kullanıcıları  
+"ekleyebileceğimiz ve sorgulayabileceğimiz özel bir _kullanıcı veritabanı_  
+"uygulamayı deneyelim. Yeni tipi temsil etmek için bir yapı ve işlevselliğini  
+"tanımlamak için bir özellik tanımlamamız gerekecek:"
+
 
 #: src/ch03-03-custom-data-structures.md:51
 msgid ""
@@ -3556,63 +4671,83 @@ msgid ""
 "over the balances of the users, giving major flexibility to whoever uses our "
 "data type. Its two members are:"
 msgstr ""
+"Yeni tipimiz `UserDatabase<T>`, kullanıcıların bir veritabanını temsil eder.  
+"Kullanıcıların bakiyeleri üzerinden genel olarak tanımlanmıştır, bu da  
+"veri tipimizi kullanan herkese büyük bir esneklik sağlar. İki üyesi vardır:"
+
 
 #: src/ch03-03-custom-data-structures.md:53
 msgid "`users_updates`, the number of users updates in the dictionary and"
-msgstr ""
+msgstr "`users_updates`, sözlükteki kullanıcı güncelleme sayısı ve"
 
 #: src/ch03-03-custom-data-structures.md:54
 msgid "`balances`, a mapping of each user to its balance."
-msgstr ""
+msgstr "`balances`, her bir kullanıcının bakiyesiyle eşleştirilmesi."
 
 #: src/ch03-03-custom-data-structures.md:56
 msgid ""
 "The database core functionality is defined by `UserDatabaseTrait`. The "
 "following methods are defined:"
 msgstr ""
+"Veritabanının temel işlevselliği `UserDatabaseTrait` tarafından tanımlanır.  
+"Tanımlanan metodlar şunlardır:"
+
 
 #: src/ch03-03-custom-data-structures.md:58
 msgid "`new` for easily creating new `UserDatabase` types."
-msgstr ""
+msgstr "`new`, yeni `UserDatabase` türlerini kolayca oluşturmak için."
 
 #: src/ch03-03-custom-data-structures.md:59
 msgid "`update_user` to update the balance of users in the database."
-msgstr ""
+msgstr "`update_user`, veritabanındaki kullanıcıların bakiyelerini güncellemek için."
 
 #: src/ch03-03-custom-data-structures.md:60
 msgid "`get_balance` to find user's balance in the database."
-msgstr ""
+msgstr "`get_balance`, veritabanında kullanıcının bakiyesini bulmak için."
 
 #: src/ch03-03-custom-data-structures.md:62
 msgid ""
 "The only remaining step is to implement each of the methods in "
-"`UserDatabaseTrait`, but since we are working with [generic "
-"types](/src/ch08-00-generic-types-and-traits.md) we also need to correctly "
-"establish the requirements of `T` so it can be a valid `Felt252Dict<T>` "
-"value type:"
+"`UserDatabaseTrait`, but since we are working with [generic types](/src/"
+"ch08-00-generic-types-and-traits.md) we also need to correctly establish the "
+"requirements of `T` so it can be a valid `Felt252Dict<T>` value type:"
 msgstr ""
+"`UserDatabaseTrait` içindeki her bir metodun uygulanması kalan tek adımdır,  
+"ancak [genel türler](/src/ch08-00-generic-types-and-traits.md) ile çalıştığımız için, `T`'nin  
+"geçerli bir `Felt252Dict<T>` değer türü olabilmesi için gereksinimleri doğru bir şekilde 
+"belirlememiz gerekiyor:"
+
 
 #: src/ch03-03-custom-data-structures.md:64
 msgid ""
 "`T` should implement the `Copy<T>` since it's required for getting values "
 "from a `Felt252Dict<T>`."
 msgstr ""
+"`T`, bir `Felt252Dict<T>`'den değerler almak için gereken `Copy<T>` trait'ini  
+"uygulamalıdır."
+
 
 #: src/ch03-03-custom-data-structures.md:65
 msgid ""
 "All value types of a dictionary implement the `Felt252DictValue<T>`, our "
 "generic type should do as well."
 msgstr ""
+"Bir sözlüğün tüm değer türleri `Felt252DictValue<T>`'i uygular, bizim genel  
+"türümüz de bunu yapmalıdır."
+
 
 #: src/ch03-03-custom-data-structures.md:66
 msgid ""
 "To insert values, `Felt252DictTrait<T>` requires all value types to be "
 "destructible."
 msgstr ""
+"Değerleri eklemek için, `Felt252DictTrait<T>` tüm değer türlerinin  
+"yok edilebilir olmasını gerektirir."
+
 
 #: src/ch03-03-custom-data-structures.md:68
 msgid "The implementation, with all restrictions in place, would be as follow:"
-msgstr ""
+msgstr "Tüm kısıtlamalar yürürlükteyken uygulama aşağıdaki gibi olacaktır:"
 
 #: src/ch03-03-custom-data-structures.md:74
 #: src/ch03-03-custom-data-structures.md:119
@@ -3638,17 +4773,28 @@ msgid ""
 "forced to implement the `Destruct<T>` trait manually (refer to the "
 "[Ownership](ch04-01-what-is-ownership.md#the-drop-trait) chapter for more "
 "information). Using `#[derive(Destruct)]` on top of the `UserDatabase<T>` "
-"definition won't work because of the use of "
-"[genericity](/src/ch08-00-generic-types-and-traits.md) in the struct "
-"definition. We need to code the `Destruct<T>` trait implementation by "
-"ourselves:"
+"definition won't work because of the use of [genericity](/src/ch08-00-"
+"generic-types-and-traits.md) in the struct definition. We need to code the "
+"`Destruct<T>` trait implementation by ourselves:"
 msgstr ""
+"Veritabanı uygulamamız neredeyse tamamlandı, tek bir eksik var: derleyici,  
+"`UserDatabase<T>`'nin kapsam dışına çıkma şeklini bilmiyor, çünkü `Drop<T>`  
+"trait'ini veya `Destruct<T>` trait'ini uygulamıyor. Bir `Felt252Dict<T>`'yi  
+"üye olarak içerdiği için bırakılamaz, bu yüzden `Destruct<T>` trait'ini  
+"manuel olarak uygulamak zorundayız ([Sahiplik](ch04-01-what-is-ownership.md#the-drop-trait)  
+"bölümüne daha fazla bilgi için bakınız). `UserDatabase<T>` tanımının üstüne  
+"`#[derive(Destruct)]` kullanmak, yapı tanımında [genellik](/src/ch08-00-generic-types-and-traits.md)  
+"kullanımı nedeniyle işe yaramaz. `Destruct<T>` trait uygulamasını kendimiz kodlamalıyız:"
+
 
 #: src/ch03-03-custom-data-structures.md:104
 msgid ""
 "Implementing `Destruct<T>` for `UserDatabase` was our last step to get a "
 "fully functional database. We can now try it out:"
 msgstr ""
+"`UserDatabase` için `Destruct<T>`'yi uygulamak, tamamen işlevsel bir veritabanına  
+"sahip olmak için son adımımızdı. Şimdi bunu deneyebiliriz:"
+
 
 #: src/ch03-03-custom-data-structures.md:154
 msgid "\"Expected 40\""
@@ -3660,13 +4806,16 @@ msgstr ""
 
 #: src/ch03-03-custom-data-structures.md:161
 msgid "Simulating a dynamic array with dicts"
-msgstr ""
+msgstr "Dinamik bir diziyi dicts ile simüle etme"
 
 #: src/ch03-03-custom-data-structures.md:163
 msgid ""
 "First, let's think about how we want our mutable dynamic array to behave. "
 "What operations should it support?"
 msgstr ""
+"Öncelikle, değiştirilebilir dinamik dizimizin nasıl davranmasını istediğimiz  
+"hakkında düşünelim. Hangi işlemleri desteklemelidir?"
+
 
 #: src/ch03-03-custom-data-structures.md:166
 msgid "It should:"
@@ -3674,33 +4823,36 @@ msgstr ""
 
 #: src/ch03-03-custom-data-structures.md:168
 msgid "Allow us to append items at the end."
-msgstr ""
+msgstr "Sonuna öğe eklememize izin verin."
 
 #: src/ch03-03-custom-data-structures.md:169
 msgid "Let us access any item by index."
-msgstr ""
+msgstr "Herhangi bir öğeye dizine göre erişelim."
 
 #: src/ch03-03-custom-data-structures.md:170
 msgid "Allow setting the value of an item at a specific index."
-msgstr ""
+msgstr "Bir öğenin değerini belirli bir dizinde ayarlamaya izin verir."
 
 #: src/ch03-03-custom-data-structures.md:171
 msgid "Return the current length."
-msgstr ""
+msgstr "Geçerli uzunluğu döndürür."
 
 #: src/ch03-03-custom-data-structures.md:173
 msgid "We can define this interface in Cairo like:"
-msgstr ""
+msgstr "Bu arayüzü Cairo'daki gibi tanımlayabiliriz:"
 
 #: src/ch03-03-custom-data-structures.md:186
 msgid ""
 "This provides a blueprint for the implementation of our dynamic array. We "
 "named it _Vec_ as it is similar to the `Vec<T>` data structure in Rust."
 msgstr ""
+"Bu, dinamik dizimizin uygulaması için bir plan sağlar. Bunu Rust'taki `Vec<T>`  
+"veri yapısına benzer olduğu için _Vec_ olarak adlandırdık."
+
 
 #: src/ch03-03-custom-data-structures.md:189
 msgid "Implementing a dynamic array in Cairo"
-msgstr ""
+msgstr "Cairo'da dinamik bir dizi uygulama"
 
 #: src/ch03-03-custom-data-structures.md:191
 msgid ""
@@ -3708,15 +4860,21 @@ msgid ""
 "(felts) to values. We'll also store a separate `len` field to track the "
 "length."
 msgstr ""
+"Verilerimizi saklamak için, indeks numaralarını (felts) değerlere eşleyen bir  
+"`Felt252Dict<T>` kullanacağız. Ayrıca, uzunluğu takip etmek için ayrı bir `len` alanı saklayacağız."
+
 
 #: src/ch03-03-custom-data-structures.md:194
 msgid ""
 "Here is what our struct looks like. We wrap the type `T` inside `Nullable` "
 "pointer to allow using any type `T` in our data structure, as explained in "
-"the "
-"[Dictionaries](./ch03-02-dictionaries.md#dictionaries-of-types-not-supported-natively) "
-"section:"
+"the [Dictionaries](./ch03-02-dictionaries.md#dictionaries-of-types-not-"
+"supported-natively) section:"
 msgstr ""
+"İşte yapımızın nasıl göründüğü. `T` türünü `Nullable` işaretçi içine sarıyoruz ki,  
+"[Sözlükler](./ch03-02-dictionaries.md#dictionaries-of-types-not-supported-natively) bölümünde açıklandığı gibi,  
+"veri yapımızda herhangi bir `T` türünü kullanabilmemize izin verilsin:"
+
 
 #: src/ch03-03-custom-data-structures.md:206
 msgid ""
@@ -3724,6 +4882,10 @@ msgid ""
 "into the dictionary to set or update values in our data structure. For "
 "example, to update a value at a specific index, we do:"
 msgstr ""
+"Bu vektörü değiştirilebilir kılan ana şey, veri yapımızda değerleri ayarlamak veya  
+"güncellemek için sözlüğe değerler ekleyebilmemizdir. Örneğin, belirli bir indeksteki  
+"değeri güncellemek için şunu yaparız:"
+
 
 #: src/ch03-03-custom-data-structures.md:212
 #: src/ch03-03-custom-data-structures.md:241
@@ -3736,12 +4898,16 @@ msgid ""
 "This overwrites the previously existing value at that index in the "
 "dictionary."
 msgstr ""
+"Bu, sözlükteki o indeksteki önceden var olan değerin üzerine yazar."
 
 #: src/ch03-03-custom-data-structures.md:219
 msgid ""
 "While arrays are immutable, dictionaries provide the flexibility we need for "
 "modifiable data structures like vectors."
 msgstr ""
+"Diziler değiştirilemezken, sözlükler vektörler gibi değiştirilebilir veri yapıları " 
+"için ihtiyacımız olan esnekliği sağlar."
+
 
 #: src/ch03-03-custom-data-structures.md:222
 msgid ""
@@ -3749,22 +4915,30 @@ msgid ""
 "implementation of all the methods defined in our interface can be done as "
 "follow :"
 msgstr ""
+"Arayüzün geri kalanının uygulanması basittir. Arayüzümüzde tanımlanan tüm metodların " 
+"uygulanması şu şekilde yapılabilir:"
+
 
 #: src/ch03-03-custom-data-structures.md:259
 msgid ""
-"The full implementation of the `Vec` structure can be found in the "
-"community-maintained library "
-"[Alexandria](https://github.com/keep-starknet-strange/alexandria/tree/main/src/data_structures)."
+"The full implementation of the `Vec` structure can be found in the community-"
+"maintained library [Alexandria](https://github.com/keep-starknet-strange/"
+"alexandria/tree/main/src/data_structures)."
 msgstr ""
+"`Vec` yapısının tam uygulaması, topluluk tarafından sürdürülen [Alexandria](https://github.com/keep-starknet-strange/alexandria/tree/main/src/data_structures)  
+"kütüphanesinde bulunabilir."
+
 
 #: src/ch03-03-custom-data-structures.md:263
 msgid "Simulating a Stack with dicts"
-msgstr ""
+msgstr "Yığını diktelerle simüle etme"
 
 #: src/ch03-03-custom-data-structures.md:265
 msgid ""
 "We will now look at a second example and its implementation details: a Stack."
 msgstr ""
+"Şimdi ikinci bir örneğe ve onun uygulama detaylarına bakacağız: Bir Stack."
+
 
 #: src/ch03-03-custom-data-structures.md:267
 msgid ""
@@ -3772,30 +4946,39 @@ msgid ""
 "element and removal of an existing element takes place at the same end, "
 "represented as the top of the stack."
 msgstr ""
+"Bir Yığın, LIFO (Last-In, First-Out) bir koleksiyondur. Yeni bir elemanın ekleme  
+"ve mevcut bir elemanın çıkarma işlemi aynı uçta, yığının tepesi olarak temsil  
+"edilen yerde gerçekleşir."
+
 
 #: src/ch03-03-custom-data-structures.md:271
 msgid "Let us define what operations we need to create a stack :"
-msgstr ""
+msgstr "Bir yığın oluşturmak için hangi işlemlere ihtiyacımız olduğunu tanımlayalım:"
+
 
 #: src/ch03-03-custom-data-structures.md:273
 msgid "Push an item to the top of the stack."
-msgstr ""
+msgstr "Yığının tepesine bir öğe ekleyin."
+
 
 #: src/ch03-03-custom-data-structures.md:274
 msgid "Pop an item from the top of the stack."
-msgstr ""
+msgstr "Yığının tepesinden bir öğe çıkarın."
+
 
 #: src/ch03-03-custom-data-structures.md:275
 msgid "Check whether there are still any elements in the stack."
-msgstr ""
+msgstr "Yığında hala eleman olup olmadığını kontrol edin."
 
 #: src/ch03-03-custom-data-structures.md:277
 msgid "From these specifications we can define the following interface :"
-msgstr ""
+msgstr "Bu özelliklerden yola çıkarak aşağıdaki arayüzü tanımlayabiliriz:"
+
 
 #: src/ch03-03-custom-data-structures.md:287
 msgid "Implementing a Mutable Stack in Cairo"
-msgstr ""
+msgstr "Cairo'da Değiştirilebilir Bir Yığın Uygulamak"
+
 
 #: src/ch03-03-custom-data-structures.md:289
 msgid ""
@@ -3803,14 +4986,20 @@ msgid ""
 "`Felt252Dict<T>` to store the values of the stack along with a `usize` field "
 "to keep track of the length of the stack to iterate over it."
 msgstr ""
+"Cairo'da bir yığın veri yapısı oluşturmak için, yığının değerlerini saklamak ve  
+"üzerinde yineleme yapmak için yığının uzunluğunu takip etmek amacıyla bir `usize`  
+"alanı ile birlikte yine bir `Felt252Dict<T>` kullanabiliriz."
+
 
 #: src/ch03-03-custom-data-structures.md:293
 msgid "The Stack struct is defined as:"
-msgstr ""
+msgstr "Stack yapısı şu şekilde tanımlanır:"
 
 #: src/ch03-03-custom-data-structures.md:302
-msgid "Next, let's see how our main functions `push` and `pop` are implemented."
+msgid ""
+"Next, let's see how our main functions `push` and `pop` are implemented."
 msgstr ""
+"Şimdi, ana fonksiyonlarımız olan `push` ve `pop`'un nasıl uygulandığını görelim."
 
 #: src/ch03-03-custom-data-structures.md:325
 msgid ""
@@ -3822,14 +5011,25 @@ msgid ""
 "`len-1` and then decreases the value of `len` to update the position of the "
 "stack top accordingly."
 msgstr ""
+"Kod, `Felt252Dict<T>` içindeki değerlere erişmek için `insert` ve `get` metodlarını 
+"kullanır. Yığının tepesine bir eleman eklemek için, `push` fonksiyonu elemanı `len`  
+"indeksinde sözlüğe ekler ve yığının tepesinin pozisyonunu takip etmek için `len` alanını 
+"artırır. Bir değeri kaldırmak için, `pop` fonksiyonu `len-1` pozisyonundaki son değeri 
+"alır ve ardından yığının tepesinin pozisyonunu güncellemek için `len` değerini azaltır. "
+
 
 #: src/ch03-03-custom-data-structures.md:333
 msgid ""
 "The full implementation of the Stack, along with more data structures that "
 "you can use in your code, can be found in the community-maintained "
-"[Alexandria](https://github.com/keep-starknet-strange/alexandria/tree/main/src/data_structures) "
-"library, in the \"data_structures\" crate."
+"[Alexandria](https://github.com/keep-starknet-strange/alexandria/tree/main/"
+"src/data_structures) library, in the \"data_structures\" crate."
 msgstr ""
+"Yığının tam uygulaması, kodunuzda kullanabileceğiniz daha 
+"fazla veri yapısı ile birlikte, topluluk tarafından sürdürülen  
+"[Alexandria](https://github.com/keep-starknet-strange/alexandria/tree/main/src/data_structures)  
+"kütüphanesinde, \"data_structures\" crate'inde bulunabilir. "
+
 
 #: src/ch03-03-custom-data-structures.md:340
 msgid ""
@@ -3841,6 +5041,14 @@ msgid ""
 "applications, effectively hiding the complexity of the underlying memory "
 "model."
 msgstr ""
+"Harika! Artık diziler, sözlükler ve hatta özel veri yapıları 
+"hakkında bilgiye sahipsiniz. Cairo'nun bellek modeli değiştirilemez 
+"olduğu ve değiştirilebilir veri yapılarını uygulamayı zorlaştırabileceği 
+"halde, neyse ki `Felt252Dict<T>` türünü değiştirilebilir veri yapılarını  
+"simüle etmek için kullanabiliriz. Bu, birçok uygulama için yararlı olan 
+"geniş bir veri yapısı yelpazesini uygulamamıza olanak tanır, etkili bir 
+"şekilde altta yatan bellek modelinin karmaşıklığını gizler."
+
 
 #: src/ch03-03-custom-data-structures.md:347
 msgid ""
@@ -3848,10 +5056,13 @@ msgid ""
 "with Rust and that doesn’t commonly exist in other programming languages: "
 "ownership."
 msgstr ""
+"Hazır olduğunuzda, Cairo'nun Rust ile paylaştığı ve diğer programlama  
+"dillerinde yaygın olmayan bir kavramdan bahsedeceğiz: sahiplik."
+
 
 #: src/ch04-00-understanding-ownership.md:1
 msgid "Understanding Cairo's Ownership system"
-msgstr ""
+msgstr "Cairo'nun Mülkiyet Sistemini Anlamak"
 
 #: src/ch04-00-understanding-ownership.md:3
 msgid ""
@@ -3864,37 +5075,49 @@ msgid ""
 "this chapter, we’ll talk about Cairo's ownership system as well as "
 "references and snapshots."
 msgstr ""
+"Cairo, değerlerin her Cairo programında tam olarak bir kez kullanılmasını "
+"statik olarak garanti altına alan doğrusal bir tip sistemine dayalı olarak "
+"kurulmuş bir dildir. Bu doğrusal tip sistemi, bir bellek hücresine iki kez "
+"yazma gibi hatalara yol açabilecek işlemlerin çalışma zamanı hatalarını  "
+"önleyerek derleme zamanında tespit edilmesini sağlar. Bu, bir sahiplik "
+"sistemi uygulayarak ve değerlerin varsayılan olarak kopyalanmasını ve "
+"atılmasını yasaklayarak başarılır. Bu bölümde, Cairo'nun sahiplik sisteminden "
+"ve referanslar ile anlık görüntülerden bahsedeceğiz."
 
 #: src/ch04-01-what-is-ownership.md:1
 msgid "Ownership Using a Linear Type System"
-msgstr ""
+msgstr "Doğrusal Tip Sistemi Kullanarak Sahiplik"
 
 #: src/ch04-01-what-is-ownership.md:3
 msgid ""
 "Cairo uses a linear type system. In such a type system, any value (a basic "
 "type, a struct, an enum) must be used and must only be used once. 'Used' "
 "here means that the value is either _destroyed_ or _moved_."
-msgstr ""
+msgstr "Cairo, doğrusal bir tip sistemini kullanır. Bu tip sistemde, herhangi bir değer (bir temel tip, bir yapı, bir enum) kullanılmalı ve yalnızca bir kez kullanılmalıdır. 'Kullanılmış' burada, değerin ya _yok edilmesi_ ya da _taşınması_ anlamına gelir."
+
 
 #: src/ch04-01-what-is-ownership.md:5
 msgid "_Destruction_ can happen in several ways:"
-msgstr ""
+msgstr "_Yok etme_ birkaç şekilde gerçekleşebilir:"
+
 
 #: src/ch04-01-what-is-ownership.md:7
-msgid "a variable goes out of scope."
-msgstr ""
+msgid "a variable goes out of scope"
+msgstr "bir değişkenin kapsamı dışına çıkması"
+
 
 #: src/ch04-01-what-is-ownership.md:8
-msgid "a struct is destructured."
-msgstr ""
+msgid "a struct is destructured"
+msgstr "bir yapının yapılandırılması açılması"
+
 
 #: src/ch04-01-what-is-ownership.md:9
-msgid "explicit destruction using `destruct()`."
-msgstr ""
+msgid "explicit destruction using destruct()"
+msgstr "destruct() kullanılarak açık yok etme"
 
 #: src/ch04-01-what-is-ownership.md:11
 msgid "_Moving_ a value simply means passing that value to another function."
-msgstr ""
+msgstr "Bir değeri _taşımak_ basitçe o değeri başka bir fonksiyona geçirmek demektir."
 
 #: src/ch04-01-what-is-ownership.md:13
 msgid ""
@@ -3904,19 +5127,20 @@ msgid ""
 "memory value. This is obviously impossible in Cairo since the memory is "
 "immutable. Instead, Cairo leverages its linear type system for two main "
 "purposes:"
-msgstr ""
+msgstr "Bu, Rust sahiplik modeline benzer bazı kısıtlamalar sonucunu doğurur, ancak bazı farklılıklar vardır. Özellikle, rust sahiplik modeli kısmen veri yarışlarını ve bir bellek değerine yönelik eşzamanlı değişebilir erişimi önlemek için var olur. Bu, Cairo'da imkansızdır çünkü bellek değişmez. Bunun yerine, Cairo doğrusal tip sistemini iki ana amaç için kullanır:"
+
 
 #: src/ch04-01-what-is-ownership.md:17
 msgid "Ensuring that all code is provable and thus verifiable."
-msgstr ""
+msgstr "Tüm kodun kanıtlanabilir ve dolayısıyla doğrulanabilir olduğunu sağlamak."
 
 #: src/ch04-01-what-is-ownership.md:18
 msgid "Abstracting away the immutable memory of the Cairo VM."
-msgstr ""
+msgstr "Cairo VM'nin değişmez belleğini soyutlamak."
 
 #: src/ch04-01-what-is-ownership.md:20
 msgid "Ownership"
-msgstr ""
+msgstr "Sahiplik"
 
 #: src/ch04-01-what-is-ownership.md:22
 msgid ""
@@ -3927,121 +5151,122 @@ msgid ""
 "accidentally modified by the programmer. This makes it possible to talk "
 "about ownership of a variable: the owner is the code that can read (and "
 "write if mutable) the variable."
-msgstr ""
+msgstr "Cairo'da, sahiplik _değerlere_ değil, _değişkenlere_ uygulanır. Bir değer, değer kendisi her zaman değişmez olduğu için birçok farklı değişken tarafından güvenle atıfta bulunulabilir (hatta değişebilir değişkenler olsalar bile). Ancak değişkenler değişebilir olabilir, bu yüzden derleyici, sabit değişkenlerin yanlışlıkla programcı tarafından değiştirilmediğinden emin olmalıdır. Bu, bir değişkenin sahipliğinden bahsetmeyi mümkün kılar: sahip, değişkeni okuyabilen (ve değişebilir ise yazabilen) koddur."
 
 #: src/ch04-01-what-is-ownership.md:26
 msgid ""
 "This means that variables (not values) follow similar rules to Rust values:"
-msgstr ""
+msgstr "Bu, değişkenlerin (değerler değil) Rust değerlerine benzer kuralları izlediği anlamına gelir:"
 
 #: src/ch04-01-what-is-ownership.md:28
 msgid "Each variable in Cairo has an owner."
-msgstr ""
+msgstr "Cairo'daki her değişkenin bir sahibi vardır."
 
 #: src/ch04-01-what-is-ownership.md:29
 msgid "There can only be one owner at a time."
-msgstr ""
+msgstr "Bir zaman da yalnızca bir sahip olabilir."
 
 #: src/ch04-01-what-is-ownership.md:30
 msgid "When the owner goes out of scope, the variable is destroyed."
-msgstr ""
+msgstr "Sahip kapsam dışına çıktığında, değişken yok edilir."
 
 #: src/ch04-01-what-is-ownership.md:32
 msgid ""
 "Now that we’re past basic Cairo syntax, we won’t include all the `fn main() "
-"{` code in examples, so if you’re following along, make sure to put the "
-"following examples inside a main function manually. As a result, our "
-"examples will be a bit more concise, letting us focus on the actual details "
+"{` examples inside a `main` function manually. As a result, our examples "
+"will be a code in examples, so if you’re following along, make sure to put "
+"the following bit more concise, letting us focus on the actual details "
 "rather than boilerplate code."
-msgstr ""
+msgstr "Artık temel Cairo sözdizimini geride bıraktığımıza göre, `fn main() {` örneklerinin tümünü manuel olarak bir `main` fonksiyonunun içine dahil etmeyeceğiz. Sonuç olarak, örneklerimiz örneklerde bir kod olacak, bu nedenle eğer takip ediyorsanız, aşağıdaki bölümü daha öz hale getirin, böylece dikkatimizi kalıp kodlar yerine gerçek detaylara odaklayabiliriz."
 
-#: src/ch04-01-what-is-ownership.md:34
+#: src/ch04-01-what-is-ownership.md:38
 msgid "Variable Scope"
-msgstr ""
+msgstr "Değişken Kapsamı"
 
-#: src/ch04-01-what-is-ownership.md:36
+#: src/ch04-01-what-is-ownership.md:40
 msgid ""
 "As a first example of the linear type system, we’ll look at the _scope_ of "
 "some variables. A scope is the range within a program for which an item is "
 "valid. Take the following variable:"
-msgstr ""
+msgstr "Doğrusal tip sisteminin ilk örneği olarak, bazı değişkenlerin _kapsamına_ bakacağız. Bir kapsam, bir program içinde bir öğenin geçerli olduğu aralıktır. Aşağıdaki değişkeni alın:"
 
-#: src/ch04-01-what-is-ownership.md:44
+#: src/ch04-01-what-is-ownership.md:48
 msgid ""
 "The variable `s` refers to a short string. The variable is valid from the "
 "point at which it’s declared until the end of the current _scope_. Listing "
 "4-1 shows a program with comments annotating where the variable `s` would be "
 "valid."
-msgstr ""
+msgstr "`s` değişkeni kısa bir metni ifade eder. Değişken, tanımlandığı noktadan itibaren geçerli olduğu mevcut _kapsamın_ sonuna kadar geçerlidir. Liste 4-1, `s` değişkeninin nerede geçerli olacağını açıklayan yorumlarla bir programı gösterir."
 
-#: src/ch04-01-what-is-ownership.md:49
+
+#: src/ch04-01-what-is-ownership.md:53
 msgid "//TAG: ignore_fmt\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:51
+#: src/ch04-01-what-is-ownership.md:55
 msgid "// s is not valid here, it’s not yet declared\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:52
+#: src/ch04-01-what-is-ownership.md:56
 msgid ""
 "// s is valid from this point forward\n"
 "    // do stuff with s\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:54
+#: src/ch04-01-what-is-ownership.md:58
 msgid "// this scope is now over, and s is no longer valid\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:58
+#: src/ch04-01-what-is-ownership.md:62
 msgid "Listing 4-1: A variable and the scope in which it is valid"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:60
+#: src/ch04-01-what-is-ownership.md:64
 msgid "In other words, there are two important points in time here:"
-msgstr ""
+msgstr "Diğer bir deyişle, burada iki önemli zaman noktası vardır:"
 
-#: src/ch04-01-what-is-ownership.md:62
+#: src/ch04-01-what-is-ownership.md:66
 msgid "When `s` comes _into_ scope, it is valid."
-msgstr ""
+msgstr "`s` kapsama _girdiğinde_, geçerlidir."
 
-#: src/ch04-01-what-is-ownership.md:63
+#: src/ch04-01-what-is-ownership.md:67
 msgid "It remains valid until it goes _out of_ scope."
-msgstr ""
+msgstr "_Kapsam dışına_ çıkana kadar geçerli kalır."
 
-#: src/ch04-01-what-is-ownership.md:65
+#: src/ch04-01-what-is-ownership.md:69
 msgid ""
 "At this point, the relationship between scopes and when variables are valid "
 "is similar to that in other programming languages. Now we’ll build on top of "
 "this understanding by using the `Array` type we introduced in the [previous "
 "chapter](./ch03-01-arrays.md)."
-msgstr ""
+msgstr "Bu noktada, kapsamlar ve değişkenlerin ne zaman geçerli olduğu arasındaki ilişki, diğer programlama dillerindeki ile benzerdir. Şimdi, [önceki bölümde](./ch03-01-arrays.md) tanıttığımız `Array` tipini kullanarak bu anlayışın üzerine inşa edeceğiz."
 
-#: src/ch04-01-what-is-ownership.md:67
+#: src/ch04-01-what-is-ownership.md:71
 msgid "Moving values - example with Array"
-msgstr ""
+msgstr "Değerleri Taşımak - Array ile örnek"
 
-#: src/ch04-01-what-is-ownership.md:69
+#: src/ch04-01-what-is-ownership.md:73
 msgid ""
 "As said earlier, _moving_ a value simply means passing that value to another "
 "function. When that happens, the variable referring to that value in the "
 "original scope is destroyed and can no longer be used, and a new variable is "
 "created to hold the same value."
-msgstr ""
+msgstr "Daha önce belirtildiği gibi, bir değeri _taşımak_ basitçe o değeri başka bir fonksiyona geçirmek demektir. Bu olduğunda, orijinal kapsamdaki değere atıfta bulunan değişken yok edilir ve artık kullanılamaz hale gelir ve aynı değeri tutmak için yeni bir değişken oluşturulur."
 
-#: src/ch04-01-what-is-ownership.md:71
+#: src/ch04-01-what-is-ownership.md:75
 msgid ""
 "Arrays are an example of a complex type that is moved when passing it to "
 "another function. Here is a short reminder of what an array looks like:"
-msgstr ""
+msgstr "Diziler, başka bir fonksiyona geçirildiğinde taşınan karmaşık bir tipin bir örneğidir. İşte bir dizinin nasıl göründüğüne dair kısa bir hatırlatma:"
 
-#: src/ch04-01-what-is-ownership.md:82
+#: src/ch04-01-what-is-ownership.md:86
 msgid ""
 "How does the type system ensure that the Cairo program never tries to write "
 "to the same memory cell twice? Consider the following code, where we try to "
 "remove the front of the array twice:"
-msgstr ""
+msgstr "Tip sistemi, Cairo programının asla aynı bellek hücresine iki kez yazmaya çalışmamasını nasıl sağlar? Aşağıdaki kodu düşünün, burada dizinin önünü iki kez kaldırmaya çalışıyoruz:"
 
-#: src/ch04-01-what-is-ownership.md:97
+#: src/ch04-01-what-is-ownership.md:101
 msgid ""
 "In this case, we try to pass the same value (the array in the `arr` "
 "variable) to both function calls. This means our code tries to remove the "
@@ -4051,13 +5276,13 @@ msgid ""
 "array to the `foo` function, the variable `arr` is no longer usable. We get "
 "this compile-time error, telling us that we would need Array to implement "
 "the Copy Trait:"
-msgstr ""
+msgstr "Bu durumda, aynı değeri (`arr` değişkenindeki dizi) her iki fonksiyon çağrısına da geçirmeye çalışıyoruz. Bu, kodumuzun ilk elemanı iki kez kaldırmaya çalıştığı anlamına gelir ki bu, aynı bellek hücresine iki kez yazmaya çalışır - bu Cairo VM tarafından yasaklanmıştır ve bir çalışma zamanı hatasına yol açar. Neyse ki, bu kod aslında derlenmez. Diziyi `foo` fonksiyonuna geçirdikten sonra, `arr` değişkeni artık kullanılamaz. Bu derleme zamanı hatasını alırız, bize Array'in Copy Trait'ini uygulaması gerektiğini söyler:"
 
-#: src/ch04-01-what-is-ownership.md:107
+#: src/ch04-01-what-is-ownership.md:111
 msgid "The Copy trait"
-msgstr ""
+msgstr "Copy özelliği"
 
-#: src/ch04-01-what-is-ownership.md:109
+#: src/ch04-01-what-is-ownership.md:113
 msgid ""
 "If a type implements the `Copy` trait, passing a value of that type to a "
 "function does not move the value. Instead, a new variable is created, "
@@ -4066,48 +5291,42 @@ msgid ""
 "only and because _values_ in Cairo are always immutable. This, in "
 "particular, conceptually differs from the rust version of the `Copy` trait, "
 "where the value is potentially copied in memory."
-msgstr ""
+msgstr "Bir tip `Copy` özelliğini uygularsa, o tipten bir değeri bir fonksiyona geçirmek değeri taşımaz. Bunun yerine, aynı değere atıfta bulunan yeni bir değişken oluşturulur. Burada dikkat edilmesi gereken önemli şey, bu işlemin tamamen ücretsiz bir işlem olmasıdır, çünkü değişkenler yalnızca bir cairo soyutlamasıdır ve Cairo'daki _değerler_ her zaman değişmezdir. Bu, özellikle, değerin bellekte potansiyel olarak kopyalandığı rust versiyonundaki `Copy` özelliğinden kavramsal olarak farklıdır."
 
-#: src/ch04-01-what-is-ownership.md:112
+#: src/ch04-01-what-is-ownership.md:116
 msgid ""
-"All basic types previously described in [data types "
-"chapter](ch02-02-data-types.md) implement by default the `Copy` trait."
-msgstr ""
+"You can implement the `Copy` trait on your type by adding the "
+"`#[derive(Copy)]` annotation to your type definition. However, Cairo won't "
+"allow a type to be annotated with Copy if the type itself or any of its "
+"components don't implement the Copy trait. While Arrays and Dictionaries "
+"can't be copied, custom types that don't contain either of them can be."
+msgstr "Tür tanımınıza `#[derive(Copy)]` ekleyerek türünüze `Copy` özelliğini uygulayabilirsiniz. Ancak, türün kendisi veya bileşenlerinden herhangi biri Copy özelliğini uygulamıyorsa, Cairo bir türün Copy ile etiketlenmesine izin vermez. Diziler ve Sözlükler kopyalanamazken, bunlardan herhangi birini içermeyen özel türler kopyalanabilir."
 
-#: src/ch04-01-what-is-ownership.md:114
-msgid ""
-"While Arrays and Dictionaries can't be copied, custom types that don't "
-"contain either of them can be. You can implement the `Copy` trait on your "
-"type by adding the `#[derive(Copy)]` annotation to your type definition. "
-"However, Cairo won't allow a type to be annotated with Copy if the type "
-"itself or any of its components doesn't implement the Copy trait."
-msgstr ""
-
-#: src/ch04-01-what-is-ownership.md:130
+#: src/ch04-01-what-is-ownership.md:132
 msgid "// do something with p\n"
-msgstr ""
+msgstr "// p ile bir şeyler yapın\n"
 
-#: src/ch04-01-what-is-ownership.md:134
+#: src/ch04-01-what-is-ownership.md:136
 msgid ""
 "In this example, we can pass `p1` twice to the foo function because the "
 "`Point` type implements the `Copy` trait. This means that when we pass `p1` "
 "to `foo`, we are actually passing a copy of `p1`, so `p1` remains valid. In "
-"ownership terms, this means that the ownership of `p1` remains with the "
-"`main` function. If you remove the `Copy` trait derivation from the `Point` "
-"type, you will get a compile-time error when trying to compile the code."
-msgstr ""
+"ownership terms, this means that the ownership of `p1` remains with the main "
+"function. If you remove the `Copy` trait derivation from the `Point` type, "
+"you will get a compile-time error when trying to compile the code."
+msgstr "Bu örnekte, `Point` tipi `Copy` özelliğini uyguladığı için `p1`'i foo fonksiyonuna iki kez geçirebiliriz. Bu, `p1`'i `foo`'ya geçirdiğimizde aslında `p1`'in bir kopyasını geçirdiğimiz anlamına gelir, bu yüzden `p1` geçerli kalır. Sahiplik terimleriyle, bu, `p1`'in sahipliğinin ana fonksiyonla kaldığı anlamına gelir. `Point` tipinden `Copy` özelliği türetmesini kaldırırsanız, kodu derlemeye çalışırken bir derleme zamanı hatası alırsınız."
 
-#: src/ch04-01-what-is-ownership.md:137
+#: src/ch04-01-what-is-ownership.md:139
 msgid ""
 "_Don't worry about the `Struct` keyword. We will introduce this in [Chapter "
 "5](ch05-00-using-structs-to-structure-related-data.md)._"
-msgstr ""
-
-#: src/ch04-01-what-is-ownership.md:139
-msgid "Destroying values - example with FeltDict"
-msgstr ""
+msgstr "`Struct` anahtar kelimesi hakkında endişelenmeyin. Bunu [Bölüm 5](ch05-00-using-structs-to-structure-related-data.md)’te tanıtacağız."
 
 #: src/ch04-01-what-is-ownership.md:141
+msgid "Destroying values - example with FeltDict"
+msgstr "Değerleri Yok Etme - FeltDict ile örnek"
+
+#: src/ch04-01-what-is-ownership.md:143
 msgid ""
 "The other way linear types can be _used_ is by being destroyed. Destruction "
 "must ensure that the 'resource' is now correctly released. In rust for "
@@ -4115,133 +5334,140 @@ msgid ""
 "Cairo, one type that has such behaviour is `Felt252Dict`. For provability, "
 "dicts must be 'squashed' when they are destructed. This would be very easy "
 "to forget, so it is enforced by the type system and the compiler."
-msgstr ""
+msgstr "Doğrusal tiplerin _kullanılma_ yollarından bir diğeri yok edilerek olur. Yok etme, 'kaynağın' artık doğru bir şekilde serbest bırakıldığından emin olmalıdır. Örneğin rust'ta, bu bir dosyaya erişimin kapatılması veya bir mutex'in kilitlemesi olabilir. Cairo'da, böyle bir davranışı olan bir tip `Felt252Dict`'tir. Kanıtlanabilirlik için, sözlükler yok edildiklerinde 'ezilmelidir'. Bu, çok kolay unutulabilen bir şey olduğundan, tip sistemi ve derleyici tarafından zorunlu kılınır."
 
-#: src/ch04-01-what-is-ownership.md:145
-msgid "No-op destruction: the `Drop` Trait"
-msgstr ""
 
 #: src/ch04-01-what-is-ownership.md:147
+msgid "No-op destruction: the Drop Trait"
+msgstr "Etkisiz yok etme: Drop Özelliği"
+
+#: src/ch04-01-what-is-ownership.md:149
 msgid ""
 "You may have noticed that the `Point` type in the previous example also "
 "implements the `Drop` trait. For example, the following code will not "
 "compile, because the struct `A` is not moved or destroyed before it goes out "
 "of scope:"
-msgstr ""
+msgstr "Önceki örnekteki `Point` tipinin de `Drop` özelliğini uyguladığını fark etmiş olabilirsiniz. Örneğin, aşağıdaki kod, `A` yapısı kapsam dışına çıkmadan önce taşınmadığı veya yok edilmediği için derlenmez:"
 
-#: src/ch04-01-what-is-ownership.md:154
+#: src/ch04-01-what-is-ownership.md:156
 msgid "// error: Value not dropped.\n"
-msgstr ""
+msgstr "// hata: Değer bırakılmadı.\n"
 
-#: src/ch04-01-what-is-ownership.md:158
+#: src/ch04-01-what-is-ownership.md:160
 msgid ""
 "However, types that implement the `Drop` trait are automatically destroyed "
 "when going out of scope. This destruction does nothing, it is a no-op - "
 "simply a hint to the compiler that this type can safely be destroyed once "
 "it's no longer useful. We call this \"dropping\" a value."
-msgstr ""
+msgstr "Ancak, `Drop` özelliğini uygulayan tipler, kapsam dışına çıktıklarında otomatik olarak yok edilir. Bu yok etme işlemi hiçbir şey yapmaz, bir etkisiz işlemdir - sadece bu tipin artık yararlı olmadığında güvenle yok edilebileceğine dair derleyiciye bir ipucudur. Buna bir değeri \"bırakmak\" diyoruz."
 
-#: src/ch04-01-what-is-ownership.md:160
+#: src/ch04-01-what-is-ownership.md:162
 msgid ""
 "At the moment, the `Drop` implementation can be derived for all types, "
 "allowing them to be dropped when going out of scope, except for dictionaries "
 "(`Felt252Dict`) and types containing dictionaries. For example, the "
 "following code compiles:"
-msgstr ""
+msgstr "Şu anda, `Drop` uygulaması, sözlükler (`Felt252Dict`) ve sözlük içeren tipler hariç, tüm tipler için türetilebilir ve bunların kapsam dışına çıktıklarında bırakılmalarına izin verilir. Örneğin, aşağıdaki kod derlenir:"
 
-#: src/ch04-01-what-is-ownership.md:168
+#: src/ch04-01-what-is-ownership.md:170
 msgid "// Now there is no error.\n"
-msgstr ""
-
-#: src/ch04-01-what-is-ownership.md:172
-msgid "Destruction with a side-effect: the `Destruct` trait"
-msgstr ""
+msgstr "// Şimdi bir hata yok.\n"
 
 #: src/ch04-01-what-is-ownership.md:174
+msgid "Destruction with a side-effect: the Destruct trait"
+msgstr "Yan etkili yok etme: Destruct Özelliği"
+
+#: src/ch04-01-what-is-ownership.md:176
 msgid ""
 "When a value is destroyed, the compiler first tries to call the `drop` "
 "method on that type. If it doesn't exist, then the compiler tries to call "
 "`destruct` instead. This method is provided by the `Destruct` trait."
-msgstr ""
+msgstr "Bir değer yok edildiğinde, derleyici önce o tip üzerinde `drop` metodunu çağırmayı dener. Eğer bu mevcut değilse, derleyici bunun yerine `destruct`'u çağırmayı dener. Bu metod, `Destruct` özelliği tarafından sağlanır."
 
-#: src/ch04-01-what-is-ownership.md:176
+#: src/ch04-01-what-is-ownership.md:178
 msgid ""
 "As said earlier, dictionaries in Cairo are types that must be \"squashed\" "
 "when destructed, so that the sequence of access can be proven. This is easy "
 "for developers to forget, so instead dictionaries implement the `Destruct` "
 "trait to ensure that all dictionaries are _squashed_ when going out of "
 "scope. As such, the following example will not compile:"
-msgstr ""
+msgstr "Daha önce belirtildiği gibi, Cairo'daki sözlükler, yok edildiklerinde \"ezilmeleri\" gereken tiplerdir, böylece erişim sırası kanıtlanabilir. Bu, geliştiricilerin unutması kolaydır, bu yüzden sözlükler kapsam dışına çıktıklarında tüm sözlüklerin _ezilmesini_ sağlamak için `Destruct` özelliğini uygularlar. Bu nedenle, aşağıdaki örnek derlenmez:"
 
-#: src/ch04-01-what-is-ownership.md:189
+#: src/ch04-01-what-is-ownership.md:191
 msgid "If you try to run this code, you will get a compile-time error:"
-msgstr ""
+msgstr "Bu kodu çalıştırmayı denerseniz, bir derleme zamanı hatası alırsınız:"
 
-#: src/ch04-01-what-is-ownership.md:198
+#: src/ch04-01-what-is-ownership.md:200
 msgid ""
-"When `A` goes out of scope, it can't be dropped as it implements neither the "
+"When A goes out of scope, it can't be dropped as it implements neither the "
 "`Drop` (as it contains a dictionary and can't `derive(Drop)`) nor the "
 "`Destruct` trait. To fix this, we can derive the `Destruct` trait "
 "implementation for the `A` type:"
-msgstr ""
+msgstr "`A` kapsam dışına çıktığında, ne `Drop`'u (bir sözlük içerdiği ve `derive(Drop)` yapılamadığı için) ne de `Destruct` özelliğini uyguladığı için bırakılamaz. Bunu düzeltmek için, `A` tipi için `Destruct` özelliği uygulamasını türetebiliriz:"
 
-#: src/ch04-01-what-is-ownership.md:207
+#: src/ch04-01-what-is-ownership.md:209
 msgid "// No error here\n"
-msgstr ""
+msgstr "// Burada bir hata yok\n"
 
-#: src/ch04-01-what-is-ownership.md:211
+#: src/ch04-01-what-is-ownership.md:213
 msgid ""
 "Now, when `A` goes out of scope, its dictionary will be automatically "
 "`squashed`, and the program will compile."
-msgstr ""
-
-#: src/ch04-01-what-is-ownership.md:213
-msgid "Copy Array data with Clone"
-msgstr ""
+msgstr "Şimdi, `A` kapsam dışına çıktığında, sözlüğü otomatik olarak `ezilecek` ve program derlenecek."
 
 #: src/ch04-01-what-is-ownership.md:215
-msgid ""
-"If we _do_ want to deeply copy the data of an `Array`, we can use a common "
-"method called `clone`. We’ll discuss method syntax in [Chapter "
-"5-3](ch05-03-method-syntax.md), but because methods are a common feature in "
-"many programming languages, you’ve probably seen them before."
-msgstr ""
+msgid "Copy Array data with Clone"
+msgstr "Clone ile Dizi Verilerini Kopyala"
 
 #: src/ch04-01-what-is-ownership.md:217
-msgid "Here’s an example of the `clone` method in action."
-msgstr ""
+msgid ""
+"If we _do_ want to deeply copy the data of an `Array`, we can use a common "
+"method called `clone`. We’ll discuss method syntax in Chapter 6, but because "
+"methods are a common feature in many programming languages, you’ve probably "
+"seen them before."
+msgstr "Bir `Array`'in verilerini derinlemesine kopyalamak istiyorsak, `clone` adında yaygın bir metod kullanabiliriz. Metod sözdizimini Bölüm 6'da tartışacağız, ancak metodlar birçok programlama dilinde yaygın bir özellik olduğu için, muhtemelen daha önce görmüşsünüzdür."
 
-#: src/ch04-01-what-is-ownership.md:226
+
+#: src/ch04-01-what-is-ownership.md:219
+msgid "Here’s an example of the `clone` method in action."
+msgstr "İşte `clone` metodunun eylemdeki bir örneği."
+
+
+#: src/ch04-01-what-is-ownership.md:228
 msgid ""
 "When you see a call to `clone`, you know that some arbitrary code is being "
 "executed and that code may be expensive. It’s a visual indicator that "
-"something different is going on. In this case, the _value_ `arr1` refers to "
-"is being copied, resulting in new memory cells being used, and a new "
-"_variable_ `arr2` is created, referring to the new copied value."
-msgstr ""
+"something different is going on. In this case, _value_ is being copied, "
+"resulting in new memory cells being used, and a new _variable_ is created, "
+"referring to the new, copied value."
+msgstr "`clone` çağrısını gördüğünüzde, bazı keyfi kodların çalıştırıldığını ve bu kodun pahalı olabileceğini biliyorsunuz. Bu, farklı bir şeylerin olduğunun görsel bir göstergesidir. Bu durumda, _değer_ kopyalanır, yeni bellek hücreleri kullanılır ve yeni, kopyalanan değere atıfta bulunan yeni bir _değişken_ oluşturulur."
 
-#: src/ch04-01-what-is-ownership.md:229
-msgid "Return Values and Scope"
-msgstr ""
 
 #: src/ch04-01-what-is-ownership.md:231
+msgid "Return Values and Scope"
+msgstr "Dönüş Değerleri ve Kapsam"
+
+
+#: src/ch04-01-what-is-ownership.md:233
 msgid ""
 "Returning values is equivalent to _moving_ them. Listing 4-2 shows an "
 "example of a function that returns some value, with similar annotations as "
 "those in Listing 4-1."
 msgstr ""
+"Değerleri döndürmek, onları _taşımak_ ile eşdeğerdir. Liste 4-2, benzer notasyonlarla bazı değerler döndüren bir fonksiyonun bir örneğini gösterir."
 
-#: src/ch04-01-what-is-ownership.md:242
+
+#: src/ch04-01-what-is-ownership.md:244
 msgid ""
 "// gives_ownership moves its return\n"
 "                                          // value into a1\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:245
+#: src/ch04-01-what-is-ownership.md:247
 msgid "// a2 comes into scope\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:247
+#: src/ch04-01-what-is-ownership.md:249
 msgid ""
 "// a2 is moved into\n"
 "                                          // takes_and_gives_back, which "
@@ -4249,46 +5475,54 @@ msgid ""
 "                                          // moves its return value into a3\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:251
+#: src/ch04-01-what-is-ownership.md:253
 msgid ""
 "// Here, a3 goes out of scope and is dropped. a2 was moved, so nothing\n"
 "  // happens. a1 goes out of scope and is dropped.\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:254
+#: src/ch04-01-what-is-ownership.md:256
 msgid ""
 "// gives_ownership will move its\n"
 "                                          // return value into the function\n"
 "                                          // that calls it\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:258 src/ch04-01-what-is-ownership.md:266
+#: src/ch04-01-what-is-ownership.md:260
 msgid "// some_a comes into scope\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:260
+#: src/ch04-01-what-is-ownership.md:262
 msgid ""
 "// some_a is returned and\n"
 "                                          // moves ownership to the calling\n"
 "                                          // function\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:264
+#: src/ch04-01-what-is-ownership.md:266
 msgid "// This function takes an instance some_a of A and returns it\n"
 msgstr ""
 
 #: src/ch04-01-what-is-ownership.md:268
+msgid ""
+"// some_a comes into\n"
+"                                          // scope\n"
+msgstr ""
+
+#: src/ch04-01-what-is-ownership.md:271
 msgid ""
 "// some_a is returned and \n"
 "                                          // moves ownership to the calling\n"
 "                                          // function\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:274
+#: src/ch04-01-what-is-ownership.md:277
 msgid "Listing 4-2: Moving return values"
-msgstr ""
+msgstr "Liste 4-3: Birden fazla değer döndürmek"
 
-#: src/ch04-01-what-is-ownership.md:276
+
+
+#: src/ch04-01-what-is-ownership.md:279
 msgid ""
 "While this works, moving into and out of every function is a bit tedious. "
 "What if we want to let a function use a value but not move the value? It’s "
@@ -4296,27 +5530,35 @@ msgid ""
 "want to use it again, in addition to any data resulting from the body of the "
 "function that we might want to return as well."
 msgstr ""
+"Bu işe yarasa da, her fonksiyona girip çıkmak biraz yorucu. Bir değeri bir fonksiyona kullanması için vermek ama değeri taşımamak istiyorsak ne olur? İstediğimiz her şeyi içeri vermek ve tekrar kullanmak istiyorsak geri vermek zorunda olmamız oldukça can sıkıcı, fonksiyonun gövdesinden kaynaklanan herhangi bir veriyi de döndürmek isteyebiliriz."
 
-#: src/ch04-01-what-is-ownership.md:278
+
+#: src/ch04-01-what-is-ownership.md:281
 msgid ""
 "Cairo does let us return multiple values using a tuple, as shown in Listing "
 "4-3."
 msgstr ""
+"Cairo bize bir demet kullanarak birden fazla değeri döndürme imkanı tanır, Liste 4-3'te gösterildiği gibi."
 
-#: src/ch04-01-what-is-ownership.md:290
+
+#: src/ch04-01-what-is-ownership.md:293
 msgid "// len() returns the length of an array\n"
 msgstr ""
 
-#: src/ch04-01-what-is-ownership.md:296
+#: src/ch04-01-what-is-ownership.md:299
 msgid "Listing 4-3: Returning many values"
 msgstr ""
+"Liste 4-3: Birden fazla değer döndürmek"
 
-#: src/ch04-01-what-is-ownership.md:298
+
+#: src/ch04-01-what-is-ownership.md:301
 msgid ""
 "But this is too much ceremony and a lot of work for a concept that should be "
 "common. Luckily for us, Cairo has two features for passing a value without "
 "destroying or moving it, called _references_ and _snapshots_."
 msgstr ""
+"Ama bu çok fazla tören ve olması gereken bir kavram için çok fazla iş. Neyse ki, Cairo bizim için bir değeri yok etmeden veya taşımadan geçirmek için _referanslar_ ve _anlık görüntüler_ adında iki özelliğe sahip."
+
 
 #: src/ch04-02-references-and-snapshots.md:3
 msgid ""
@@ -4325,10 +5567,12 @@ msgid ""
 "after the call to `calculate_length`, because the `Array` was moved into "
 "`calculate_length`."
 msgstr ""
+"Önceki Liste 4-3'teki demet kodunun sorunu, `calculate_length` çağrısından sonra `Array`'i hala kullanabilmemiz için `Array`'i çağıran fonksiyona geri döndürmemiz gerektiğidir, çünkü `Array` `calculate_length` içine taşınmıştı."
+
 
 #: src/ch04-02-references-and-snapshots.md:8
 msgid "Snapshots"
-msgstr ""
+msgstr "Anlık Görüntüler"
 
 #: src/ch04-02-references-and-snapshots.md:10
 msgid ""
@@ -4338,6 +5582,8 @@ msgid ""
 "convenient. Let's see how we can retain ownership of the variable in the "
 "calling function using snapshots."
 msgstr ""
+"Önceki bölümde, Cairo'nun sahiplik sisteminin, bir değişkeni taşıdıktan sonra onu kullanmamızı engelleyerek, aynı bellek hücresine potansiyel olarak iki kez yazmamızı önlediğinden bahsettik. Ancak, bu pek uygun değil. Çağıran fonksiyonda değişkenin sahipliğini anlık görüntüler kullanarak nasıl koruyabileceğimizi görelim."
+
 
 #: src/ch04-02-references-and-snapshots.md:15
 msgid ""
@@ -4347,6 +5593,8 @@ msgid ""
 "variables that refer to that \"old\" value. In this sense, snapshots are a "
 "view \"into the past\"."
 msgstr ""
+"Cairo'da, bir anlık görüntü, belirli bir zamandaki bir değerin değişmez bir görünümüdür. Belleğin değişmez olduğunu hatırlayın, bu yüzden bir değeri değiştirmek aslında yeni bir bellek hücresi oluşturur. Eski bellek hücresi hala var olur ve anlık görüntüler o \"eski\" değere atıfta bulunan değişkenlerdir. Bu anlamda, anlık görüntüler \"geçmişe bir bakış\"tır."
+
 
 #: src/ch04-02-references-and-snapshots.md:20
 msgid ""
@@ -4358,6 +5606,7 @@ msgid ""
 "the `calculate_length` function will not mutate the array, and ownership of "
 "the array is kept in the `main` function."
 msgstr ""
+"İşte, bir dizi görüntüsünü parametre olarak alarak altta yatan değerin sahipliğini almak yerine bir `calculate_length` fonksiyonunu nasıl tanımlayıp kullanacağınızı gösteren bir örnek. Bu örnekte, `calculate_length` fonksiyonu, parametre olarak geçirilen dizinin uzunluğunu döndürür. Bu, diziye bir görüntü olarak geçirdiğimiz için, diziye mutasyon uygulanmayacağından emin olabiliriz ve dizi sahipliği `main` fonksiyonunda tutulur."
 
 #: src/ch04-02-references-and-snapshots.md:31
 msgid "// Take a snapshot of `arr1` at this point in time\n"
@@ -4389,13 +5638,16 @@ msgid ""
 "Note: It is only possible to call the `len()` method on an array snapshot "
 "because it is defined as such in the `ArrayTrait` trait. If you try to call "
 "a method that is not defined for snapshots on a snapshot, you will get a "
-"compilation error. However, you can call methods expecting a snapshot on "
-"non-snapshot types."
+"compilation error. However, you can call methods expecting a snapshot on non-"
+"snapshot types."
 msgstr ""
+"Not: Anlık görüntü üzerinde `len()` metodunu çağırabilmemizin nedeni, `ArrayTrait` özelliğinde bu şekilde tanımlanmış olmasıdır. Anlık görüntüler için tanımlanmamış bir metodu anlık görüntü üzerinde çağırmayı denerseniz, bir derleme hatası alırsınız. Ancak, anlık görüntü bekleyen metodları anlık görüntü olmayan tipler üzerinde çağırabilirsiniz."
+
 
 #: src/ch04-02-references-and-snapshots.md:48
 msgid "The output of this program is:"
-msgstr ""
+msgstr "Bu programın çıktısı:"
+
 
 #: src/ch04-02-references-and-snapshots.md:56
 msgid ""
@@ -4404,10 +5656,13 @@ msgid ""
 "`calculate_length` and, in its definition, we take `@Array<u128>` rather "
 "than `Array<u128>`."
 msgstr ""
+"İlk olarak, değişken tanımı ve fonksiyon dönüş değerindeki tüm demet kodunun gittiğini fark edin. İkinci olarak, `@arr1`'i `calculate_length`'e geçirdiğimizi ve tanımında `Array<u128>` yerine `@Array<u128>` aldığımızı not edin."
+
 
 #: src/ch04-02-references-and-snapshots.md:59
 msgid "Let’s take a closer look at the function call here:"
-msgstr ""
+msgstr "Fonksiyon çağrısına burada daha yakından bakalım:"
+
 
 #: src/ch04-02-references-and-snapshots.md:65
 msgid ""
@@ -4417,12 +5672,16 @@ msgid ""
 "snapshot variables always implement the `Drop` trait, never the `Destruct` "
 "trait, even dictionary snapshots."
 msgstr ""
+"`@arr1` sözdizimi, `arr1`'deki değerin bir anlık görüntüsünü oluşturmamıza olanak tanır. Bir anlık görüntü, belirli bir zamandaki bir değerin değişmez bir görünümü olduğundan, doğrusal tip sisteminin normal kuralları uygulanmaz. Özellikle, anlık görüntü değişkenleri her zaman `Drop` özelliğini uygular, `Destruct` özelliğini asla uygulamaz, hatta sözlük anlık görüntüleri bile."
+
 
 #: src/ch04-02-references-and-snapshots.md:67
 msgid ""
 "Similarly, the signature of the function uses `@` to indicate that the type "
 "of the parameter `arr` is a snapshot. Let’s add some explanatory annotations:"
 msgstr ""
+"Benzer şekilde, fonksiyonun imzası `@` kullanılarak parametre `arr`'in tipinin bir anlık görüntü olduğunu belirtir. Açıklayıcı notlar ekleyelim:"
+
 
 #: src/ch04-02-references-and-snapshots.md:71
 msgid "// array_snapshot is a snapshot of an Array\n"
@@ -4444,16 +5703,21 @@ msgid ""
 "return the values in order to give back ownership of the original value, "
 "because we never had it."
 msgstr ""
+"Değişken `array_snapshot`'ın geçerli olduğu kapsam, herhangi bir fonksiyon parametresinin kapsamı ile aynıdır, ancak `array_snapshot` kullanılmayı bıraktığında anlık görüntünün altındaki değer bırakılmaz. Fonksiyonların parametreleri olarak gerçek değerler yerine anlık görüntüler varsa, orijinal değerin sahipliğini geri vermek için değerleri döndürmemize gerek kalmaz, çünkü zaten sahip olmamışızdır."
+
 
 #: src/ch04-02-references-and-snapshots.md:80
 msgid "Desnap Operator"
-msgstr ""
+msgstr "Desnap Operatörü"
+
 
 #: src/ch04-02-references-and-snapshots.md:82
 msgid ""
 "To convert a snapshot back into a regular variable, you can use the `desnap` "
 "operator `*`, which serves as the opposite of the `@` operator."
 msgstr ""
+"Bir anlık görüntüyü normal bir değişkene geri dönüştürmek için, `@` operatörünün tersi olarak hizmet veren `desnap` operatörü `*` kullanılabilir."
+
 
 #: src/ch04-02-references-and-snapshots.md:84
 msgid ""
@@ -4462,6 +5726,8 @@ msgid ""
 "reuses the old value, and so desnapping is a completely free operation, just "
 "like `Copy`."
 msgstr ""
+"Yalnızca `Copy` tipleri desnap edilebilir. Ancak, genel olarak, değer değiştirilmediğinden, `desnap` operatörü tarafından oluşturulan yeni değişken eski değeri yeniden kullanır ve bu nedenle desnapping tamamen ücretsiz bir işlemdir, tıpkı `Copy` gibi."
+
 
 #: src/ch04-02-references-and-snapshots.md:86
 msgid ""
@@ -4472,8 +5738,12 @@ msgid ""
 "can pass the snapshot of the rectangle to the function, and then transform "
 "the snapshots back into values using the `desnap` operator `*`."
 msgstr ""
+"Aşağıdaki örnekte, bir dikdörtgenin alanını hesaplamak istiyoruz, ancak `calculate_area` fonksiyonunda dikdörtgenin sahipliğini almak istemiyoruz, çünkü fonksiyon çağrısından sonra dikdörtgeni tekrar kullanmak isteyebiliriz. Fonksiyonumuz dikdörtgen örneğini değiştirmediğinden, fonksiyona dikdörtgenin anlık görüntüsünü geçirebilir ve sonra anlık görüntüleri `desnap` operatörü `*` kullanarak değerlere geri dönüştürebiliriz."
+
 
 #: src/ch04-02-references-and-snapshots.md:98
+#: src/ch05-02-an-example-program-using-structs.md:84
+#: src/ch05-03-method-syntax.md:40
 msgid "\"Area: {}\""
 msgstr ""
 
@@ -4494,22 +5764,28 @@ msgid ""
 "But, what happens if we try to modify something we’re passing as a snapshot? "
 "Try the code in Listing 4-4. Spoiler alert: it doesn’t work!"
 msgstr ""
+"Bir anlık görüntü olarak geçirdiğimiz bir şeyi değiştirmeyi denediğimizde ne olur? Liste 4-4'teki kodu deneyin. Spoiler uyarısı: işe yaramaz!"
+
 
 #: src/ch04-02-references-and-snapshots.md:134
 msgid "Listing 4-4: Attempting to modify a snapshot value"
-msgstr ""
+msgstr "Liste 4-4: Bir anlık görüntü değerini değiştirmeye çalışmak"
+
 
 #: src/ch04-02-references-and-snapshots.md:136
 msgid "Here’s the error:"
-msgstr ""
+msgstr "İşte hata:"
+
 
 #: src/ch04-02-references-and-snapshots.md:145
 msgid "The compiler prevents us from modifying values associated to snapshots."
-msgstr ""
+msgstr "Derleyici, anlık görüntülere bağlı değerlerin değiştirilmesini engeller."
+
 
 #: src/ch04-02-references-and-snapshots.md:147
 msgid "Mutable References"
-msgstr ""
+msgstr "Değiştirilebilir Referanslar"
+
 
 #: src/ch04-02-references-and-snapshots.md:149
 msgid ""
@@ -4521,12 +5797,16 @@ msgid ""
 "returning it automatically at the end of the execution. In Cairo, a "
 "parameter can be passed as _mutable reference_ using the `ref` modifier."
 msgstr ""
+"Liste 4-4'teki istediğimiz davranışı, bir anlık görüntü yerine _değiştirilebilir bir referans_ kullanarak elde edebiliriz. Değiştirilebilir referanslar, aslında bir fonksiyona geçirilen ve fonksiyonun sonunda implisit olarak geri döndürülen değiştirilebilir değerlerdir, sahipliği çağrı yapan bağlama geri döndürür. Bunu yaparak, değeri geçirirken değiştirmenize izin verirler ve yürütmenin sonunda otomatik olarak geri döndürerek onun sahipliğini korumanızı sağlarlar. Cairo'da, bir parametre _değiştirilebilir referans_ olarak `ref` değiştiricisi kullanılarak geçirilebilir."
+
 
 #: src/ch04-02-references-and-snapshots.md:152
 msgid ""
 "**Note**: In Cairo, a parameter can only be passed as _mutable reference_ "
 "using the `ref` modifier if the variable is declared as mutable with `mut`."
 msgstr ""
+"**Not**: Cairo'da, bir parametre yalnızca `ref` değiştiricisi kullanılarak _değiştirilebilir referans_ olarak geçirilebilir, eğer değişken `mut` ile değiştirilebilir olarak tanımlanmışsa."
+
 
 #: src/ch04-02-references-and-snapshots.md:154
 msgid ""
@@ -4534,6 +5814,8 @@ msgid ""
 "`height` and `width` fields of the `Rectangle` instance in the `flip` "
 "function."
 msgstr ""
+"Liste 4-5'te, `flip` fonksiyonunda `Rectangle` örneğinin `height` ve `width` alanlarının değerini değiştirmek için değiştirilebilir bir referans kullanıyoruz."
+
 
 #: src/ch04-02-references-and-snapshots.md:166
 msgid "\"height: {}, width: {}\""
@@ -4542,6 +5824,8 @@ msgstr ""
 #: src/ch04-02-references-and-snapshots.md:176
 msgid "Listing 4-5: Use of a mutable reference to modify a value"
 msgstr ""
+"Liste 4-5: Bir değeri değiştirmek için değiştirilebilir bir referans kullanımı"
+
 
 #: src/ch04-02-references-and-snapshots.md:178
 msgid ""
@@ -4551,53 +5835,70 @@ msgid ""
 "clear that the `flip` function will mutate the value of the `Rectangle` "
 "instance passed as parameter."
 msgstr ""
+"Öncelikle, `rec`'i `mut` olarak değiştiriyoruz. Sonra `rec`'in değiştirilebilir bir referansını `ref rec` ile `flip`'e geçiriyoruz ve fonksiyon imzasını `ref rec: Rectangle` ile değiştirilebilir bir referansı kabul edecek şekilde güncelliyoruz. Bu, `flip` fonksiyonunun parametre olarak geçirilen `Rectangle` örneğinin değerini değiştireceğini çok açık hale getirir."
+
 
 #: src/ch04-02-references-and-snapshots.md:180
 msgid "The output of the program is:"
-msgstr ""
+msgstr "Programın çıktısı:"
+
 
 #: src/ch04-02-references-and-snapshots.md:187
 msgid ""
 "As expected, the `height` and `width` fields of the `rec` variable have been "
 "swapped."
 msgstr ""
+"Beklendiği gibi, `rec` değişkeninin `height` ve `width` alanları yer değiştirdi."
+
 
 #: src/ch04-02-references-and-snapshots.md:189
 msgid "Small recap"
-msgstr ""
+msgstr "Küçük bir özet"
+
 
 #: src/ch04-02-references-and-snapshots.md:191
 msgid ""
 "Let’s recap what we’ve discussed about the linear type system, ownership, "
 "snapshots, and references:"
 msgstr ""
+"Doğrusal tip sistemi, sahiplik, anlık görüntüler ve referanslar hakkında tartıştığımız konuları özetleyelim:"
+
 
 #: src/ch04-02-references-and-snapshots.md:193
 msgid "At any given time, a variable can only have one owner."
-msgstr ""
+msgstr "Herhangi bir zamanda, bir değişkenin yalnızca bir sahibi olabilir."
+
 
 #: src/ch04-02-references-and-snapshots.md:194
 msgid ""
 "You can pass a variable by-value, by-snapshot, or by-reference to a function."
 msgstr ""
+"Bir değişkeni bir fonksiyona değer-olarak, anlık görüntü-olarak veya referans-olarak geçirebilirsiniz."
+
 
 #: src/ch04-02-references-and-snapshots.md:195
 msgid ""
 "If you pass-by-value, ownership of the variable is transferred to the "
 "function."
 msgstr ""
+"Değer-olarak geçirirseniz, değişkenin sahipliği fonksiyona aktarılır."
+
 
 #: src/ch04-02-references-and-snapshots.md:196
 msgid ""
 "If you want to keep ownership of the variable and know that your function "
 "won’t mutate it, you can pass it as a snapshot with `@`."
 msgstr ""
+"Değişkenin sahipliğini korumak ve fonksiyonunuzun onu değiştirmeyeceğini bilmek istiyorsanız, `@` ile bir anlık görüntü olarak geçirebilirsiniz."
+
 
 #: src/ch04-02-references-and-snapshots.md:197
 msgid ""
 "If you want to keep ownership of the variable and know that your function "
 "will mutate it, you can pass it as a mutable reference with `ref`."
 msgstr ""
+"Değişkenin sahipliğini korumak ve fonksiyonunuzun onu değiştireceğini bilmek istiyorsanız, `ref` ile değiştirilebilir bir referans olarak geçirebilirsiniz."
+
 
 #: src/ch05-00-using-structs-to-structure-related-data.md:3
 msgid ""
@@ -4608,27 +5909,33 @@ msgid ""
 "to build on what you already know and demonstrate when structs are a better "
 "way to group data."
 msgstr ""
+"Bir struct, veya yapı, birden fazla ilgili değeri bir araya getirip adlandırmanıza olanak tanıyan özel bir veri tipidir. Eğer nesne yönelimli bir dil ile tanıdıksanız, bir struct bir nesnenin veri özelliklerine benzer. Bu bölümde, struct'ları tuple'lar ile karşılaştırıp kontrast oluşturarak bildikleriniz üzerine inşa edeceğiz ve struct'ların veriyi gruplamak için ne zaman daha iyi bir yol olduğunu göstereceğiz."
+
 
 #: src/ch05-00-using-structs-to-structure-related-data.md:5
 msgid ""
 "We’ll demonstrate how to define and instantiate structs. We’ll discuss how "
 "to define associated functions, especially the kind of associated functions "
 "called methods, to specify behavior associated with a struct type. Structs "
-"and enums (discussed in the [next chapter](ch06-01-enums.md)) are the "
-"building blocks for creating new types in your program’s domain to take full "
-"advantage of Cairo's compile-time type checking."
+"and enums (discussed in the next chapter) are the building blocks for "
+"creating new types in your program’s domain to take full advantage of "
+"Cairo's compile-time type checking."
 msgstr ""
+"Struct'ları nasıl tanımlayıp oluşturacağımızı göstereceğiz. Bir struct türü ile ilişkilendirilmiş davranışları belirtmek için, özellikle metodlar olarak adlandırılan türdeki ilişkilendirilmiş fonksiyonları nasıl tanımlayacağımızı tartışacağız. Struct'lar ve enum'lar (bir sonraki bölümde tartışılacak), programınızın alanında yeni tipler oluşturmak için yapı taşlarıdır ve Cairo'nun derleme zamanı tip kontrolünden tam olarak yararlanmak için."
+
 
 #: src/ch05-01-defining-and-instantiating-structs.md:3
 msgid ""
-"Structs are similar to tuples, discussed in the [Data "
-"Types](ch02-02-data-types.md) section, in that both hold multiple related "
-"values. Like tuples, the pieces of a struct can be different types. Unlike "
-"with tuples, in a struct you’ll name each piece of data so it’s clear what "
-"the values mean. Adding these names means that structs are more flexible "
-"than tuples: you don’t have to rely on the order of the data to specify or "
-"access the values of an instance."
+"Structs are similar to tuples, discussed in the [Data Types](ch02-02-data-"
+"types.md) section, in that both hold multiple related values. Like tuples, "
+"the pieces of a struct can be different types. Unlike with tuples, in a "
+"struct you’ll name each piece of data so it’s clear what the values mean. "
+"Adding these names means that structs are more flexible than tuples: you "
+"don’t have to rely on the order of the data to specify or access the values "
+"of an instance."
 msgstr ""
+"Struct'lar, [Veri Tipleri](ch02-02-data-types.md) bölümünde tartışılan tuple'lar gibi, birden fazla ilgili değeri tutar. Tuple'lar gibi, bir struct'ın parçaları farklı tiplerde olabilir. Tuple'lar ile farklı olarak, bir struct'ta her bir veri parçasını adlandırırsınız, böylece değerlerin ne anlama geldiği açıktır. Bu adları eklemek, struct'ları tuple'lardan daha esnek hale getirir: bir örneğin değerlerini belirtmek veya erişmek için veri sırasına bağımlı olmanıza gerek yoktur."
+
 
 #: src/ch05-01-defining-and-instantiating-structs.md:5
 msgid ""
@@ -4638,10 +5945,13 @@ msgid ""
 "names and types of the pieces of data, which we call fields. For example, "
 "Listing 5-1 shows a struct that stores information about a user account."
 msgstr ""
+"Bir struct tanımlamak için, `struct` anahtar kelimesini girer ve tüm struct'ı adlandırırız. Bir struct'ın adı, bir araya getirilen veri parçalarının önemini açıklamalıdır. Sonra, süslü parantezler içinde, alanları adlandırırız ve veri parçalarının adlarını ve tiplerini tanımlarız. Örneğin, Liste 5-1 bir kullanıcı hesabı hakkında bilgi depolayan bir struct'ı gösterir."
+
 
 #: src/ch05-01-defining-and-instantiating-structs.md:19
 msgid "Listing 5-1: A `User` struct definition"
-msgstr ""
+msgstr "Liste 5-1: Bir `User` struct tanımı"
+
 
 #: src/ch05-01-defining-and-instantiating-structs.md:21
 msgid ""
@@ -4655,54 +5965,69 @@ msgid ""
 "the type, and instances fill in that template with particular data to create "
 "values of the type."
 msgstr ""
+"Bir struct'ı tanımladıktan sonra kullanmak için, her bir alan için somut değerler belirterek o struct'ın bir _örneğini_ oluştururuz. Bir örneği oluşturmak için, struct'ın adını belirtir ve sonra _anahtar: değer_ çiftleri içeren süslü parantezler ekleriz, burada anahtarlar alanların adlarıdır ve değerler, bu alanlarda saklamak istediğimiz verilerdir. Struct'ta tanımladığımız sırayla aynı sırada alanları belirtmek zorunda değiliz. Diğer bir deyişle, struct tanımı, tip için genel bir şablon gibidir ve örnekler, belirli verilerle o şablonu doldurarak tipin değerlerini oluşturur."
+
 
 #: src/ch05-01-defining-and-instantiating-structs.md:24
-msgid "For example, we can declare two particular users as shown in Listing 5-2."
-msgstr ""
+msgid "For example, we can declare a particular user as shown in Listing 5-2."
+msgstr "Örneğin, Liste 5-2'de gösterildiği gibi belirli bir kullanıcıyı beyan edebiliriz."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:47
-msgid "Listing 5-2: Creating two instances of the `User` struct"
-msgstr ""
 
-#: src/ch05-01-defining-and-instantiating-structs.md:49
+#: src/ch05-01-defining-and-instantiating-structs.md:44
+msgid "Listing 5-2: Creating an instance of the `User` struct"
+msgstr "Liste 5-2: `User` struct'ının bir örneğini oluşturmak"
+
+
+#: src/ch05-01-defining-and-instantiating-structs.md:46
 msgid ""
 "To get a specific value from a struct, we use dot notation. For example, to "
-"access `user1`'s email address, we use `user1.email`. If the instance is "
+"access this user’s email address, we use `user1.email`. If the instance is "
 "mutable, we can change a value by using the dot notation and assigning into "
 "a particular field. Listing 5-3 shows how to change the value in the `email` "
 "field of a mutable `User` instance."
 msgstr ""
+"Bir struct'tan belirli bir değeri almak için nokta notasyonunu kullanırız. Örneğin, bu kullanıcının e-posta adresine erişmek için `user1.email` kullanırız. Örnek değiştirilebilir ise, nokta notasyonunu kullanarak belirli bir alandaki bir değeri değiştirebiliriz. Liste 5-3, değiştirilebilir bir `User` örneğindeki `email` alanındaki değeri nasıl değiştireceğinizi gösterir."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:79
+
+#: src/ch05-01-defining-and-instantiating-structs.md:76
 msgid "Listing 5-3: Changing the value in the email field of a `User` instance"
-msgstr ""
+msgstr "Liste 5-3: Bir `User` örneğindeki email alanındaki değeri değiştirme"
 
-#: src/ch05-01-defining-and-instantiating-structs.md:81
+
+#: src/ch05-01-defining-and-instantiating-structs.md:78
 msgid ""
 "Note that the entire instance must be mutable; Cairo doesn’t allow us to "
 "mark only certain fields as mutable."
 msgstr ""
+"Tüm örneğin değiştirilebilir olması gerektiğini unutmayın; Cairo, belirli alanların değiştirilebilir olarak işaretlenmesine izin vermez."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:83
+
+#: src/ch05-01-defining-and-instantiating-structs.md:80
 msgid ""
 "As with any expression, we can construct a new instance of the struct as the "
 "last expression in the function body to implicitly return that new instance."
 msgstr ""
+"Herhangi bir ifade gibi, fonksiyon gövdesinin son ifadesi olarak struct'ın yeni bir örneğini oluşturarak bu yeni örneği dolaylı olarak döndürebiliriz."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:85
+
+#: src/ch05-01-defining-and-instantiating-structs.md:82
 msgid ""
 "Listing 5-4 shows a `build_user` function that returns a `User` instance "
 "with the given email and username. The `active` field gets the value of "
 "`true`, and the `sign_in_count` gets a value of `1`."
 msgstr ""
+"Liste 5-4, verilen e-posta ve kullanıcı adı ile bir `User` örneği döndüren bir `build_user` fonksiyonunu gösterir. `active` alanı `true` değerini alır ve `sign_in_count` alanı `1` değerini alır."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:115
+
+#: src/ch05-01-defining-and-instantiating-structs.md:112
 msgid ""
 "Listing 5-4: A `build_user` function that takes an email and username and "
 "returns a `User` instance"
 msgstr ""
+"Liste 5-4: Bir e-posta ve kullanıcı adı alan ve bir `User` örneği döndüren bir `build_user` fonksiyonu"
 
-#: src/ch05-01-defining-and-instantiating-structs.md:117
+
+#: src/ch05-01-defining-and-instantiating-structs.md:114
 msgid ""
 "It makes sense to name the function parameters with the same name as the "
 "struct fields, but having to repeat the `email` and `username` field names "
@@ -4710,26 +6035,33 @@ msgid ""
 "each name would get even more annoying. Luckily, there’s a convenient "
 "shorthand!"
 msgstr ""
+"Fonksiyon parametrelerinin adını struct alanları ile aynı adlandırmak mantıklıdır, ancak `email` ve `username` alan adlarını ve değişkenleri tekrar etmek biraz yorucudur. Struct daha fazla alana sahip olsaydı, her adı tekrar etmek daha da can sıkıcı olurdu. Neyse ki, kullanışlı bir kısayol var!"
 
-#: src/ch05-01-defining-and-instantiating-structs.md:119
+
+#: src/ch05-01-defining-and-instantiating-structs.md:116
 msgid "Using the Field Init Shorthand"
-msgstr ""
+msgstr "Alan Başlatma Kısayolu Kullanımı"
 
-#: src/ch05-01-defining-and-instantiating-structs.md:121
+
+#: src/ch05-01-defining-and-instantiating-structs.md:118
 msgid ""
 "Because the parameter names and the struct field names are exactly the same "
 "in Listing 5-4, we can use the field init shorthand syntax to rewrite "
 "`build_user` so it behaves exactly the same but doesn’t have the repetition "
 "of `username` and `email`, as shown in Listing 5-5."
 msgstr ""
+"Liste 5-4'te parametre adları ile struct alan adları tam olarak aynı olduğu için, `build_user`'ı tam olarak aynı davranışı göstermek üzere yeniden yazmak için alan başlatma kısayol sözdizimini kullanabiliriz, böylece `username` ve `email` tekrarını ortadan kaldırabiliriz, Liste 5-5'te gösterildiği gibi."
 
-#: src/ch05-01-defining-and-instantiating-structs.md:151
+
+#: src/ch05-01-defining-and-instantiating-structs.md:148
 msgid ""
 "Listing 5-5: A `build_user` function that uses field init shorthand because "
 "the `username` and `email` parameters have the same name as struct fields"
 msgstr ""
+"Liste 5-5: `username` ve `email` parametrelerinin struct alanları ile aynı adı taşıdığı için alan başlatma kısayolunu kullanan bir `build_user` fonksiyonu"
 
-#: src/ch05-01-defining-and-instantiating-structs.md:153
+
+#: src/ch05-01-defining-and-instantiating-structs.md:150
 msgid ""
 "Here, we’re creating a new instance of the `User` struct, which has a field "
 "named `email`. We want to set the `email` field’s value to the value in the "
@@ -4737,6 +6069,8 @@ msgid ""
 "and the `email` parameter have the same name, we only need to write `email` "
 "rather than `email: email`."
 msgstr ""
+"Burada, `email` adında bir alanı olan `User` struct'ının yeni bir örneğini oluşturuyoruz. `email` alanının değerini `build_user` fonksiyonunun `email` parametresindeki değere ayarlamak istiyoruz. `email` alanı ve `email` parametresi aynı adı taşıdığı için, `email: email` yerine yalnızca `email` yazmamız yeterlidir."
+
 
 #: src/ch05-02-an-example-program-using-structs.md:3
 msgid ""
@@ -4744,6 +6078,8 @@ msgid ""
 "calculates the area of a rectangle. We’ll start by using single variables, "
 "and then refactor the program until we’re using structs instead."
 msgstr ""
+"Struct'ları kullanmak isteyebileceğimiz durumları anlamak için, bir dikdörtgenin alanını hesaplayan bir program yazalım. Tek değişkenler kullanarak başlayacak ve programı struct'ları kullanacak şekilde yeniden düzenleyene kadar devam edeceğiz."
+
 
 #: src/ch05-02-an-example-program-using-structs.md:5
 msgid ""
@@ -4752,11 +6088,11 @@ msgid ""
 "of the rectangle. Listing 5-6 shows a short program with one way of doing "
 "exactly that in our project’s _src/lib.cairo_."
 msgstr ""
+"Scarb ile _rectangles_ adında yeni bir proje yapalım ki bu, pikseller cinsinden belirtilen bir dikdörtgenin genişliğini ve yüksekliğini alıp dikdörtgenin alanını hesaplasın. Liste 5-6, projemizin _src/lib.cairo_'sında tam olarak bunu yapan kısa bir programı gösterir."
+
 
 #: src/ch05-02-an-example-program-using-structs.md:15
-#: src/ch05-02-an-example-program-using-structs.md:53
-#: src/ch05-02-an-example-program-using-structs.md:83
-#: src/ch05-03-method-syntax.md:40
+#: src/ch05-02-an-example-program-using-structs.md:54
 msgid "\"Area is {}\""
 msgstr ""
 
@@ -4765,54 +6101,70 @@ msgid ""
 "Listing 5-6: Calculating the area of a rectangle specified by separate width "
 "and height variables"
 msgstr ""
+"Liste 5-6: Ayrı genişlik ve yükseklik değişkenleriyle belirtilen bir dikdörtgenin alanını hesaplama"
+
 
 #: src/ch05-02-an-example-program-using-structs.md:25
-msgid "Now run the program with `scarb cairo-run`:"
-msgstr ""
+msgid "Now run the program with `scarb cairo-run --available-gas=200000000`:"
+msgstr "Şimdi programı `scarb cairo-run --available-gas=200000000` ile çalıştırın:"
 
-#: src/ch05-02-an-example-program-using-structs.md:33
+
+
+#: src/ch05-02-an-example-program-using-structs.md:34
 msgid ""
 "This code succeeds in figuring out the area of the rectangle by calling the "
 "`area` function with each dimension, but we can do more to make this code "
 "clear and readable."
 msgstr ""
+"Bu kod, her boyutu `area` fonksiyonu ile çağırarak dikdörtgenin alanını bulmayı başarır, ancak bu kodu daha net ve okunabilir hale getirmek için daha fazlasını yapabiliriz."
 
-#: src/ch05-02-an-example-program-using-structs.md:35
+
+
+#: src/ch05-02-an-example-program-using-structs.md:36
 msgid "The issue with this code is evident in the signature of `area`:"
-msgstr ""
+msgstr "Bu kodun sorunu, `area` fonksiyonunun imzasında açıktır:"
 
-#: src/ch05-02-an-example-program-using-structs.md:41
+
+#: src/ch05-02-an-example-program-using-structs.md:42
 msgid ""
 "The `area` function is supposed to calculate the area of one rectangle, but "
 "the function we wrote has two parameters, and it’s not clear anywhere in our "
 "program that the parameters are related. It would be more readable and more "
 "manageable to group width and height together. We’ve already discussed one "
-"way we might do that in the [tuple section of Chapter "
-"2](ch02-02-data-types.html#the-tuple-type)."
+"way we might do that in [Chapter 2](ch02-02-data-types.html#the-tuple-type): "
+"using tuples."
 msgstr ""
+"`area` fonksiyonunun bir dikdörtgenin alanını hesaplaması gerekiyor, ancak yazdığımız fonksiyonun iki parametresi var ve programımızda bu parametrelerin ilgili olduğu hiçbir yerde açık değil. Genişliği ve yüksekliği bir arada gruplamanın daha okunabilir ve daha yönetilebilir olacağı açıktır. Bunu nasıl yapabileceğimizi [Bölüm 2](ch02-02-data-types.html#the-tuple-type)'de zaten tartışmıştık: tuple'ları kullanarak."
 
-#: src/ch05-02-an-example-program-using-structs.md:43
+
+#: src/ch05-02-an-example-program-using-structs.md:44
 msgid "Refactoring with Tuples"
-msgstr ""
+msgstr "Tuple'larla Yeniden Düzenleme"
 
-#: src/ch05-02-an-example-program-using-structs.md:45
+
+#: src/ch05-02-an-example-program-using-structs.md:46
 msgid "Listing 5-7 shows another version of our program that uses tuples."
-msgstr ""
+msgstr "Liste 5-7, programımızın tuple'ları kullanan başka bir versiyonunu gösterir."
 
-#: src/ch05-02-an-example-program-using-structs.md:62
+
+#: src/ch05-02-an-example-program-using-structs.md:63
 msgid ""
 "Listing 5-7: Specifying the width and height of the rectangle with a tuple"
 msgstr ""
+"Liste 5-7: Dikdörtgenin genişliğini ve yüksekliğini bir tuple ile belirtme"
 
-#: src/ch05-02-an-example-program-using-structs.md:64
+
+#: src/ch05-02-an-example-program-using-structs.md:65
 msgid ""
 "In one way, this program is better. Tuples let us add a bit of structure, "
 "and we’re now passing just one argument. But in another way, this version is "
 "less clear: tuples don’t name their elements, so we have to index into the "
 "parts of the tuple, making our calculation less obvious."
 msgstr ""
+"Bir yönden, bu program daha iyi. Tuple'lar biraz yapı eklememize izin verir ve artık sadece bir argüman geçiriyoruz. Ancak başka bir yönden, bu versiyon daha az açık: tuple'lar elemanlarını adlandırmaz, bu yüzden tuple'ın parçalarına indeksle erişmemiz gerekiyor, bu da hesaplamamızı daha az açık hale getiriyor."
 
-#: src/ch05-02-an-example-program-using-structs.md:66
+
+#: src/ch05-02-an-example-program-using-structs.md:67
 msgid ""
 "Mixing up the width and height wouldn’t matter for the area calculation, but "
 "if we want to calculate the difference, it would matter! We would have to "
@@ -4821,23 +6173,29 @@ msgid ""
 "in mind if they were to use our code. Because we haven’t conveyed the "
 "meaning of our data in our code, it’s now easier to introduce errors."
 msgstr ""
+"Genişliği ve yüksekliği karıştırmak alan hesaplaması için önemli olmaz, ancak farkı hesaplamak isteseydik önemli olurdu! `width`'ın tuple indeksi `0` ve `height`'ın tuple indeksi `1` olduğunu aklımızda tutmamız gerekirdi. Kodumuzu kullanacak başka biri için bu, anlaması ve aklında tutması daha zor olurdu. Verilerimizin anlamını kodumuzda iletemediğimiz için, hataları daha kolaylıkla tanıtmak şimdi daha kolay."
 
-#: src/ch05-02-an-example-program-using-structs.md:68
+
+#: src/ch05-02-an-example-program-using-structs.md:69
 msgid "Refactoring with Structs: Adding More Meaning"
-msgstr ""
+msgstr "Struct'larla Yeniden Düzenleme: Daha Fazla Anlam Katma"
 
-#: src/ch05-02-an-example-program-using-structs.md:70
+
+#: src/ch05-02-an-example-program-using-structs.md:71
 msgid ""
 "We use structs to add meaning by labeling the data. We can transform the "
 "tuple we’re using into a struct with a name for the whole as well as names "
 "for the parts."
 msgstr ""
+"Verilere anlam katmak için struct'ları kullanıyoruz. Kullandığımız tuple'ı hem bütün hem de parçalar için adlarla bir struct'a dönüştürebiliriz."
 
-#: src/ch05-02-an-example-program-using-structs.md:91
+
+#: src/ch05-02-an-example-program-using-structs.md:92
 msgid "Listing 5-8: Defining a `Rectangle` struct"
-msgstr ""
+msgstr "Liste 5-8: Bir `Rectangle` struct'ını tanımlama"
 
-#: src/ch05-02-an-example-program-using-structs.md:93
+
+#: src/ch05-02-an-example-program-using-structs.md:94
 msgid ""
 "Here we’ve defined a struct and named it `Rectangle`. Inside the curly "
 "brackets, we defined the fields as `width` and `height`, both of which have "
@@ -4848,51 +6206,70 @@ msgid ""
 "notation, and it gives descriptive names to the values rather than using the "
 "tuple index values of `0` and `1`."
 msgstr ""
+"Burada bir struct tanımladık ve ona `Rectangle` adını verdik. Süslü parantezlerin içinde, `width` ve `height` olarak tanımlanan alanları, her ikisi de `u64` tipinde. Sonra, `main`'de `width`'ı `30` ve `height`'ı `10` olan `Rectangle`'ın belirli bir örneğini oluşturduk. `area` fonksiyonumuz artık bir parametre ile tanımlanıyor, bu parametreyi `rectangle` olarak adlandırdık ve tipi `Rectangle` struct'ı. Sonra örneğin alanlarına nokta notasyonu ile erişebiliriz ve `0` ve `1` tuple indeks değerlerini kullanmak yerine değerlere açıklayıcı adlar verir."
 
-#: src/ch05-02-an-example-program-using-structs.md:95
+
+#: src/ch05-02-an-example-program-using-structs.md:96
 msgid "Adding Useful Functionality with Trait"
-msgstr ""
+msgstr "Yararlı Fonksiyonellik Eklemek İçin Trait Kullanma"
 
-#: src/ch05-02-an-example-program-using-structs.md:97
+
+#: src/ch05-02-an-example-program-using-structs.md:98
 msgid ""
 "It’d be useful to be able to print an instance of `Rectangle` while we’re "
 "debugging our program and see the values for all its fields. Listing 5-9 "
-"tries to print `rectangle` using the `print` function. This won’t work."
+"tries using the `print` as we have used in previous chapters. This won’t "
+"work."
 msgstr ""
+"`Rectangle` örneğini programımızı hata ayıklarken yazdırabilmek ve tüm alanlarının değerlerini görebilmek yararlı olurdu. Liste 5-9, önceki bölümlerde kullandığımız gibi `print` kullanmayı dener. Bu işe yaramaz."
+
 
 #: src/ch05-02-an-example-program-using-structs.md:118
 msgid "Listing 5-9: Attempting to print a `Rectangle` instance"
-msgstr ""
+msgstr "Liste 5-9: Bir `Rectangle` örneğini yazdırmaya çalışma"
+
 
 #: src/ch05-02-an-example-program-using-structs.md:120
 msgid "When we compile this code, we get an error with this message:"
+msgstr "Bu kodu derlediğimizde, bu mesajla bir hata alırız:"
+
+
+#: src/ch05-02-an-example-program-using-structs.md:122
+msgid ""
+"```text\n"
+"$ cairo-compile src/lib.cairo\n"
+"error: Method `print` not found on type \"../src::Rectangle\". Did you "
+"import the correct trait and impl?\n"
+" --> lib.cairo:16:15\n"
+"    rectangle.print();\n"
+"              ^***^\n"
+"\n"
+"Error: Compilation failed.\n"
+"```"
 msgstr ""
 
-#: src/ch05-02-an-example-program-using-structs.md:133
+#: src/ch05-02-an-example-program-using-structs.md:132
 msgid ""
-"The `PrintTrait` trait is implemented for many data types, but not for the "
+"The `print` trait is implemented for many data types, but not for the "
 "`Rectangle` struct. We can fix this by implementing the `PrintTrait` trait "
 "on `Rectangle` as shown in Listing 5-10. To learn more about traits, see "
 "[Traits in Cairo](ch08-02-traits-in-cairo.md)."
 msgstr ""
+"`print` trait birçok veri tipi için uygulanmıştır, ancak `Rectangle` struct'ı için değil. `Rectangle` üzerinde `PrintTrait` trait'ini uygulayarak bunu düzeltebiliriz, Liste 5-10'da gösterildiği gibi. Trait'ler hakkında daha fazla bilgi için, [Cairo'da Trait'ler](ch08-02-traits-in-cairo.md)'e bakın."
 
-#: src/ch05-02-an-example-program-using-structs.md:161
-msgid "Listing 5-10: Implementing the `PrintTrait` trait on Rectangle"
-msgstr ""
 
-#: src/ch05-02-an-example-program-using-structs.md:163
-msgid "When we run the `main` function, we get the following output:"
-msgstr ""
+#: src/ch05-02-an-example-program-using-structs.md:160
+msgid "Listing 5-10: Implementing the `PrintTrait` trait on `Rectangle`"
+msgstr "Liste 5-10: `Rectangle` üzerine `PrintTrait` trait'ini uygulama"
 
-#: src/ch05-02-an-example-program-using-structs.md:168
-msgid "'\n'"
-msgstr ""
 
-#: src/ch05-02-an-example-program-using-structs.md:173
+#: src/ch05-02-an-example-program-using-structs.md:162
 msgid ""
 "Nice! It’s not the prettiest output, but it shows the values of all the "
 "fields for this instance, which would definitely help during debugging."
 msgstr ""
+"Güzel! En güzel çıktı değil, ama bu örneğin tüm alanlarının değerlerini gösteriyor, bu kesinlikle hata ayıklama sırasında yardımcı olurdu."
+
 
 #: src/ch05-03-method-syntax.md:3
 msgid ""
@@ -4906,21 +6283,27 @@ msgid ""
 "you must define a [trait](./ch08-02-traits-in-cairo.md) and an "
 "implementation associated with the type for which the method is intended."
 msgstr ""
+"_Metodlar_ fonksiyonlara benzerdir: `fn` anahtar kelimesi ve bir ad ile tanımlanırlar, parametreleri ve bir dönüş değeri olabilir ve metod başka bir yerden çağrıldığında çalışacak bazı kodlar içerirler. Fonksiyonlardan farklı olarak, metodlar bir tipin bağlamı içinde tanımlanır ve ilk parametreleri her zaman `self`tir, bu da metodun çağrıldığı tipin örneğini temsil eder. Rust ile tanıdık olanlar için, Cairo'nun yaklaşımı kafa karıştırıcı olabilir, çünkü metodlar doğrudan tipler üzerinde doğrudan tanımlanamaz. Bunun yerine, metodun niyet edildiği tip için bir [trait](./ch08-02-traits-in-cairo.md) ve bir uygulama tanımlamalısınız."
+
 
 #: src/ch05-03-method-syntax.md:12
 msgid "Defining Methods"
-msgstr ""
+msgstr "Metod Tanımlama"
+
 
 #: src/ch05-03-method-syntax.md:14
 msgid ""
 "Let’s change the `area` function that has a `Rectangle` instance as a "
 "parameter and instead make an `area` method defined on the `RectangleTrait` "
-"trait, as shown in Listing 5-11."
+"trait, as shown in Listing 5-13."
 msgstr ""
+"`Rectangle` örneğini parametre olarak alan `area` fonksiyonunu değiştirelim ve bunun yerine `RectangleTrait` trait'i üzerinde tanımlanmış bir `area` metodunu yapalım, Liste 5-13'te gösterildiği gibi."
+
 
 #: src/ch05-03-method-syntax.md:44
 msgid "Listing 5-11: Defining an `area` method to use on the `Rectangle` "
-msgstr ""
+msgstr "Liste 5-11: `Rectangle` üzerinde kullanılacak bir `area` metodunun tanımlanması"
+
 
 #: src/ch05-03-method-syntax.md:47
 msgid ""
@@ -4943,6 +6326,8 @@ msgid ""
 "instance: we add a dot followed by the method name, parentheses, and any "
 "arguments."
 msgstr ""
+"`Rectangle` bağlamı içinde fonksiyonu tanımlamak için, uygulamak istediğimiz metodun imzası ile bir `trait` bloğu tanımlayarak başlarız. Trait'ler belirli bir tipe bağlı değildir; yalnızca metodun `self` parametresi, hangi tip ile kullanılabileceğini tanımlar. Sonra, metodların davranışını tanımlayan `RectangleTrait` için bir `impl` (uygulama) bloğu tanımlarız. Bu `impl` bloğu içindeki her şey, metodun çağrıldığı `self` parametresinin tipi ile ilişkilendirilecektir. Teknik olarak aynı `impl` bloğu içinde birden fazla tip için metod tanımlamak mümkündür, ancak bu, kafa karışıklığına yol açabileceği için önerilmez. `self` parametresinin tipinin aynı `impl` bloğu içinde tutarlı kalması önerilir. Sonra `area` fonksiyonunu `impl` süslü parantezleri içine taşırız ve imzadaki ilk (ve bu durumda tek) parametreyi ve gövde içindeki her yerde `self` olarak değiştiririz. `main`'de, `area` fonksiyonunu çağırdığımız ve argüman olarak `rect1`'i geçtiğimiz yerde, _metod sözdizimini_ kullanarak `Rectangle` örneğimizde `area` metodunu çağırabiliriz. Metod sözdizimi bir örneğin ardından gelir: bir nokta, metod adı, parantezler ve herhangi bir argüman ekleriz."
+
 
 #: src/ch05-03-method-syntax.md:65
 msgid ""
@@ -4955,6 +6340,8 @@ msgid ""
 "with snapshots as we’ve done here, or use a mutable reference to `self` "
 "using the `ref self: T` syntax."
 msgstr ""
+"Metodlar, uygulandıkları tip için ilk parametre olarak `self` adında bir parametreye sahip olmalıdır. İmzada `Rectangle` tipinin önünde `@` anlık görüntü operatörünü kullandığımızı unutmayın. Bunu yaparak, bu metodun `Rectangle` örneğinin değişmez bir anlık görüntüsünü aldığını belirtiyoruz, bu anlık görüntü metod örneğe geçirildiğinde derleyici tarafından otomatik olarak oluşturulur. Metodlar `self`'i sahiplenme, burada yaptığımız gibi `self` ile anlık görüntüler kullanma veya `ref self: T` sözdizimi kullanarak `self`'in değiştirilebilir referansını kullanma şeklinde kullanılabilir."
+
 
 #: src/ch05-03-method-syntax.md:73
 msgid ""
@@ -4968,6 +6355,8 @@ msgid ""
 "into something else and you want to prevent the caller from using the "
 "original instance after the transformation."
 msgstr ""
+"`self: @Rectangle`'ı burada fonksiyon versiyonunda `@Rectangle` kullandığımız aynı nedenle seçtik: sahipliği almak istemiyoruz ve sadece struct içindeki verileri okumak istiyoruz, yazmak değil. Eğer metodun yaptığı işin bir parçası olarak üzerinde çağrıldığı örneği değiştirmek isteseydik, ilk parametre olarak `ref self: Rectangle` kullanırdık. Bir metodun ilk parametre olarak yalnızca `self` kullanarak örneğin sahipliğini alması nadirdir; bu teknik genellikle metod `self`'i başka bir şeye dönüştürdüğünde ve çağrıyı yapanın dönüşümden sonra orijinal örneği kullanmasını önlemek istediğinizde kullanılır."
+
 
 #: src/ch05-03-method-syntax.md:82
 msgid ""
@@ -4976,6 +6365,8 @@ msgid ""
 "passed as a snapshot, and all of its field values are of type `@T`, "
 "requiring them to be desnapped in order to manipulate them."
 msgstr ""
+"Alan metodunda struct üyelerine erişirken desnap operatörü `*`'ın kullanımını gözlemleyin. Bu, struct'ın bir anlık görüntü olarak geçirilmesi ve tüm alan değerlerinin `@T` tipinde olması gerektiği için, onları manipüle edebilmek için desnapped olmaları gerektiğinden gereklidir."
+
 
 #: src/ch05-03-method-syntax.md:87
 msgid ""
@@ -4989,6 +6380,8 @@ msgid ""
 "example, you could implement the `Add` trait for your type in one `impl` "
 "block, and the `Sub` trait in another block."
 msgstr ""
+"Metodlar yerine fonksiyonları kullanmanın ana nedeni organizasyon ve kod açıklığıdır. Bir tipin örneği ile yapabileceğimiz her şeyi bir `trait` & `impl` bloklar kombinasyonunda koyduk, kodumuzun gelecekteki kullanıcılarını `Rectangle`'ın yeteneklerini sağladığımız kütüphanenin çeşitli yerlerinde aramak zorunda bırakmadık. Ancak, aynı tip için farklı yerlerde birden fazla `trait` & `impl` blokları kombinasyonunu tanımlayabiliriz, bu da daha ince taneli bir kod organizasyonu için yararlı olabilir. Örneğin, `Add` trait'ini tipiniz için bir `impl` bloğunda ve `Sub` trait'ini başka bir blokta uygulayabilirsiniz."
+
 
 #: src/ch05-03-method-syntax.md:96
 msgid ""
@@ -4996,24 +6389,29 @@ msgid ""
 "struct’s fields. For example, we can define a method on `Rectangle` that is "
 "also named `width`:"
 msgstr ""
+"Bir metodun adını struct'ın alanlarından biriyle aynı adı vermek serbesttir. Örneğin, `Rectangle` üzerinde de `width` adında bir metod tanımlayabiliriz:"
+
 
 #: src/ch05-03-method-syntax.md:121
-msgid "\"Width is {}\""
+msgid "\"Width: {}\""
 msgstr ""
 
 #: src/ch05-03-method-syntax.md:125
 msgid ""
 "Here, we’re choosing to make the `width` method return `true` if the value "
-"in the instance’s `width` field is greater than `0`, and `false` if the "
-"value is `0`: we can use a field within a method of the same name for any "
-"purpose. In `main`, when we follow `rect1.width` with parentheses, Cairo "
-"knows we mean the method `width`. When we don’t use parentheses, Cairo knows "
-"we mean the field `width`."
+"in the instance’s `width` field is greater than `0` and `false` if the value "
+"is `0`: we can use a field within a method of the same name for any purpose. "
+"In `main`, when we follow `rect1.width` with parentheses, Cairo knows we "
+"mean the method `width`. When we don’t use parentheses, Cairo knows we mean "
+"the field `width`."
 msgstr ""
+"Burada, `width` metodunun, örneğin `width` alanındaki değer `0`'dan büyükse `true`, değer `0` ise `false` dönmesini tercih ediyoruz: aynı adı taşıyan bir alana sahip bir metodun, herhangi bir amaç için kullanılabilir. `main`'de, `rect1.width`'i parantezlerle takip ettiğimizde, Cairo metod `width`'i kastettiğimizi anlar. Parantez kullanmadığımızda, Cairo alan `width`'i kastettiğimizi anlar."
+
 
 #: src/ch05-03-method-syntax.md:132
 msgid "Methods with More Parameters"
-msgstr ""
+msgstr "Daha Fazla Parametre ile Metodlar"
+
 
 #: src/ch05-03-method-syntax.md:134
 msgid ""
@@ -5022,8 +6420,10 @@ msgid ""
 "another instance of `Rectangle` and return `true` if the second `Rectangle` "
 "can fit completely within `self` (the first `Rectangle`); otherwise, it "
 "should return `false`. That is, once we’ve defined the `can_hold` method, we "
-"want to be able to write the program shown in Listing 5-12."
+"want to be able to write the program shown in Listing 5-14."
 msgstr ""
+"Metodları kullanmayı pratik yapalım ve `Rectangle` struct'ı üzerine ikinci bir metod uygulayalım. Bu sefer, `Rectangle` örneğinin başka bir `Rectangle` örneğini almasını ve ikinci `Rectangle` kendisine (`self` yani ilk `Rectangle`) tamamen sığabiliyorsa `true`, aksi takdirde `false` döndürmesini istiyoruz. Yani, `can_hold` metodunu tanımladıktan sonra, Liste 5-14'te gösterilen programı yazmak istiyoruz."
+
 
 #: src/ch05-03-method-syntax.md:156
 msgid "\"Can rect1 hold rect2? {}\""
@@ -5035,7 +6435,8 @@ msgstr ""
 
 #: src/ch05-03-method-syntax.md:161
 msgid "Listing 5-12: Using the as-yet-unwritten `can_hold` method"
-msgstr ""
+msgstr "Liste 5-12: Henüz yazılmamış `can_hold` metodunu kullanma"
+
 
 #: src/ch05-03-method-syntax.md:164
 msgid ""
@@ -5043,8 +6444,10 @@ msgid ""
 "`rect2` are smaller than the dimensions of `rect1`, but `rect3` is wider "
 "than `rect1`:"
 msgstr ""
+"Beklenen çıktı aşağıdaki gibi olurdu çünkü `rect2`'nin her iki boyutu da `rect1`'in boyutlarından küçüktür, ancak `rect3` `rect1`'den daha geniştir:"
 
-#: src/ch05-03-method-syntax.md:176
+
+#: src/ch05-03-method-syntax.md:180
 msgid ""
 "We know we want to define a method, so it will be within the `trait "
 "RectangleTrait` and `impl RectangleImpl of RectangleTrait` blocks. The "
@@ -5061,26 +6464,33 @@ msgid ""
 "the new `can_hold` method to the `trait` and `impl` blocks from Listing "
 "5-11, shown in Listing 5-13."
 msgstr ""
+"Bir metod tanımlamak istediğimizi biliyoruz, bu yüzden `trait RectangleTrait` ve `impl RectangleImpl of RectangleTrait` blokları içinde olacak. Metod adı `can_hold` olacak ve bir başka `Rectangle`'ın anlık görüntüsünü parametre olarak alacak. `rect1.can_hold(@rect2)` metodunu çağıran kodu inceleyerek parametrenin tipini belirleyebiliriz: `@rect2`, `Rectangle` örneği olan `rect2`'ye bir anlık görüntüdür. Bu mantıklı çünkü `rect2`'yi yalnızca okumamız gerekiyor (yazmak demek mutable borrow gerektirecekti) ve `can_hold` metodunu çağırdıktan sonra `main`'de `rect2`'yi tekrar kullanmak istiyoruz. `can_hold`'un dönüş değeri bir Boolean olacak ve uygulama, `self`'in genişliğinin ve yüksekliğinin diğer `Rectangle`'ın genişliğinden ve yüksekliğinden sırasıyla daha büyük olup olmadığını kontrol edecek. Yeni `can_hold` metodunu Liste 5-11'den `trait` ve `impl` bloklarına ekleyelim, Liste 5-13'te gösterildiği gibi."
 
-#: src/ch05-03-method-syntax.md:209
+
+#: src/ch05-03-method-syntax.md:213
 msgid ""
 "Listing 5-13: Implementing the `can_hold` method on `Rectangle` that takes "
 "another `Rectangle` instance as a parameter"
 msgstr ""
+"Liste 5-13: Bir başka `Rectangle` örneğini parametre olarak alan `Rectangle` üzerinde `can_hold` metodunu uygulama"
 
-#: src/ch05-03-method-syntax.md:212
+
+#: src/ch05-03-method-syntax.md:216
 msgid ""
-"When we run this code with the `main` function in Listing 5-12, we’ll get "
+"When we run this code with the `main` function in Listing 5-14, we’ll get "
 "our desired output. Methods can take multiple parameters that we add to the "
 "signature after the `self` parameter, and those parameters work just like "
 "parameters in functions."
 msgstr ""
+"Bu kodu Liste 5-14'teki `main` fonksiyonu ile çalıştırdığımızda, istediğimiz çıktıyı alırız. Metodlar, `self` parametresinden sonra imzaya eklediğimiz birden fazla parametre alabilir ve bu parametreler fonksiyonlardaki parametreler gibi çalışır."
 
-#: src/ch05-03-method-syntax.md:217
+
+#: src/ch05-03-method-syntax.md:221
 msgid "Accessing implementation functions"
-msgstr ""
+msgstr "Uygulama fonksiyonlarına erişim"
 
-#: src/ch05-03-method-syntax.md:219
+
+#: src/ch05-03-method-syntax.md:223
 msgid ""
 "All functions defined within a `trait` and `impl` block can be directly "
 "addressed using the `::` operator on the implementation name. Functions in "
@@ -5092,46 +6502,62 @@ msgid ""
 "easier to create a square `Rectangle` rather than having to specify the same "
 "value twice:"
 msgstr ""
+"`trait` ve `impl` bloğu içinde tanımlanan tüm fonksiyonlar, uygulama adı ile `::` operatörü kullanılarak doğrudan adreslenebilir. Metod olmayan trait fonksiyonları, genellikle struct'ın yeni bir örneğini döndürecek yapılandırıcılar için kullanılır. Bunlar genellikle `new` olarak adlandırılır, ancak `new` özel bir ad değildir ve dile yerleşik değildir. Örneğin, bir boyut parametresi alacak ve bunu hem genişlik hem de yükseklik olarak kullanacak, böylece aynı değeri iki kez belirtmek zorunda kalmadan kolayca bir kare `Rectangle` oluşturmayı kolaylaştıracak `square` adında bir ilişkili fonksiyon sağlamayı seçebiliriz:"
 
-#: src/ch05-03-method-syntax.md:242
+
+#: src/ch05-03-method-syntax.md:246
 msgid ""
-"To call this function, we use the `::` syntax with the implementation name: "
+"To call this function, we use the `::` syntax with the implementation name; "
 "`let square = RectangleImpl::square(10);` is an example. This function is "
 "namespaced by the implementation; the `::` syntax is used for both trait "
 "functions and namespaces created by modules. We’ll discuss modules in "
-"[Chapter 7](ch07-02-defining-modules-to-control-scope.md)."
+"\\[Chapter 8\\]\\[modules\\]"
+msgstr ""
+"Bu fonksiyonu çağırmak için, uygulama adı ile `::` sözdizimini kullanırız; `let square = RectangleImpl::square(10);` bir örnektir. Bu fonksiyon uygulama tarafından ad alanına alınmıştır; `::` sözdizimi hem trait fonksiyonları hem de modüller tarafından oluşturulan ad alanları için kullanılır. Modüller hakkında [Bölüm 8](ch08-00-generic-types-and-traits.md)'de tartışacağız."
+
+
+#: src/ch05-03-method-syntax.md:250 src/appendix-06-cairo-binaries.md:167
+msgid "."
 msgstr ""
 
-#: src/ch05-03-method-syntax.md:247
+#: src/ch05-03-method-syntax.md:252
 msgid ""
 "Note: It is also possible to call this function using the trait name, with "
 "`RectangleTrait::square(10)`."
 msgstr ""
+"Not: Bu fonksiyonu, trait adı ile de çağırabiliriz, `RectangleTrait::square(10)` kullanarak."
 
-#: src/ch05-03-method-syntax.md:250
+
+#: src/ch05-03-method-syntax.md:255
 msgid "Multiple `impl` Blocks"
-msgstr ""
+msgstr "Çoklu `impl` Blokları"
 
-#: src/ch05-03-method-syntax.md:252
+
+#: src/ch05-03-method-syntax.md:257
 msgid ""
 "Each struct is allowed to have multiple `trait` and `impl` blocks. For "
 "example, Listing 5-13 is equivalent to the code shown in Listing 5-14, which "
 "has each method in its own `trait` and `impl` blocks."
 msgstr ""
+"Her struct, birden fazla `trait` ve `impl` bloğuna sahip olabilir. Örneğin, Liste 5-13, her metodun kendi `trait` ve `impl` bloklarında olduğu Liste 5-14'teki kod ile eşdeğerdir."
 
-#: src/ch05-03-method-syntax.md:277
+
+#: src/ch05-03-method-syntax.md:282
 msgid "Listing 5-14: Rewriting Listing 5-13 using multiple `impl` blocks"
-msgstr ""
+msgstr "Liste 5-14: Liste 5-13'ü çoklu `impl` blokları kullanarak yeniden yazma"
 
-#: src/ch05-03-method-syntax.md:280
+
+#: src/ch05-03-method-syntax.md:285
 msgid ""
 "There’s no reason to separate these methods into multiple `trait` and `impl` "
 "blocks here, but this is valid syntax. We’ll see a case in which multiple "
 "blocks are useful in [Chapter 8](ch08-00-generic-types-and-traits.md), where "
 "we discuss generic types and traits."
 msgstr ""
+"Burada, bu metodları birden fazla `trait` ve `impl` bloğuna ayırmanın bir nedeni yok, ancak bu geçerli bir sözdizimidir. Birden fazla bloğun [Bölüm 8](ch08-00-generic-types-and-traits.md)'de, jenerik tipler ve trait'ler hakkında tartıştığımızda yararlı olduğu bir durumu göreceğiz."
 
-#: src/ch05-03-method-syntax.md:287
+
+#: src/ch05-03-method-syntax.md:292
 msgid ""
 "Structs let you create custom types that are meaningful for your domain. By "
 "using structs, you can keep associated pieces of data connected to each "
@@ -5139,12 +6565,16 @@ msgid ""
 "blocks, you can define methods, which are functions associated to a type and "
 "let you specify the behavior that instances of your type have."
 msgstr ""
+"Struct'lar, alanınız için anlamlı olan özel tipler oluşturmanıza izin verir. Struct'ları kullanarak, ilişkili veri parçalarını birbirine bağlı tutabilir ve her bir parçayı adlandırarak kodunuzu açık hale getirebilirsiniz. `trait` ve `impl` bloklarında, bir tip ile ilişkilendirilmiş fonksiyonlar olan metodları tanımlayabilirsiniz ve tipinizin örneklerinin sahip olduğu davranışı belirtebilirsiniz."
 
-#: src/ch05-03-method-syntax.md:293
+
+#: src/ch05-03-method-syntax.md:298
 msgid ""
 "But structs aren’t the only way you can create custom types: let’s turn to "
 "Cairo’s enum feature to add another tool to your toolbox."
 msgstr ""
+"Ancak struct'lar özel tipler oluşturmanın tek yolu değil: Cairo’nun enum özelliğine dönerek araç kutunuza başka bir araç ekleyelim."
+
 
 #: src/ch06-00-enums-and-pattern-matching.md:3
 msgid ""
@@ -5156,6 +6586,8 @@ msgid ""
 "Finally, we’ll look at how pattern matching in the `match` expression makes "
 "it easy to run different code for different values of an enum."
 msgstr ""
+"Bu bölümde, _enumerasyonlara_ veya kısaca _enumlara_ bakacağız. Enumlar, olası _varyantlarını_ sıralayarak bir tipi tanımlamanıza izin verir. Öncelikle, bir enum tanımlayıp kullanarak bir enumun veri ile birlikte nasıl anlam kodlayabileceğini göstereceğiz. Daha sonra, bir değerin bir şey veya hiçbir şey olabileceğini ifade eden, özellikle yararlı olan `Option` adlı bir enumu inceleyeceğiz. Son olarak, bir enumun farklı değerleri için farklı kodları çalıştırmayı kolaylaştıran `match` ifadesindeki desen eşleştirmeye bakacağız."
+
 
 #: src/ch06-01-enums.md:3
 msgid ""
@@ -5164,14 +6596,18 @@ msgid ""
 "useful for representing a collection of related values where each value is "
 "distinct and has a specific meaning."
 msgstr ""
+"Enumlar, \"enumerasyonlar\" için kısa, sabit bir adlandırılmış değer kümesinden oluşan özel bir veri tipi tanımlamanın bir yoludur. Enumlar, her biri belirgin ve belirli bir anlama sahip olan ilişkili değerlerin bir koleksiyonunu temsil etmek için yararlıdır."
+
 
 #: src/ch06-01-enums.md:5
 msgid "Enum Variants and Values"
-msgstr ""
+msgstr "Enum Varyantları ve Değerleri"
+
 
 #: src/ch06-01-enums.md:7
 msgid "Here's a simple example of an enum:"
-msgstr ""
+msgstr "İşte basit bir enum örneği:"
+
 
 #: src/ch06-01-enums.md:19
 msgid ""
@@ -5181,6 +6617,8 @@ msgid ""
 "of the Direction type. In this particular example, variants don't have any "
 "associated value. One variant can be instantiated using this syntax:"
 msgstr ""
+"Bu örnekte, `Direction` adında dört varyantı olan bir enum tanımladık: `North`, `East`, `South` ve `West`. Enum varyantları için isimlendirme kuralı PascalCase kullanmaktır. Her bir varyant, Direction tipinin belirgin bir değerini temsil eder. Bu özel örnekte, varyantlarla ilişkilendirilmiş herhangi bir değer yoktur. Bir varyantı bu sözdizimi kullanarak örnekleyebiliriz:"
+
 
 #: src/ch06-01-enums.md:37
 msgid ""
@@ -5189,44 +6627,57 @@ msgid ""
 "Direction. You can learn more about it on [The Match Control Flow Construct "
 "page](ch06-02-the-match-control-flow-construct.md)."
 msgstr ""
+"Bir enum örneğinin varyantına bağlı olarak farklı şekilde hareket eden kod yazmak kolaydır, bu örnekte bir Yön'e göre belirli kodu çalıştırmak için. [Eşleştirme Kontrol Akışı Yapısı sayfasında](ch06-02-the-match-control-flow-construct.md) daha fazla bilgi edinebilirsiniz."
+
 
 #: src/ch06-01-enums.md:39
 msgid "Enums Combined with Custom Types"
-msgstr ""
+msgstr "Enumlar Özel Tiplerle Birleştirilmiş"
+
 
 #: src/ch06-01-enums.md:41
 msgid ""
 "Enums can also be used to store more interesting data associated with each "
 "variant. For example:"
 msgstr ""
+"Enumlar, her bir varyantla ilişkilendirilmiş daha ilginç verileri de depolamak için kullanılabilir. Örneğin:"
+
 
 #: src/ch06-01-enums.md:52
 msgid ""
 "In this example, the `Message` enum has three variants: `Quit`, `Echo` and "
 "`Move`, all with different types:"
 msgstr ""
+"Bu örnekte, `Message` enumu üç varyanta sahiptir: `Quit`, `Echo` ve `Move`, hepsi farklı tiplerdedir:"
+
 
 #: src/ch06-01-enums.md:54
 msgid "`Quit` doesn't have any associated value."
-msgstr ""
+msgstr "`Quit` herhangi bir ilişkilendirilmiş değere sahip değildir."
+
 
 #: src/ch06-01-enums.md:55
 msgid "`Echo` is a single felt."
-msgstr ""
+msgstr "`Echo` tek bir felt'tir."
+
 
 #: src/ch06-01-enums.md:56
 msgid "`Move` is a tuple of two u128 values."
-msgstr ""
+msgstr "`Move` iki u128 değerinden oluşan bir demettir."
+
 
 #: src/ch06-01-enums.md:58
 msgid ""
 "You could even use a Struct or another Enum you defined inside one of your "
 "Enum variants."
 msgstr ""
+"Enum varyantlarınızın birinde tanımladığınız bir Struct veya başka bir Enum kullanabilirsiniz."
+
 
 #: src/ch06-01-enums.md:60
 msgid "Trait Implementations for Enums"
-msgstr ""
+msgstr "Enumlar için Trait Uygulamaları"
+
 
 #: src/ch06-01-enums.md:62
 msgid ""
@@ -5235,6 +6686,8 @@ msgid ""
 "Here's an example of defining a trait and implementing it for the previous "
 "`Message` enum:"
 msgstr ""
+"Cairo'da, özel enumlarınız için trait'leri tanımlayabilir ve bunları uygulayabilirsiniz. Bu, enumunuzla ilişkilendirilmiş metodları ve davranışları tanımlamanıza olanak tanır. İşte önceki `Message` enumu için bir trait tanımlayıp bunu uygulama örneği:"
+
 
 #: src/ch06-01-enums.md:72 src/ch06-01-enums.md:98
 msgid "\"quitting\""
@@ -5253,14 +6706,18 @@ msgid ""
 "In this example, we implemented the `Processing` trait for `Message`. Here "
 "is how it could be used to process a Quit message:"
 msgstr ""
+"Bu örnekte, `Message` için `Processing` trait'ini uyguladık. İşte bir Quit mesajının nasıl işlenebileceği:"
+
 
 #: src/ch06-01-enums.md:112
 msgid "Running this code would print `quitting`."
-msgstr ""
+msgstr "Bu kodu çalıştırdığınızda `quitting` yazdırılır."
+
 
 #: src/ch06-01-enums.md:114
 msgid "The Option Enum and Its Advantages"
-msgstr ""
+msgstr "Option Enumu ve Avantajları"
+
 
 #: src/ch06-01-enums.md:116
 msgid ""
@@ -5269,6 +6726,8 @@ msgid ""
 "indicates that there's a value of type `T`, while `None` represents the "
 "absence of a value."
 msgstr ""
+"Option enumu, bir değerin isteğe bağlı olduğu kavramını temsil eden standart bir Cairo enumudur. İki varyanta sahiptir: `Some: T` ve `None: ()`. `Some: T` bir `T` tipinde değer olduğunu belirtirken, `None` bir değerin yokluğunu temsil eder."
+
 
 #: src/ch06-01-enums.md:125
 msgid ""
@@ -5277,6 +6736,8 @@ msgid ""
 "and easier to reason about. Using `Option` can also help prevent bugs caused "
 "by using uninitialized or unexpected `null` values."
 msgstr ""
+"`Option` enumu yararlıdır çünkü bir değerin yokluğunun açıkça temsil edilmesine izin verir, kodunuzu daha ifade edilebilir ve hakkında düşünmesi daha kolay hale getirir. `Option` kullanmak, başlatılmamış veya beklenmedik `null` değerleri nedeniyle oluşan hataları önlemeye de yardımcı olabilir."
+
 
 #: src/ch06-01-enums.md:127
 msgid ""
@@ -5284,24 +6745,31 @@ msgid ""
 "first element of an array with a given value, or None if the element is not "
 "present."
 msgstr ""
+"Size bir örnek vermek için, verilen bir değere sahip bir dizinin ilk elemanının indeksini döndüren veya eleman mevcut değilse None döndüren bir fonksiyon işte burada."
+
 
 #: src/ch06-01-enums.md:129
 msgid "We are demonstrating two approaches for the above function:"
-msgstr ""
+msgstr "Yukarıdaki fonksiyon için iki yaklaşımı gösteriyoruz:"
+
 
 #: src/ch06-01-enums.md:131
 msgid "Recursive Approach `find_value_recursive`"
-msgstr ""
+msgstr "Recursive Yaklaşım `find_value_recursive`"
+
 
 #: src/ch06-01-enums.md:132
 msgid "Iterative Approach `find_value_iterative`"
-msgstr ""
+msgstr "Iterative Yaklaşım `find_value_iterative`"
+
 
 #: src/ch06-01-enums.md:134
 msgid ""
 "Note: in the future it would be nice to replace this example by something "
 "simpler using a loop and without gas related code."
 msgstr ""
+"Not: Gelecekte bu örneği, bir döngü kullanarak ve gazla ilgili kod olmadan daha basit bir şeyle değiştirmek güzel olurdu."
+
 
 #: src/ch06-01-enums.md:183
 msgid "\"found recursively at index {}\""
@@ -5317,71 +6785,85 @@ msgstr ""
 
 #: src/ch06-01-enums.md:201
 msgid "Running this code would print `it worked`."
-msgstr ""
+msgstr "Bu kodu çalıştırmak `it worked` yazdırır."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:3
 msgid ""
 "Cairo has an extremely powerful control flow construct called `match` that "
 "allows you to compare a value against a series of patterns and then execute "
 "code based on which pattern matches. Patterns can be made up of literal "
-"values, variable names, wildcards, and many other things. The power of "
-"`match` comes from the expressiveness of the patterns and the fact that the "
-"compiler confirms that all possible cases are handled."
+"values, variable names, wildcards, and many other things. The power of match "
+"comes from the expressiveness of the patterns and the fact that the compiler "
+"confirms that all possible cases are handled."
 msgstr ""
+"Cairo, `match` adında son derece güçlü bir kontrol akışı yapılandırmasına sahiptir ki bu, bir değeri bir dizi desenle karşılaştırmanıza ve hangi desenin uyuştuğuna bağlı olarak kod çalıştırmanıza olanak tanır. Desenler, literal değerler, değişken isimleri, joker karakterler ve daha birçok şeyden oluşabilir. Match'in gücü, desenlerin ifade gücünden ve derleyicinin tüm olası durumların ele alındığını doğrulaması gerçeğinden gelir."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:5
 msgid ""
-"Think of a `match` expression as being like a coin-sorting machine: coins "
+"Think of a match expression as being like a coin-sorting machine: coins "
 "slide down a track with variously sized holes along it, and each coin falls "
 "through the first hole it encounters that it fits into. In the same way, "
 "values go through each pattern in a match, and at the first pattern the "
 "value “fits”, the value falls into the associated code block to be used "
 "during execution."
 msgstr ""
+"Bir match ifadesini, çeşitli büyüklükteki deliklerle birlikte bir yol üzerinde kayan bozuk paraların sıralandığı bir bozuk para sıralama makinesi gibi düşünebilirsiniz: her bozuk para, içine sığdığı ilk delikten düşer. Aynı şekilde, değerler bir match'teki her desenden geçer ve değerin “uyduğu” ilk desende, değer yürütme sırasında kullanılacak ilişkili kod bloğuna düşer."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:7
 msgid ""
-"Speaking of coins, let’s use them as an example using `match`! We can write "
-"a function that takes an unknown US coin and, in a similar way as the "
-"counting machine, determines which coin it is and returns its value in "
-"cents, as shown in Listing 6-3."
+"Speaking of coins, let’s use them as an example using match! We can write a "
+"function that takes an unknown US coin and, in a similar way as the counting "
+"machine, determines which coin it is and returns its value in cents, as "
+"shown in Listing 6-3."
 msgstr ""
+"Bozuk paralardan bahsetmişken, onları match kullanarak bir örnek olarak kullanalım! Belirli bir ABD bozuk parasını alan ve sayma makinesine benzer şekilde, hangi bozuk para olduğunu belirleyip sent cinsinden değerini döndüren bir fonksiyon yazabiliriz, Liste 6-3'te gösterildiği gibi."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:27
 msgid ""
-"Listing 6-3: An enum and a `match` expression that has the variants of the "
+"Listing 6-3: An enum and a match expression that has the variants of the "
 "enum as its patterns"
 msgstr ""
+"Liste 6-3: Enumun varyantlarını desenleri olarak kullanan bir enum ve bir match ifadesi"
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:29
 msgid ""
-"Let’s break down the `match` expression in the `value_in_cents` function. "
-"First we list the `match` keyword followed by an expression, which in this "
-"case is the value `coin`. This seems very similar to a conditional "
-"expression used with if, but there’s a big difference: with if, the "
-"condition needs to evaluate to a Boolean value, but here it can be any type. "
-"The type of `coin` in this example is the `Coin` enum that we defined on the "
-"first line."
+"Let’s break down the `match` in the `value_in_cents` function. First we list "
+"the `match` keyword followed by an expression, which in this case is the "
+"value `coin`. This seems very similar to a conditional expression used with "
+"if, but there’s a big difference: with if, the condition needs to evaluate "
+"to a Boolean value, but here it can be any type. The type of coin in this "
+"example is the `Coin` enum that we defined on the first line."
 msgstr ""
+"`value_in_cents` fonksiyonundaki `match`'i detaylandıralım. İlk olarak `match` anahtar kelimesini bir ifade ile listeleriz, bu durumda değer `coin`. Bu, if ile kullanılan bir koşullu ifadeye çok benzer görünüyor, ancak büyük bir fark var: if ile, koşulun bir Boolean değerine değerlendirilmesi gerekirken, burada herhangi bir tür olabilir. Bu örnekte coin tipi, ilk satırda tanımladığımız `Coin` enumudur."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:31
 msgid ""
 "Next are the `match` arms. An arm has two parts: a pattern and some code. "
-"The first arm here has a pattern that is the value `Coin::Penny` and then "
+"The first arm here has a pattern that is the value `Coin::Penny(_)` and then "
 "the `=>` operator that separates the pattern and the code to run. The code "
 "in this case is just the value `1`. Each arm is separated from the next with "
 "a comma."
 msgstr ""
+"Sonra `match` kolları gelir. Bir kolun iki bölümü vardır: bir desen ve biraz kod. İlk kolun burada `Coin::Penny(_)` değerinde bir deseni ve ardından deseni ve çalıştırılacak kodu ayıran `=>` operatörü vardır. Bu durumda kod sadece `1` değeridir. Her kol bir virgülle bir sonrakinden ayrılır."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:33
 msgid ""
 "When the `match` expression executes, it compares the resultant value "
-"against the pattern of each arm, in the order they are given. If a pattern "
-"matches the value, the code associated with that pattern is executed. If "
-"that pattern doesn’t match the value, execution continues to the next arm, "
-"much as in a coin-sorting machine. We can have as many arms as we need: in "
-"the above example, our `match` has four arms."
+"against the pattern of each arm, in order. If a pattern matches the value, "
+"the code associated with that pattern is executed. If that pattern doesn’t "
+"match the value, execution continues to the next arm, much as in a coin-"
+"sorting machine. We can have as many arms as we need: in the above example, "
+"our match has four arms."
 msgstr ""
+"`match` ifadesi yürütüldüğünde, sonuç değeri her kolun deseniyle sırayla karşılaştırır. Bir desen değerle eşleşirse, o desenle ilişkili kod çalıştırılır. O desen değerle eşleşmezse, yürütme bir sonraki kola devam eder, tıpkı bir bozuk para sıralama makinesinde olduğu gibi. İhtiyacımız kadar çok kola sahip olabiliriz: yukarıdaki örnekte, bizim match'imiz dört kola sahiptir."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:35
 msgid ""
@@ -5389,16 +6871,20 @@ msgid ""
 "of the expression in the matching arm is the value that gets returned for "
 "the entire match expression."
 msgstr ""
+"Her kol ile ilişkili kod bir ifadedir ve eşleşen kolun ifadesinin sonuç değeri, tüm match ifadesi için döndürülen değerdir."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:37
 msgid ""
-"We don’t typically use curly brackets if the `match` arm code is short, as "
-"it is in our example where each arm just returns a value. If you want to run "
-"multiple lines of code in a `match` arm, you must use curly brackets, with a "
+"We don’t typically use curly brackets if the match arm code is short, as it "
+"is in our example where each arm just returns a value. If you want to run "
+"multiple lines of code in a match arm, you must use curly brackets, with a "
 "comma following the arm. For example, the following code prints “Lucky "
 "penny!” every time the method is called with a `Coin::Penny`, but still "
 "returns the last value of the block, `1`:"
 msgstr ""
+"Genellikle, match kolunun kodu kısa olduğunda, örneğimizdeki gibi her kol sadece bir değer döndürdüğünde süslü parantezleri kullanmayız. Bir match kolunda birden fazla satır kod çalıştırmak istiyorsanız, bir virgül ile birlikte süslü parantezleri kullanmanız gerekir. Örneğin, aşağıdaki kod, her seferinde `Coin::Penny` ile çağrıldığında “Lucky penny!” yazdırır, ancak bloğun son değeri olan `1`'i döndürür:"
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:43
 msgid "\"Lucky penny!\""
@@ -5406,14 +6892,17 @@ msgstr ""
 
 #: src/ch06-02-the-match-control-flow-construct.md:53
 msgid "Patterns That Bind to Values"
-msgstr ""
+msgstr "Değerlere Bağlanan Desenler"
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:55
 msgid ""
-"Another useful feature of `match` arms is that they can bind to the parts of "
+"Another useful feature of match arms is that they can bind to the parts of "
 "the values that match the pattern. This is how we can extract values out of "
 "enum variants."
 msgstr ""
+"Match kollarının başka bir yararlı özelliği, değerlerin desene uyan kısımlarına bağlanabilmesidir. Enum varyantlarından değerleri nasıl çıkarabileceğimiz budur."
+
 
 #: src/ch06-02-the-match-control-flow-construct.md:57
 msgid ""
@@ -5424,58 +6913,63 @@ msgid ""
 "to our `enum` by changing the `Quarter` variant to include a `UsState` value "
 "stored inside it, which we’ve done in Listing 6-4."
 msgstr ""
+"Bir örnek olarak, enum varyantlarımızdan birine içinde veri tutacak şekilde değiştirelim. 1999'dan 2008'e kadar, Amerika Birleşik Devletleri her biri 50 eyaletin bir yüzünde farklı tasarımlarla çeyrek dolar basmıştır. Diğer bozuk paraların eyalet tasarımları olmadığından, yalnızca çeyrek dolarlar bu ek değere sahiptir. `enum`umuza bu bilgiyi ekleyebiliriz, `Quarter` varyantını içinde `UsState` değeri tutacak şekilde değiştirdiğimizde, bunu Liste 6-4'te yaptık."
 
-#: src/ch06-02-the-match-control-flow-construct.md:61
-msgid "// Debug so we can inspect the state in a minute\n"
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:76
+#: src/ch06-02-the-match-control-flow-construct.md:75
 msgid ""
 "Listing 6-4: A `Coin` enum in which the `Quarter` variant also holds a "
 "`UsState` value"
 msgstr ""
+"Liste 6-4: `Quarter` varyantının içinde bir `UsState` değeri tutan bir `Coin` enumu"
 
-#: src/ch06-02-the-match-control-flow-construct.md:78
+
+#: src/ch06-02-the-match-control-flow-construct.md:77
 msgid ""
 "Let’s imagine that a friend is trying to collect all 50 state quarters. "
 "While we sort our loose change by coin type, we’ll also call out the name of "
 "the state associated with each quarter so that if it’s one our friend "
 "doesn’t have, they can add it to their collection."
 msgstr ""
+"Hayal edelim ki bir arkadaşımız tüm 50 eyalet çeyreğini toplamaya çalışıyor. Bozuk paralarımızı madeni para türüne göre sıralarken, her çeyreğin ilişkili olduğu eyaletin adını da söyleyelim ki, arkadaşımızın koleksiyonunda olmayan bir eyaletse, onu koleksiyonlarına ekleyebilsinler."
 
-#: src/ch06-02-the-match-control-flow-construct.md:80
+
+#: src/ch06-02-the-match-control-flow-construct.md:79
 msgid ""
-"In the `match` expression for this code, we add a variable called `state` to "
+"In the match expression for this code, we add a variable called `state` to "
 "the pattern that matches values of the variant `Coin::Quarter`. When a "
 "`Coin::Quarter` matches, the `state` variable will bind to the value of that "
 "quarter’s state. Then we can use `state` in the code for that arm, like so:"
 msgstr ""
+"Bu kod için match ifadesinde, `Coin::Quarter` varyantına uyan değerlerle desen eşleşen `state` adında bir değişken ekliyoruz. `Coin::Quarter` eşleştiğinde, `state` değişkeni o çeyreğin eyalet değerine bağlanacak. Sonra bu koldaki kodda `state`'i kullanabiliriz, şöyle:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:89
-msgid "\"State quarter from {:?}!\""
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:96
+#: src/ch06-02-the-match-control-flow-construct.md:95
 msgid ""
-"Because `state` is an `UsState` enum which implements the `Debug` trait, we "
-"can print `state` value with `println!` macro."
+"To print the value of a variant of an enum in Cairo, we need to add an "
+"implementation for the `print` function for the `debug::PrintTrait`:"
 msgstr ""
+"Cairo'da, bir enumun varyantının değerini yazdırmak için, `debug::PrintTrait` için `print` fonksiyonunun bir uygulamasını eklememiz gerekiyor:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:98
+
+#: src/ch06-02-the-match-control-flow-construct.md:108
 msgid ""
 "If we were to call `value_in_cents(Coin::Quarter(UsState::Alaska))`, `coin` "
 "would be `Coin::Quarter(UsState::Alaska)`. When we compare that value with "
-"each of the match arms, none of them match until we reach "
-"`Coin::Quarter(state)`. At that point, the binding for `state` will be the "
-"value `UsState::Alaska`. We can then use that binding in `println!` macro, "
-"thus getting the inner state value out of the Coin enum variant for Quarter."
+"each of the match arms, none of them match until we reach `Coin::"
+"Quarter(state)`. At that point, the binding for state will be the value "
+"`UsState::Alaska`. We can then use that binding in the `PrintTrait`, thus "
+"getting the inner state value out of the `Coin` enum variant for `Quarter`."
 msgstr ""
+"`value_in_cents(Coin::Quarter(UsState::Alaska))` çağırdığımızda, `coin` `Coin::Quarter(UsState::Alaska)` olacak. Her bir match kolunu değerle karşılaştırdığımızda, `Coin::Quarter(state)`'e ulaşıncaya kadar hiçbiri eşleşmez. O noktada, state'in bağlaması `UsState::Alaska` değeri olacak. Sonra bu bağlamayı `PrintTrait` içinde kullanabiliriz, böylece `Quarter` için `Coin` enum varyantından iç eyalet değerini çıkarabiliriz."
 
-#: src/ch06-02-the-match-control-flow-construct.md:102
+
+#: src/ch06-02-the-match-control-flow-construct.md:110
 msgid "Matching with `Option<T>`"
-msgstr ""
+msgstr "`Option<T>` ile Eşleşme"
 
-#: src/ch06-02-the-match-control-flow-construct.md:104
+
+#: src/ch06-02-the-match-control-flow-construct.md:112
 msgid ""
 "In the previous section, we wanted to get the inner `T` value out of the "
 "`Some` case when using `Option<T>`; we can also handle `Option<T>` using "
@@ -5483,61 +6977,86 @@ msgid ""
 "compare the variants of `Option<T>`, but the way the `match` expression "
 "works remains the same."
 msgstr ""
+"Önceki bölümde, `Option<T>` kullanırken `Some` durumundaki iç `T` değerini çıkarmak istedik; `Coin` enumu ile yaptığımız gibi `Option<T>`'yi `match` kullanarak da ele alabiliriz! Madeni paraları karşılaştırmak yerine `Option<T>`'nin varyantlarını karşılaştıracağız, ancak `match` ifadesinin çalışma şekli aynı kalır."
 
-#: src/ch06-02-the-match-control-flow-construct.md:106
+
+#: src/ch06-02-the-match-control-flow-construct.md:114
 msgid ""
 "Let’s say we want to write a function that takes an `Option<u8>` and, if "
 "there’s a value inside, adds `1` to that value. If there isn’t a value "
 "inside, the function should return the `None` value and not attempt to "
 "perform any operations."
 msgstr ""
+"Diyelim ki `Option<u8>` alan ve içinde bir değer varsa bu değere `1` ekleyen bir fonksiyon yazmak istiyoruz. İçinde bir değer yoksa, fonksiyonun `None` değerini döndürmesi ve herhangi bir işlem yapmaması gerekiyor."
 
-#: src/ch06-02-the-match-control-flow-construct.md:108
+
+#: src/ch06-02-the-match-control-flow-construct.md:116
 msgid ""
-"This function is very easy to write, thanks to `match`, and will look like "
+"This function is very easy to write, thanks to match, and will look like "
 "Listing 6-5."
 msgstr ""
+"Bu fonksiyon, match sayesinde çok kolay yazılır ve Liste 6-5 gibi görünür."
 
-#: src/ch06-02-the-match-control-flow-construct.md:125
-msgid "Listing 6-5: A function that uses a `match` expression on an `Option<u8>`"
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:127
-msgid ""
-"Let’s examine the first execution of `plus_one` in more detail. When we call "
-"`plus_one(five)`, the variable `x` in the body of `plus_one` will have the "
-"value `Some(5)`. We then compare that against each `match` arm:"
+#: src/ch06-02-the-match-control-flow-construct.md:131
+msgid "\"six: {}\""
 msgstr ""
 
 #: src/ch06-02-the-match-control-flow-construct.md:133
+msgid "\"none: {}\""
+msgstr ""
+
+#: src/ch06-02-the-match-control-flow-construct.md:137
+msgid "Listing 6-5: A function that uses a match expression on an `Option<u8>`"
+msgstr "Liste 6-5: Bir `Option<u8>` üzerinde bir match ifadesi kullanan bir fonksiyon"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:140
+msgid ""
+"Let’s examine the first execution of `plus_one` in more detail. When we call "
+"`plus_one(five)`, the variable `x` in the body of `plus_one` will have the "
+"value `Some(5)`. We then compare that against each match arm:"
+msgstr ""
+"`plus_one`'ın ilk yürütülmesini daha detaylı inceleyelim. `plus_one(five)` çağırdığımızda, `plus_one`'ın gövdesindeki `x` değişkeni `Some(5)` değerine sahip olacak. Sonra bunu her match koluna karşı karşılaştırırız:"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:146
 msgid ""
 "Does `Option::Some(5)` value match the pattern `Option::Some(val)`? It does! "
-"We have the same variant. The `val` binds to the value contained in "
-"`Option::Some`, so `val` takes the value `5`. The code in the `match` arm is "
-"then executed, so we add `1` to the value of `val` and create a new "
-"`Option::Some` value with our total `6` inside. Because the first arm "
-"matched, no other arms are compared."
+"We have the same variant. The `val` binds to the value contained in `Option::"
+"Some`, so `val` takes the value `5`. The code in the match arm is then "
+"executed, so we add `1` to the value of `val` and create a new `Option::"
+"Some` value with our total `6` inside. Because the first arm matched, no "
+"other arms are compared."
 msgstr ""
+"`Option::Some(5)` değeri `Option::Some(val)` deseniyle eşleşir mi? Evet! Aynı varyantımız var. `val`, `Option::Some` içindeki değere bağlanır, bu yüzden `val` `5` değerini alır. Sonra match kolundaki kod çalıştırılır, böylece `val`'ın değerine `1` ekler ve içinde toplamımız olan `6` ile yeni bir `Option::Some` değeri oluştururuz. İlk kol eşleştiğinden, başka kollar karşılaştırılmaz."
 
-#: src/ch06-02-the-match-control-flow-construct.md:135
+
+#: src/ch06-02-the-match-control-flow-construct.md:148
 msgid ""
 "Now let’s consider the second call of `plus_one` in our main function, where "
-"`x` is `Option::None`. We enter the `match` and compare to the first arm:"
+"`x` is `Option::None`. We enter the match and compare to the first arm:"
 msgstr ""
+"Şimdi ana fonksiyonumuzda `plus_one`'ın ikinci çağrısını düşünelim, burada `x` `Option::None`. Match'e girer ve ilk kola karşılaştırırız:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:141
+
+#: src/ch06-02-the-match-control-flow-construct.md:154
 msgid ""
 "The `Option::Some(val)` value doesn’t match the pattern `Option::None`, so "
 "we continue to the next arm:"
 msgstr ""
+"`Option::Some(val)` değeri `Option::None` deseniyle eşleşmez, bu yüzden bir sonraki kola devam ederiz:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:147
+
+#: src/ch06-02-the-match-control-flow-construct.md:160
 msgid ""
-"It matches! There’s no value to add to, so the matching construct ends and "
-"returns the `Option::None` value on the right side of `=>`."
+"It matches! There’s no value to add to, so the program stops and returns the "
+"`Option::None` value on the right side of `=>`."
 msgstr ""
+"Eşleşir! Ekleyecek bir değer yok, bu yüzden program durur ve `=>`'nin sağ tarafındaki `Option::None` değerini döndürür."
 
-#: src/ch06-02-the-match-control-flow-construct.md:149
+
+#: src/ch06-02-the-match-control-flow-construct.md:162
 msgid ""
 "Combining `match` and enums is useful in many situations. You’ll see this "
 "pattern a lot in Cairo code: `match` against an enum, bind a variable to the "
@@ -5545,26 +7064,33 @@ msgid ""
 "but once you get used to it, you’ll wish you had it in all languages. It’s "
 "consistently a user favorite."
 msgstr ""
+"`match` ve enumları birleştirmek birçok durumda yararlıdır. Bu deseni Cairo kodunda çok göreceksiniz: bir enuma karşı `match` yapın, veri içindeki bir değişkene bir değişken bağlayın ve sonra ona göre kod çalıştırın. İlk başta biraz zor olabilir, ama alıştığınızda, tüm dillerde bunu isteyeceksiniz. Tutarsız olarak bir kullanıcı favorisidir."
 
-#: src/ch06-02-the-match-control-flow-construct.md:151
+
+#: src/ch06-02-the-match-control-flow-construct.md:164
 msgid "Matches Are Exhaustive"
-msgstr ""
+msgstr "Eşleşmeler Kapsamlıdır"
 
-#: src/ch06-02-the-match-control-flow-construct.md:153
+
+#: src/ch06-02-the-match-control-flow-construct.md:166
 msgid ""
-"There’s one other aspect of `match` we need to discuss: the arms’ patterns "
+"There’s one other aspect of match we need to discuss: the arms’ patterns "
 "must cover all possibilities. Consider this version of our `plus_one` "
 "function, which has a bug and won’t compile:"
 msgstr ""
+"Match'in tartışmamız gereken bir başka yönü daha var: kolların desenleri tüm olasılıkları kapsamalı. `plus_one` fonksiyonumuzun bir hata içeren ve derlenemeyecek bir versiyonunu düşünün:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:163
+
+#: src/ch06-02-the-match-control-flow-construct.md:176
 msgid ""
 "We didn’t handle the `None` case, so this code will cause a bug. Luckily, "
 "it’s a bug Cairo knows how to catch. If we try to compile this code, we’ll "
 "get this error:"
 msgstr ""
+"`None` durumunu ele almadık, bu yüzden bu kod bir hata oluşturacak. Neyse ki, bu Cairo'nun yakalayabileceği bir hata. Bu kodu derlemeyi denediğimizde, bu hatayı alırız:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:175
+
+#: src/ch06-02-the-match-control-flow-construct.md:189
 msgid ""
 "Cairo knows that we didn’t cover every possible case, and even knows which "
 "pattern we forgot! Matches in Cairo are exhaustive: we must exhaust every "
@@ -5574,127 +7100,163 @@ msgid ""
 "might have null, thus making the billion-dollar mistake discussed earlier "
 "impossible."
 msgstr ""
+"Cairo, her olası durumu kapsamadığımızı ve hangi deseni unuttuğumuzu bile biliyor! Cairo'da maçlar tükenmiştir: kodun geçerli olması için son olasılığı tüketmemiz gerekir. Özellikle `Option<T>` durumunda, Cairo'nun `None` durumunu açıkça ele almayı unutmamızı önlemesi, bir değere sahip olduğumuzu varsayarken aslında null'a sahip olabileceğimiz, böylece daha önce tartışılan milyar dolarlık hatayı imkansız kılar."
 
-#: src/ch06-02-the-match-control-flow-construct.md:177
+
+#: src/ch06-02-the-match-control-flow-construct.md:191
 msgid "Catch-all with the `_` Placeholder"
-msgstr ""
+msgstr "_` Yer Tutucusu ile Her Şeyi Yakalama"
 
-#: src/ch06-02-the-match-control-flow-construct.md:179
+
+#: src/ch06-02-the-match-control-flow-construct.md:193
 msgid ""
 "Using enums, we can also take special actions for a few particular values, "
 "but for all other values take one default action. `_` is a special pattern "
 "that matches any value and does not bind to that value. You can use it by "
-"simply adding a new arm with `_` as the pattern for the last arm of the "
-"`match` expression."
+"simply add a new arm with `_` as the pattern as the last arm of the `match` "
+"expression."
 msgstr ""
+"Enumlar kullanarak, birkaç özel değer için özel eylemler alabilir, ancak diğer tüm değerler için bir varsayılan eylem alabiliriz. `_`, herhangi bir değerle eşleşen ve o değere bağlanmayan özel bir desendir. Basitçe, `_` deseni olan bir kol ekleyerek ve `match` ifadesinin son koluna ekleyerek kullanabilirsiniz."
 
-#: src/ch06-02-the-match-control-flow-construct.md:183
-msgid ""
-"Imagine we have a vending machine that only accepts Dime coins. We want to "
-"have a function that process inserted coins and returns `true` only if the "
-"coin is accepted."
-msgstr ""
-
-#: src/ch06-02-the-match-control-flow-construct.md:186
-msgid "Here's a `vending_machine_accept` function that implements this logic:"
-msgstr ""
 
 #: src/ch06-02-the-match-control-flow-construct.md:197
+msgid ""
+"Imagine we have a vending machine that only accepts Dime coins. We want to "
+"have a function that process inserted coins and returns true only if the "
+"coin is accepted."
+msgstr ""
+"Yalnızca Dime bozuk paralarını kabul eden bir otomat makinesi olduğunu hayal edin. İçine atılan bozuk paraları işleyen ve yalnızca bozuk para kabul edildiğinde true dönen bir fonksiyon istiyoruz."
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:200
+msgid "Here's a `vending_machine_accept` function that implements this logic:"
+msgstr "İşte bu mantığı uygulayan bir `vending_machine_accept` fonksiyonu:"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:211
 msgid ""
 "This example also meets the exhaustiveness requirement because we’re "
 "explicitly ignoring all other values in the last arm; we haven’t forgotten "
 "anything."
 msgstr ""
+"Bu örnek de tükenmişlik gereksinimini karşılıyor çünkü son kolda açıkça diğer tüm değerleri görmezden geliyoruz; hiçbir şeyi unutmadık."
 
-#: src/ch06-02-the-match-control-flow-construct.md:199
+
+#: src/ch06-02-the-match-control-flow-construct.md:213
 msgid ""
 "There's no catch-all pattern in Cairo that allows you to use the value of "
 "the pattern."
 msgstr ""
+"Cairo'da, desenin değerini kullanmanıza izin veren herhangi bir yakalama-tümü deseni yoktur."
 
-#: src/ch06-02-the-match-control-flow-construct.md:205
+
+#: src/ch06-02-the-match-control-flow-construct.md:219
 msgid "Multiple Patterns with the `|` operator"
-msgstr ""
+msgstr "`|` Operatörü ile Birden Fazla Desen"
 
-#: src/ch06-02-the-match-control-flow-construct.md:207
+
+#: src/ch06-02-the-match-control-flow-construct.md:221
 msgid ""
 "In `match` expressions, you can match multiple patterns using the `|` "
 "syntax, which is the pattern _or_ operator."
 msgstr ""
+"`match` ifadelerinde, `|` sözdizimini kullanarak birden fazla deseni eşleştirebilirsiniz, bu da desen _veya_ operatörüdür."
 
-#: src/ch06-02-the-match-control-flow-construct.md:209
+
+#: src/ch06-02-the-match-control-flow-construct.md:223
 msgid ""
 "For example, in the following code we modified the `vending_machine_accept` "
 "function to accept both `Dime` and `Quarter` coins in a single arm:"
 msgstr ""
+"Örneğin, aşağıdaki kodda `vending_machine_accept` fonksiyonunu hem `Dime` hem de `Quarter` bozuk paralarını tek bir kolda kabul edecek şekilde değiştirdik:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:220
-msgid "Matching Tuples"
-msgstr ""
-
-#: src/ch06-02-the-match-control-flow-construct.md:222
-msgid "It is possible to match tuples. Let's introduce a new `DayType` enum:"
-msgstr ""
 
 #: src/ch06-02-the-match-control-flow-construct.md:234
+msgid "Matching over Tuples"
+msgstr "Demetler Üzerinde Eşleşme"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:236
+msgid ""
+"It is possible to match over tuples. Let's introduce a new `DayType` enum:"
+msgstr ""
+"Demetler üzerinde eşleşmek mümkündür. Yeni bir `DayType` enum tanıtalım:"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:248
 msgid ""
 "Now, let's suppose that our vending machine accepts any coin on weekdays, "
 "but only accepts quarters and dimes on weekends and holidays. We can modify "
 "the `vending_machine_accept` function to accept a tuple of a `Coin` and a "
-"`Weekday` and return `true` only if the given coin is accepted on the "
-"specified day:"
+"`Weekday` and return `true` only if the coin is accepted and the day is a "
+"weekday:"
 msgstr ""
+"Şimdi, otomat makinemizin hafta içi herhangi bir bozuk parayı kabul ettiğini, ancak hafta sonları ve tatillerde yalnızca çeyrekler ve dime'ları kabul ettiğini varsayalım. `vending_machine_accept` fonksiyonunu bir `Coin` ve bir `Weekday` demetini kabul edecek şekilde değiştirebilir ve yalnızca bozuk para kabul edildiğinde ve gün hafta içi olduğunda `true` dönebiliriz:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:247
-msgid "Matching `felt252` and integer variables"
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:249
+#: src/ch06-02-the-match-control-flow-construct.md:261
+msgid "Matching over integers"
+msgstr "Tamsayılar Üzerinde Eşleşme"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:263
 msgid ""
-"You can also match `felt252` and integer variables. This is useful when you "
-"want to match against a range of values. However there are some restrictions:"
+"You can also match integers. This is useful when you want to match against a "
+"range of values. However there are some restrictions:"
 msgstr ""
+"Tamsayılarla da eşleşebilirsiniz. Bu, belirli bir değer aralığına karşı eşleşmek istediğinizde yararlıdır. Ancak bazı kısıtlamalar vardır:"
 
-#: src/ch06-02-the-match-control-flow-construct.md:252
+
+#: src/ch06-02-the-match-control-flow-construct.md:266
 msgid ""
-"Only integers that fit into a single `felt252` are supported (i.e. `u256` is "
-"not supported)."
+"Only integers that fits in a single `felt252` are supported. (i.e. `u256` is "
+"not supported)"
 msgstr ""
+"Yalnızca tek bir `felt252` içine sığan tamsayılar desteklenir. (yani `u256` desteklenmez)"
 
-#: src/ch06-02-the-match-control-flow-construct.md:253
+
+#: src/ch06-02-the-match-control-flow-construct.md:267
 msgid "The first arm must be 0."
-msgstr ""
+msgstr "İlk kolun 0 olması gerekir."
 
-#: src/ch06-02-the-match-control-flow-construct.md:254
-msgid "Each arm must cover a sequential segment, contiguously with other arms."
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:256
+#: src/ch06-02-the-match-control-flow-construct.md:268
+msgid "Each arms must be over a sequential segment (from `0`)"
+msgstr "Her kolun ardışık bir segment üzerinde olması gerekir (0'dan itibaren)"
+
+
+#: src/ch06-02-the-match-control-flow-construct.md:270
 msgid ""
 "Imagine we’re implementing a game where you roll a six-sided die to get a "
 "number between 0 and 5. If you have 0, 1 or 2 you win. If you have 3, you "
 "can roll again. For all other values you lose."
 msgstr ""
+"0 ile 5 arasında bir sayı almak için altı yüzlü bir zar attığınız bir oyun uyguladığımızı hayal edin. 0, 1 veya 2'niz varsa kazanırsınız. 3'ünüz varsa, tekrar zar atabilirsiniz. Diğer tüm değerler için kaybedersiniz."
 
-#: src/ch06-02-the-match-control-flow-construct.md:259
-msgid "Here's a match that implements that logic:"
-msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:264
+#: src/ch06-02-the-match-control-flow-construct.md:273
+msgid ""
+"Here's a match that implements that logic, with the number hardcoded rather "
+"than a random value."
+msgstr "İşte bu mantığı uygulayan bir eşleşme, rastgele bir değer yerine sabit kodlanmış sayı ile."
+
+#: src/ch06-02-the-match-control-flow-construct.md:278
 msgid "\"you won!\""
 msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:265
+#: src/ch06-02-the-match-control-flow-construct.md:279
 msgid "\"you can roll again!\""
 msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:266
+#: src/ch06-02-the-match-control-flow-construct.md:280
 msgid "\"you lost...\""
 msgstr ""
 
-#: src/ch06-02-the-match-control-flow-construct.md:271
-msgid "These restrictions are planned to be relaxed in future versions of Cairo."
+#: src/ch06-02-the-match-control-flow-construct.md:285
+msgid ""
+"These restrictions are planned to be relaxed in future versions of Cairo."
 msgstr ""
+"Bu kısıtlamaların Cairo'nun gelecek sürümlerinde gevşetilmesi planlanmaktadır."
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:3
 msgid ""
@@ -5703,6 +7265,8 @@ msgid ""
 "distinct features, you’ll clarify where to find code that implements a "
 "particular feature and where to go to change how a feature works."
 msgstr ""
+"Büyük programlar yazdıkça, kodunuzu düzenlemek giderek daha önemli hale gelecektir. İlgili işlevleri gruplayarak ve farklı özelliklere sahip kodları ayırarak, belirli bir özelliği uygulayan kodu nerede bulacağınızı ve bir özelliğin nasıl çalıştığını değiştirmek için nereye gideceğinizi netleştireceksiniz."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:8
 msgid ""
@@ -5712,6 +7276,8 @@ msgid ""
 "into separate crates that become external dependencies. This chapter covers "
 "all these techniques."
 msgstr ""
+"Şimdiye kadar yazdığımız programlar bir modülde bir dosyada yer almıştır. Bir proje büyüdükçe, kodu birden fazla modüle ve ardından birden fazla dosyaya ayırarak düzenlemeniz gerekebilir. Bir paket büyüdükçe, parçaları dışa bağımlılıklar haline gelen ayrı kraytlara çıkarabilirsiniz. Bu bölüm tüm bu teknikleri ele almaktadır."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:14
 msgid ""
@@ -5719,6 +7285,8 @@ msgid ""
 "reuse code at a higher level: once you’ve implemented an operation, other "
 "code can call your code without having to know how the implementation works."
 msgstr ""
+"Ayrıca, uygulama ayrıntılarını kapsüllemeyi de tartışacağız; bu da size daha yüksek bir seviyede kodu yeniden kullanma imkanı tanır: Bir işlemi uyguladıktan sonra, diğer kodlar kodunuzun nasıl çalıştığını bilmeksizin kodunuzu çağırabilir. "
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:19
 msgid ""
@@ -5730,6 +7298,8 @@ msgid ""
 "scopes and change which names are in or out of scope. You can’t have two "
 "items with the same name in the same scope."
 msgstr ""
+"İlgili bir kavram da kapsamdır: Kodun yazıldığı iç içe bağlamın, "kapsam" denen bir kümesi vardır. Okuma, yazma ve derleme işlemleri sırasında, bir programcının ve derleyicinin belirli bir noktadaki belirli bir adın bir değişkene, işleve, yapıya, numaralandırmaya, modüle, sabite veya başka bir öğeye mi referans ettiğini ve bu öğenin ne anlama geldiğini bilmesi gerekir. Kapsamlar oluşturabilir ve hangi adların kapsam içinde veya dışında olduğunu değiştirebilirsiniz. Aynı kapsamda aynı ada sahip iki öğe bulunamaz."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:27
 msgid ""
@@ -5737,10 +7307,15 @@ msgid ""
 "organization. These features, sometimes collectively referred to as the "
 "_module system_, include:"
 msgstr ""
+"Cairo, kodunuzun organizasyonunu yönetmenize olanak tanıyan bir dizi özellik sunar. Bu özellikler bazen _modül sistemi_ olarak topluca anılır ve şunları içerir:"
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:31
-msgid "**Packages:** A Scarb feature that lets you build, test, and share crates"
+msgid ""
+"**Packages:** A Scarb feature that lets you build, test, and share crates"
 msgstr ""
+"**Paketler:** Scarb özelliği, kraytlar oluşturmanıza, test etmenize ve paylaşmanıza olanak tanır."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:32
 msgid ""
@@ -5748,15 +7323,22 @@ msgid ""
 "It has a root directory, and a root module defined at the file `lib.cairo` "
 "under this directory."
 msgstr ""
+"**Kutu:** Tek bir derleme birimine karşılık gelen bir modül ağacıdır. Bir kök dizine ve bu dizin altındaki `lib.cairo` dosyasında tanımlanan bir kök modüle sahiptir."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:34
 msgid ""
 "**Modules** and **use:** Let you control the organization and scope of items."
 msgstr ""
+"**Modüller** ve **kullan:** Öğelerin organizasyonunu ve kapsamını kontrol etmenizi sağlar."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:35
-msgid "**Paths:** A way of naming an item, such as a struct, function, or module"
+msgid ""
+"**Paths:** A way of naming an item, such as a struct, function, or module"
 msgstr ""
+"**Yollar:** Bir öğeyi, örneğin bir yapı, işlev veya modülü adlandırmanın bir yoludur."
+
 
 #: src/ch07-00-managing-cairo-projects-with-packages-crates-and-modules.md:37
 msgid ""
@@ -5765,10 +7347,12 @@ msgid ""
 "solid understanding of the module system and be able to work with scopes "
 "like a pro!"
 msgstr ""
+"Bu bölümde, tüm bu özellikleri ele alacak, nasıl etkileşime girdiklerini tartışacak ve kapsamı yönetmek için nasıl kullanılacaklarını açıklayacağız. Sonunda, modül sistemini sağlam bir şekilde anlamalı ve kapsamlarla profesyonelce çalışabilmelisiniz!"
+
 
 #: src/ch07-01-packages-and-crates.md:3
 msgid "What is a crate?"
-msgstr ""
+msgstr "Kutu nedir?"
 
 #: src/ch07-01-packages-and-crates.md:5
 msgid ""
@@ -5779,22 +7363,26 @@ msgid ""
 "that get compiled with the crate, as will be discussed in the subsequent "
 "sections."
 msgstr ""
+"Bir kutu, Cairo derleyicisinin bir seferde dikkate aldığı en küçük kod miktarıdır. `scarb build` yerine `cairo-compile` komutunu çalıştırırsanız ve tek bir kaynak kodu dosyası geçirirseniz, derleyici o dosyayı bir kutu olarak kabul eder. Kutular modülleri içerebilir ve modüller, sandıkla derlenen diğer dosyalarda tanımlanabilir, bunlar ilerleyen bölümlerde tartışılacaktır."
+
 
 #: src/ch07-01-packages-and-crates.md:7
 msgid "What is the crate root?"
-msgstr ""
+msgstr "Kutu kökü nedir?"
 
 #: src/ch07-01-packages-and-crates.md:9
 msgid ""
 "The crate root is the `lib.cairo` source file that the Cairo compiler starts "
 "from and makes up the root module of your crate (we’ll explain modules in "
-"depth in the [“Defining Modules to Control "
-"Scope”](./ch07-02-defining-modules-to-control-scope.md) section)."
-msgstr ""
+"depth in the [“Defining Modules to Control Scope”](./ch07-02-defining-"
+"modules-to-control-scope.md) section)."
+msgstr "Kutu kökü, Cairo derleyicisinin başladığı ve kutunuzun kök modülünü oluşturan `lib.cairo` kaynak dosyasıdır."
+
+
 
 #: src/ch07-01-packages-and-crates.md:11
 msgid "What is a package?"
-msgstr ""
+msgstr "Paket nedir?"
 
 #: src/ch07-01-packages-and-crates.md:13
 msgid ""
@@ -5802,35 +7390,36 @@ msgid ""
 "that describes how to build those crates. This enables the splitting of code "
 "into smaller, reusable parts and facilitates more structured dependency "
 "management."
-msgstr ""
+msgstr "Bir Cairo paketi, bir veya daha fazla kutu ile birlikte, bu kutuların nasıl inşa edileceğini açıklayan bir Scarb.toml dosyasından oluşan bir demettir."
 
 #: src/ch07-01-packages-and-crates.md:15
 msgid "Creating a Package with Scarb"
-msgstr ""
+msgstr "Scarb ile Paket Oluşturma"
 
 #: src/ch07-01-packages-and-crates.md:17
 msgid ""
 "You can create a new Cairo package using the scarb command-line tool. To "
 "create a new package, run the following command:"
-msgstr ""
+msgstr "Yeni bir Cairo paketi oluşturmak için scarb komut satırı aracını kullanabilirsiniz. Yeni bir paket oluşturmak için aşağıdaki komutu çalıştırın:"
 
 #: src/ch07-01-packages-and-crates.md:23
 msgid ""
 "This command will generate a new package directory named `my_package` with "
 "the following structure:"
-msgstr ""
+msgstr "Bu komut, aşağıdaki yapıya sahip `my_package` adında yeni bir paket dizini oluşturur:"
 
 #: src/ch07-01-packages-and-crates.md:32
 msgid ""
 "`src/` is the main directory where all the Cairo source files for the "
 "package will be stored."
-msgstr ""
+msgstr "`src/`, paket için tüm Cairo kaynak dosyalarının saklanacağı ana dizindir."
+
 
 #: src/ch07-01-packages-and-crates.md:33
 msgid ""
 "`lib.cairo` is the default root module of the crate, which is also the main "
 "entry point of the package."
-msgstr ""
+msgstr "`lib.cairo`, kutunun varsayılan kök modülüdür ve aynı zamanda paketin ana giriş noktasıdır."
 
 #: src/ch07-01-packages-and-crates.md:34
 msgid ""
@@ -5838,7 +7427,7 @@ msgid ""
 "configuration options for the package, such as dependencies, package name, "
 "version, and authors. You can find documentation about it on the [scarb "
 "reference](https://docs.swmansion.com/scarb/docs/reference/manifest.html)."
-msgstr ""
+msgstr "`Scarb.toml`, bağımlılıklar, paket adı, sürüm ve yazarlar gibi paket için meta veri ve yapılandırma seçeneklerini içeren paket manifest dosyasıdır."
 
 #: src/ch07-01-packages-and-crates.md:36
 msgid ""
@@ -5857,25 +7446,25 @@ msgid ""
 "As you develop your package, you may want to organize your code into "
 "multiple Cairo source files. You can do this by creating additional `.cairo` "
 "files within the `src` directory or its subdirectories."
-msgstr ""
+msgstr "Paketinizi geliştirirken, kodunuzu birden fazla Cairo kaynak dosyasına ayırmak isteyebilirsiniz. Bunu, `src` dizini içinde veya alt dizinlerinde ek `.cairo` dosyaları oluşturarak yapabilirsiniz."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:3
 msgid ""
 "In this section, we’ll talk about modules and other parts of the module "
 "system, namely _paths_ that allow you to name items and the `use` keyword "
 "that brings a path into scope."
-msgstr ""
+msgstr "Bu bölümde, modüller ve modül sisteminin diğer parçaları olan _yollar_ hakkında ve bir yolu kapsam içine alma imkanı veren `use` anahtar kelimesi hakkında konuşacağız."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:7
 msgid ""
 "First, we’re going to start with a list of rules for easy reference when "
 "you’re organizing your code in the future. Then we’ll explain each of the "
 "rules in detail."
-msgstr ""
+msgstr "Öncelikle, kodunuzu gelecekte organize ederken kolay referans için bir kural listesiyle başlayacağız. Sonra bu kuralların her birini detaylı bir şekilde açıklayacağız."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:11
 msgid "Modules Cheat Sheet"
-msgstr ""
+msgstr "Modüller Hile Sayfası"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:13
 msgid ""
@@ -5885,26 +7474,26 @@ msgid ""
 "chapter, but this is a great place to refer to as a reminder of how modules "
 "work. You can create a new Scarb project with `scarb new backyard` to follow "
 "along."
-msgstr ""
+msgstr "Burada, modüllerin, yolların ve `use` anahtar kelimesinin derleyicide nasıl çalıştığına ve çoğu geliştiricinin kodlarını nasıl organize ettiğine dair hızlı bir referans sunuyoruz."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:19
 msgid ""
 "**Start from the crate root**: When compiling a crate, the compiler first "
 "looks in the crate root file (_src/lib.cairo_) for code to compile."
-msgstr ""
+msgstr "Kutu kökünden başlayın: Bir kutuyu derlerken, derleyici önce kodu derlemek için kutu kök dosyasında (_src/lib.cairo_) arar."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:21
 msgid ""
 "**Declaring modules**: In the crate root file, you can declare new modules; "
 "say, you declare a “garden” module with `mod garden;`. The compiler will "
 "look for the module’s code in these places:"
-msgstr ""
+msgstr "Modülleri bildirmek: Kutu kök dosyasında, `mod garden;` diyerek yeni modüller bildirebilirsiniz. Derleyici, modülün kodunu şu yerlerde arayacaktır:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:25
 msgid ""
 "Inline, within curly brackets that replace the semicolon following `mod "
 "garden;`."
-msgstr ""
+msgstr "Kıvırcık parantezler içinde, `mod garden;`i takip eden noktalı virgülün yerini alarak."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:28
 msgid "// crate root file (src/lib.cairo)\n"
@@ -5916,21 +7505,21 @@ msgstr ""
 
 #: src/ch07-02-defining-modules-to-control-scope.md:34
 msgid "In the file _src/garden.cairo_"
-msgstr ""
+msgstr "_src/garden.cairo_ dosyasında"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:36
 msgid ""
 "**Declaring submodules**: In any file other than the crate root, you can "
-"declare submodules. For example, you might declare `mod vegetables;` in "
-"_src/garden.cairo_. The compiler will look for the submodule’s code within "
-"the directory named for the parent module in these places:"
-msgstr ""
+"declare submodules. For example, you might declare `mod vegetables;` in _src/"
+"garden.cairo_. The compiler will look for the submodule’s code within the "
+"directory named for the parent module in these places:"
+msgstr "Alt modülleri bildirmek: Kutu kök dosyası dışındaki herhangi bir dosyada, alt modüller bildirebilirsiniz."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:41
 msgid ""
 "Inline, directly following `mod vegetables`, within curly brackets instead "
 "of the semicolon."
-msgstr ""
+msgstr "Doğrudan `mod vegetables`'ı takip eden ve noktalı virgülün yerine geçen kıvırcık parantezler içinde."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:45
 msgid "// src/garden.cairo file\n"
@@ -5942,16 +7531,16 @@ msgstr ""
 
 #: src/ch07-02-defining-modules-to-control-scope.md:51
 msgid "In the file _src/garden/vegetables.cairo_"
-msgstr ""
+msgstr "_src/garden/vegetables.cairo_ dosyasında"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:53
 msgid ""
 "**Paths to code in modules**: Once a module is part of your crate, you can "
 "refer to code in that module from anywhere else in that same crate, using "
 "the path to the code. For example, an `Asparagus` type in the garden "
-"vegetables module would be found at "
-"`backyard::garden::vegetables::Asparagus`."
-msgstr ""
+"vegetables module would be found at `backyard::garden::vegetables::"
+"Asparagus`."
+msgstr "Modüllerdeki kodlara yollar: Bir modül kutunuzun bir parçası olduktan sonra, aynı kutu içindeki herhangi bir yerden o modüldeki koda, kodun yolunu kullanarak atıfta bulunabilirsiniz."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:57
 msgid ""
@@ -5960,49 +7549,49 @@ msgid ""
 "`backyard::garden::vegetables::Asparagus`, you can create a shortcut with "
 "`use backyard::garden::vegetables::Asparagus;` and from then on you only "
 "need to write `Asparagus` to make use of that type in the scope."
-msgstr ""
+msgstr "`use` anahtar kelimesi: Bir kapsam içinde, `use` anahtar kelimesi, uzun yolların tekrarını azaltmak için öğelere kısayollar oluşturur."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:63
 msgid ""
 "Here we create a crate named `backyard` that illustrates these rules. The "
 "crate’s directory, also named `backyard`, contains these files and "
 "directories:"
-msgstr ""
+msgstr "Bu bölümde, `backyard` adında bu kuralları örneklendiren bir kutu oluşturuyoruz. Kutunun dizini, aynı zamanda `backyard` olarak adlandırılmış, bu dosya ve dizinleri içerir:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:76
 msgid "The crate root file in this case is _src/lib.cairo_, and it contains:"
-msgstr ""
+msgstr "Bu durumda kutu kök dosyası _src/lib.cairo_'dır ve içerdiği:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:90
 msgid ""
 "The `mod garden;` line tells the compiler to include the code it finds in "
 "_src/garden.cairo_, which is:"
-msgstr ""
+msgstr "`mod garden;` satırı, derleyicinin _src/garden.cairo_ içinde bulduğu kodu dahil etmesini söyler, bu şu anlama gelir:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:92
 msgid "Filename: src/garden.cairo"
-msgstr ""
+msgstr "Dosya adı: src/garden.cairo"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:98
 msgid ""
 "Here, `mod vegetables;` means the code in _src/garden/vegetables.cairo_ is "
 "included too. That code is:"
-msgstr ""
+msgstr "Burada, `mod vegetables;` _src/garden/vegetables.cairo_ içindeki kodun da dahil edildiği anlamına gelir. Bu kod şudur:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:106
 msgid ""
 "The line `use garden::vegetables::Asparagus;` lets us bring the `Asparagus` "
 "type into scope, so we can use it in the `main` function."
-msgstr ""
+msgstr "`use garden::vegetables::Asparagus;` satırı, `Asparagus` türünü kapsama alır, böylece onu `main` fonksiyonunda kullanabiliriz."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:109
 msgid ""
 "Now let’s get into the details of these rules and demonstrate them in action!"
-msgstr ""
+msgstr "Şimdi bu kuralların detaylarına dalalım ve onları eylemde gösterelim!"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:111
 msgid "Grouping Related Code in Modules"
-msgstr ""
+msgstr "Modüllerde İlgili Kodları Gruplama"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:113
 msgid ""
@@ -6011,7 +7600,7 @@ msgid ""
 "functionality of a restaurant. We’ll define the signatures of functions but "
 "leave their bodies empty to concentrate on the organization of the code, "
 "rather than the implementation of a restaurant."
-msgstr ""
+msgstr "_Modüller_, bir kutu içindeki kodu okunabilirlik ve kolay yeniden kullanım için düzenlememize izin verir. Örneğin, bir restoranın işlevselliğini sağlayan bir kütüphane kutusu yazalım. Fonksiyonların imzalarını tanımlayacağız ama kodun organizasyonuna odaklanmak için gövdelerini boş bırakacağız, restoranın uygulanması yerine."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:119
 msgid ""
@@ -6021,7 +7610,7 @@ msgid ""
 "orders and payment, and bartenders make drinks. Back of house is where the "
 "chefs and cooks work in the kitchen, dishwashers clean up, and managers do "
 "administrative work."
-msgstr ""
+msgstr "Restoran endüstrisinde, bir restoranın bazı kısımlarına _ön ev_ ve diğerlerine _arka ev_ denir. Ön ev, müşterilerin olduğu yerdir; bu, hostların müşterileri oturttuğu, garsonların sipariş ve ödemeleri aldığı ve barmenlerin içki yaptığı yerleri kapsar. Arka ev, şeflerin ve aşçıların mutfakta çalıştığı, bulaşıkçıların temizlik yaptığı ve yöneticilerin idari işleri yürüttüğü yerdir."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:126
 msgid ""
@@ -6030,13 +7619,13 @@ msgid ""
 "new restaurant`; then enter the code in Listing 7-1 into _src/lib.cairo_ to "
 "define some modules and function signatures. Here’s the front of house "
 "section:"
-msgstr ""
+msgstr "Kutumuzu bu şekilde yapılandırmak için, fonksiyonlarını iç içe modüller halinde düzenleyebiliriz. `scarb new restaurant` çalıştırarak `restaurant` adında yeni bir paket oluşturun; sonra bazı modülleri ve fonksiyon imzalarını tanımlamak için _src/lib.cairo_ içine Listeleme 7-1'deki kodu girin. İşte ön ev bölümü:"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:150
 msgid ""
 "Listing 7-1: A `front_of_house` module containing other modules that then "
 "contain functions"
-msgstr ""
+msgstr "Listeleme 7-1: Diğer modülleri içeren ve sonra fonksiyonları içeren bir `front_of_house` modülü"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:153
 msgid ""
@@ -6046,7 +7635,7 @@ msgid ""
 "with the modules `hosting` and `serving`. Modules can also hold definitions "
 "for other items, such as structs, enums, constants, traits, and—as in "
 "Listing 6-1—functions."
-msgstr ""
+msgstr "`mod` anahtar kelimesini modülün adıyla (bu durumda, `front_of_house`) takip ederek bir modül tanımlarız. Modülün gövdesi sonra kıvırcık parantezler içine girer. Modüller içinde, bu durumda olduğu gibi `hosting` ve `serving` modülleri ile diğer modüller yerleştirebiliriz. Modüller ayrıca structlar, enumlar, sabitler, traitler ve Listeleme 6-1'de olduğu gibi fonksiyonlar gibi diğer öğeler için tanımlamaları da içerebilir."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:160
 msgid ""
@@ -6056,7 +7645,7 @@ msgid ""
 "easier to find the definitions relevant to them. Programmers adding new "
 "functionality to this code would know where to place the code to keep the "
 "program organized."
-msgstr ""
+msgstr "Modülleri kullanarak, ilgili tanımlamaları bir araya gruplayabilir ve neden ilişkili olduklarını adlandırabiliriz. Bu kodu kullanan programcılar, tüm tanımları okumak zorunda kalmadan gruplara dayanarak kodu gezinebilir, bu da onlara ilgili tanımlamaları daha kolay bulmalarını sağlar. Bu koda yeni işlevsellik ekleyen programcılar, programı düzenli tutmak için kodu nereye yerleştireceklerini bilecektir."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:166
 msgid ""
@@ -6064,15 +7653,15 @@ msgid ""
 "reason for this name is that the content of this file form a module named "
 "after the crate name at the root of the crate’s module structure, known as "
 "the _module tree_."
-msgstr ""
+msgstr "Daha önce, _src/lib.cairo_'nun kutu kökü olarak adlandırıldığını belirtmiştik. Bu adın nedeni, bu dosyanın içeriğinin kutunun modül yapısının kökünde, _modül ağacı_ olarak bilinen, kutu adıyla adlandırılan bir modülü oluşturmasıdır."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:170
 msgid "Listing 7-2 shows the module tree for the structure in Listing 7-1."
-msgstr ""
+msgstr "Listeleme 7-2, Listeleme 7-1'deki yapı için modül ağacını gösterir."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:184
 msgid "Listing 7-2: The module tree for the code in Listing 6-1"
-msgstr ""
+msgstr "Listeleme 7-2: Listeleme 6-1'deki kod için modül ağacı"
 
 #: src/ch07-02-defining-modules-to-control-scope.md:187
 msgid ""
@@ -6084,7 +7673,7 @@ msgid ""
 "module A is the _child_ of module B and that module B is the _parent_ of "
 "module A. Notice that the entire module tree is rooted under the explicit "
 "name of the crate `restaurant`."
-msgstr ""
+msgstr "Bu ağaç, bazı modüllerin birbirinin içine nasıl yerleştirildiğini gösterir; örneğin, `hosting` `front_of_house` içinde yer alır. Ağaç ayrıca bazı modüllerin birbirine _kardeş_ olduğunu, yani aynı modülde tanımlandıklarını gösterir; `hosting` ve `serving` `front_of_house` içinde tanımlanmış kardeşlerdir. Eğer modül A, modül B'nin içinde yer alıyorsa, modül A'nın modül B'nin _çocuğu_ olduğunu ve modül B'nin modül A'nın _ebeveyni_ olduğunu söyleriz. Tüm modül ağacının `restaurant` kutusunun açık adı altında köklendiğine dikkat edin."
 
 #: src/ch07-02-defining-modules-to-control-scope.md:195
 msgid ""
@@ -6092,34 +7681,36 @@ msgid ""
 "computer; this is a very apt comparison! Just like directories in a "
 "filesystem, you use modules to organize your code. And just like files in a "
 "directory, we need a way to find our modules."
-msgstr ""
+msgstr "Modül ağacı, bilgisayarınızdaki dosya sisteminin dizin ağacını hatırlatabilir; bu çok uygun bir karşılaştırmadır! Dosya sistemindeki dizinler gibi, kodunuzu düzenlemek için modülleri kullanırsınız. Ve bir dizindeki dosyalar gibi, modüllerimizi bulmanın bir yoluna ihtiyacımız var."
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:3
 msgid ""
 "To show Cairo where to find an item in a module tree, we use a path in the "
 "same way we use a path when navigating a filesystem. To call a function, we "
 "need to know its path."
-msgstr ""
+msgstr "Cairo'ya bir modül ağacında bir öğeyi nerede bulacağını göstermek için, bir dosya sistemini gezinirken yaptığımız gibi bir yolu kullanırız. Bir fonksiyonu çağırmak için, yolunu bilmemiz gerekir."
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:5
 msgid "A path can take two forms:"
-msgstr ""
+msgstr "Bir yol iki şekil alabilir:"
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:7
 msgid ""
 "An _absolute path_ is the full path starting from a crate root. The absolute "
 "path begins with the crate name."
-msgstr ""
+msgstr "Bir _mutlak yol_, kutu kökünden başlayan tam yoldur. Mutlak yol, kutu adıyla başlar."
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:8
 msgid "A _relative path_ starts from the current module."
-msgstr ""
+msgstr "Bir _göreceli yol_, mevcut modülden başlar."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:10
 msgid ""
 "Both absolute and relative paths are followed by one or more identifiers "
 "separated by double colons (`::`)."
-msgstr ""
+msgstr "Hem mutlak hem de göreceli yollar, çift iki nokta üst üste (`::`) ile ayrılmış bir veya daha fazla tanımlayıcı ile takip edilir."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:13
 msgid ""
@@ -6130,7 +7721,8 @@ msgid ""
 "`add_to_waitlist`. We want to call the `add_to_waitlist` function from the "
 "`eat_at_restaurant` function. We need to tell Cairo the path to the "
 "`add_to_waitlist` function so it can find it."
-msgstr ""
+msgstr "Bu kavramı açıklamak için son bölümde kullandığımız restoran örneğine, Listeleme 7-1'e geri dönelim. `restaurant` adında bir kutumuz var ve bu kutuda `front_of_house` adında bir modül var. `hosting` modülü, `add_to_waitlist` adında bir fonksiyon içeriyor. `eat_at_restaurant` fonksiyonundan `add_to_waitlist` fonksiyonunu çağırmak istiyoruz. Cairo'ya `add_to_waitlist` fonksiyonunun yolunu söylememiz gerekiyor ki bulabilsin."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:36
 msgid "// Absolute path\n"
@@ -6149,7 +7741,8 @@ msgstr ""
 msgid ""
 "Listing 7-3: Calling the `add_to_waitlist` function using absolute and "
 "relative paths"
-msgstr ""
+msgstr "Listeleme 7-3: `add_to_waitlist` fonksiyonunu mutlak ve göreceli yollar kullanarak çağırma"
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:46
 msgid ""
@@ -6158,42 +7751,50 @@ msgid ""
 "is defined in the same crate as `eat_at_restaurant`. In Cairo, absolute "
 "paths start from the crate root, which you need to refer to by using the "
 "crate name."
-msgstr ""
+msgstr "`eat_at_restaurant` içinde `add_to_waitlist` fonksiyonunu ilk kez çağırdığımızda, bir mutlak yol kullanırız. `add_to_waitlist` fonksiyonu, `eat_at_restaurant` ile aynı kutuda tanımlanmıştır. Cairo'da, mutlak yollar kutu kökünden başlar, bunun için kutu adını kullanmanız gerekir."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:50
 msgid ""
 "The second time we call `add_to_waitlist`, we use a relative path. The path "
 "starts with `front_of_house`, the name of the module defined at the same "
 "level of the module tree as `eat_at_restaurant`. Here the filesystem "
-"equivalent would be using the path "
-"`./front_of_house/hosting/add_to_waitlist`. Starting with a module name "
-"means that the path is relative to the current module."
-msgstr ""
+"equivalent would be using the path `./front_of_house/hosting/"
+"add_to_waitlist`. Starting with a module name means that the path is "
+"relative to the current module."
+msgstr "İkinci kez `add_to_waitlist`'i çağırdığımızda, bir göreceli yol kullanırız. Yol, modül ağacının aynı seviyesinde `eat_at_restaurant` ile tanımlanmış `front_of_house` modülünün adıyla başlar. Burada dosya sistemindeki eşdeğeri `./front_of_house/hosting/add_to_waitlist` yolunu kullanmaktır. Bir modül adıyla başlamak, yolun mevcut modüle göreli olduğu anlamına gelir."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:56
 msgid "Starting Relative Paths with `super`"
-msgstr ""
+msgstr "`super` ile Göreceli Yolların Başlatılması"
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:58
 msgid ""
 "Choosing whether to use a `super` or not is a decision you’ll make based on "
 "your project, and depends on whether you’re more likely to move item "
 "definition code separately from or together with the code that uses the item."
-msgstr ""
+msgstr "Bir `super` kullanıp kullanmamaya karar vermek, projenize bağlı bir karardır ve öğe tanım kodunu, öğeyi kullanan kodla birlikte veya ayrı olarak taşıma olasılığınıza bağlıdır."
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:77
-msgid "Listing 7-4: Calling a function using a relative path starting with super"
-msgstr ""
+msgid ""
+"Listing 7-4: Calling a function using a relative path starting with super"
+msgstr "Listeleme 7-4: `super` ile başlayan bir göreceli yol kullanarak bir fonksiyonu çağırma"
+
 
 #: src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md:79
 msgid ""
 "Here you can see directly that you access a parent's module easily using "
 "`super`, which wasn't the case previously."
-msgstr ""
+msgstr "Burada, `super` kullanarak bir ebeveyn modülüne doğrudan nasıl erişilebileceğini görebilirsiniz, bu önceki durumda mümkün değildi."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:1
 msgid "Bringing Paths into Scope with the `use` Keyword"
-msgstr ""
+msgstr "`use` Anahtar Kelimesi ile Yolları Kapsama Almak"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:3
 msgid ""
@@ -6201,7 +7802,8 @@ msgid ""
 "repetitive. Fortunately, there’s a way to simplify this process: we can "
 "create a shortcut to a path with the `use` keyword once, and then use the "
 "shorter name everywhere else in the scope."
-msgstr ""
+msgstr "Fonksiyonları çağırmak için yolları yazmak zorunda kalmak, rahatsız edici ve tekrar eden bir durum olabilir. Neyse ki, bu süreci basitleştirecek bir yol var: `use` anahtar kelimesi ile bir yola bir kez kısayol oluşturabilir ve sonra kapsamdaki her yerde daha kısa adı kullanabiliriz."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:5
 msgid ""
@@ -6209,7 +7811,8 @@ msgid ""
 "into the scope of the `eat_at_restaurant` function so we only have to "
 "specify `hosting::add_to_waitlist` to call the `add_to_waitlist` function in "
 "`eat_at_restaurant`."
-msgstr ""
+msgstr "Listeleme 7-5'te, `eat_at_restaurant` fonksiyonunun kapsamına `restaurant::front_of_house::hosting` modülünü getiriyoruz, böylece `eat_at_restaurant` içinde `add_to_waitlist` fonksiyonunu çağırmak için sadece `hosting::add_to_waitlist` dememiz yeterli oluyor."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:13
 msgid ""
@@ -6226,7 +7829,8 @@ msgstr ""
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:29
 msgid "Listing 7-5: Bringing a module into scope with `use`"
-msgstr ""
+msgstr "Listeleme 7-5: `use` ile bir modülü kapsama almak"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:32
 msgid ""
@@ -6234,7 +7838,8 @@ msgid ""
 "the filesystem. By adding `use restaurant::front_of_house::hosting` in the "
 "crate root, hosting is now a valid name in that scope, just as though the "
 "`hosting` module had been defined in the crate root."
-msgstr ""
+msgstr "Kapsamda `use` ve bir yolu eklemek, dosya sisteminde sembolik bir bağlantı oluşturmaya benzer. Kutu kökünde `use restaurant::front_of_house::hosting` ekleyerek, `hosting` artık o kapsamda geçerli bir ad olur, sanki `hosting` modülü kutu kökünde tanımlanmış gibi."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:34
 msgid ""
@@ -6242,36 +7847,39 @@ msgid ""
 "the `use` occurs. Listing 7-6 moves the `eat_at_restaurant` function into a "
 "new child module named `customer`, which is then a different scope than the "
 "`use` statement, so the function body won’t compile:"
-msgstr ""
+msgstr "`use` yalnızca `use`'ın gerçekleştiği belirli kapsam için kısayolu oluşturur. Listeleme 7-6, `eat_at_restaurant` fonksiyonunu `customer` adında yeni bir çocuk modüle taşır, bu da `use` ifadesinden farklı bir kapsam oluşturur, bu yüzden fonksiyon gövdesi derlenmez:"
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:56
 msgid "Listing 7-6: A `use` statement only applies in the scope it’s in"
-msgstr ""
+msgstr "Listeleme 7-6: Bir `use` ifadesi yalnızca içinde bulunduğu kapsamda geçerlidir"
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:59
 msgid ""
 "The compiler error shows that the shortcut no longer applies within the "
 "`customer` module:"
-msgstr ""
+msgstr "Derleyici hatası, kısayolun `customer` modülü içinde artık geçerli olmadığını gösterir:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:70
 msgid "Creating Idiomatic `use` Paths"
-msgstr ""
+msgstr "İdiyomatik `use` Yolları Oluşturma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:72
 msgid ""
-"In Listing 7-5, you might have wondered why we specified `use "
-"restaurant::front_of_house::hosting` and then called "
-"`hosting::add_to_waitlist` in `eat_at_restaurant` rather than specifying the "
-"`use` path all the way out to the `add_to_waitlist` function to achieve the "
-"same result, as in Listing 7-7."
-msgstr ""
+"In Listing 7-5, you might have wondered why we specified `use restaurant::"
+"front_of_house::hosting` and then called `hosting::add_to_waitlist` in "
+"`eat_at_restaurant` rather than specifying the `use` path all the way out to "
+"the `add_to_waitlist` function to achieve the same result, as in Listing 7-7."
+msgstr "Listeleme 7-5'te, `use restaurant::front_of_house::hosting` belirtip `eat_at_restaurant` içinde `hosting::add_to_waitlist` çağırmamızın nedeni, aynı sonucu elde etmek için `add_to_waitlist` fonksiyonuna kadar `use` yolunu belirtmememizdir, Listeleme 7-7'de olduğu gibi."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:93
 msgid ""
 "Listing 7-7: Bringing the `add_to_waitlist` function into scope with `use`, "
 "which is unidiomatic"
-msgstr ""
+msgstr "Listeleme 7-7: `use` ile `add_to_waitlist` fonksiyonunu kapsama almak, ki bu idiyomatik değildir"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:96
 msgid ""
@@ -6282,18 +7890,21 @@ msgid ""
 "calling the function makes it clear that the function isn’t locally defined "
 "while still minimizing repetition of the full path. The code in Listing 7-7 "
 "is unclear as to where `add_to_waitlist` is defined."
-msgstr ""
+msgstr "Hem Listeleme 7-5 hem de 7-7 aynı görevi yerine getirse de, Listeleme 7-5 bir fonksiyonu `use` ile kapsama almanın idiyomatik yoludur. Fonksiyonun ana modülünü `use` ile kapsama almak, fonksiyonu çağırırken ana modülü belirtmemiz gerektiği anlamına gelir. Fonksiyonu çağırırken ana modülü belirtmek, fonksiyonun yerel olarak tanımlanmadığını açıkça yaparken, tam yolu tekrarlamayı da en aza indirir. Listeleme 7-7'deki kod, `add_to_waitlist`'in nerede tanımlandığı konusunda belirsizdir."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:104
 msgid ""
 "On the other hand, when bringing in structs, enums, traits, and other items "
 "with `use`, it’s idiomatic to specify the full path. Listing 7-8 shows the "
 "idiomatic way to bring the core library’s `ArrayTrait` trait into the scope."
-msgstr ""
+msgstr "Diğer taraftan, yapılar, enumlar, traitler ve `use` ile kapsama alınan diğer öğeleri getirirken, tam yolu belirtmek idiyomatiktir. Listeleme 7-8, çekirdek kütüphanenin `ArrayTrait` trait'ini kapsama alanına idiyomatik bir şekilde getirmeyi gösterir."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:115
 msgid "Listing 7-8: Bringing `ArrayTrait` into scope in an idiomatic way"
-msgstr ""
+msgstr "Listeleme 7-8: `ArrayTrait`'i idiyomatik bir şekilde kapsama almak"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:118
 msgid ""
@@ -6301,17 +7912,20 @@ msgid ""
 "has emerged in the Rust community, and folks have gotten used to reading and "
 "writing Rust code this way. As Cairo shares many idioms with Rust, we follow "
 "this convention as well."
-msgstr ""
+msgstr "Bu idiyomun arkasında güçlü bir neden yoktur: bu sadece Rust topluluğunda ortaya çıkan bir gelenektir ve insanlar Rust kodunu bu şekilde okumaya ve yazmaya alışmışlardır. Cairo, Rust ile birçok idiyomu paylaştığı için, bu geleneği biz de takip ediyoruz."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:122
 msgid ""
 "The exception to this idiom is if we’re bringing two items with the same "
 "name into scope with `use` statements, because Cairo doesn’t allow that."
-msgstr ""
+msgstr "`use` ifadeleri ile aynı isme sahip iki öğeyi kapsama almak istediğimizde bu idiyomun bir istisnası vardır, çünkü Cairo bunu izin vermez."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:125
 msgid "Providing New Names with the `as` Keyword"
-msgstr ""
+msgstr "`as` Anahtar Kelimesi ile Yeni İsimler Sağlamak"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:127
 msgid ""
@@ -6319,7 +7933,8 @@ msgid ""
 "name into the same scope with `use`: after the path, we can specify `as` and "
 "a new local name, or _alias_, for the type. Listing 7-9 shows how you can "
 "rename an import with `as`:"
-msgstr ""
+msgstr "`use` ile aynı isimdeki iki tipi aynı kapsama almanın sorununa başka bir çözüm daha var: yolu belirttikten sonra, tip için yeni bir yerel ad veya _takma ad_ belirlemek üzere `as` ve bir adı belirtebiliriz. Listeleme 7-9, bir import'u `as` ile nasıl yeniden adlandırabileceğinizi gösterir:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:137
 msgid "// ArrayTrait was renamed to Arr\n"
@@ -6329,17 +7944,20 @@ msgstr ""
 msgid ""
 "Listing 7-9: Renaming a trait when it’s brought into scope with the `as` "
 "keyword"
-msgstr ""
+msgstr "Listeleme 7-9: `as` anahtar kelimesi ile kapsama alındığında bir trait'i yeniden adlandırma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:145
 msgid ""
 "Here, we brought `ArrayTrait` into scope with the alias `Arr`. We can now "
 "access the trait's methods with the `Arr` identifier."
-msgstr ""
+msgstr "Burada, `ArrayTrait`'i `Arr` takma adıyla kapsama aldık. Artık trait'in metodlarına `Arr` tanımlayıcısı ile erişebiliriz."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:147
 msgid "Importing multiple items from the same module"
-msgstr ""
+msgstr "Aynı Modülden Birden Fazla Öğeyi İçe Aktarma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:149
 msgid ""
@@ -6347,15 +7965,20 @@ msgid ""
 "from the same module in Cairo, you can use curly braces `{}` to list all of "
 "the items that you want to import. This helps to keep your code clean and "
 "easy to read by avoiding a long list of individual use statements."
-msgstr ""
+msgstr "Cairo'da, aynı modülden birden fazla öğeyi (fonksiyonlar, yapılar veya enumlar gibi) içe aktarmak istediğinizde, içe aktarmak istediğiniz tüm öğeleri listelemek için küme parantezleri `{}` kullanabilirsiniz. Bu, uzun bir `use` ifadeleri listesinden kaçınarak kodunuzu temiz ve okunabilir tutmaya yardımcı olur."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:154
-msgid "The general syntax for importing multiple items from the same module is:"
-msgstr ""
+msgid ""
+"The general syntax for importing multiple items from the same module is:"
+msgstr "Aynı modülden birden fazla öğeyi içe aktarmanın genel sözdizimi:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:160
-msgid "Here is an example where we import three structures from the same module:"
-msgstr ""
+msgid ""
+"Here is an example where we import three structures from the same module:"
+msgstr "İşte aynı modülden üç yapıyı içe aktardığımız bir örnek:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:163
 msgid ""
@@ -6384,11 +8007,13 @@ msgstr ""
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:194
 msgid "Listing 7-10: Importing multiple items from the same module"
-msgstr ""
+msgstr "Listeleme 7-10: Aynı modülden birden fazla öğeyi içe aktarma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:196
 msgid "Re-exporting Names in Module Files"
-msgstr ""
+msgstr "Modül Dosyalarında İsimleri Yeniden Dışa Aktarma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:198
 msgid ""
@@ -6397,28 +8022,32 @@ msgid ""
 "scope. This technique is called _re-exporting_ because we’re bringing an "
 "item into scope, but also making that item available for others to bring "
 "into their scope."
-msgstr ""
+msgstr "`use` anahtar kelimesi ile bir ismi kapsama alırken, yeni kapsamdaki isim, o kodun kapsamında tanımlanmış gibi içe aktarılabilir. Bu tekniğe _yeniden dışa aktarma_ denir çünkü bir öğeyi kapsama alıyoruz, ama aynı zamanda bu öğeyi başkalarının da kendi kapsamlarına alabilmesi için kullanılabilir hale getiriyoruz."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:203
 msgid ""
 "For example, let's re-export the `add_to_waitlist` function in the "
 "restaurant example:"
-msgstr ""
+msgstr "Örneğin, restoran örneğinde `add_to_waitlist` fonksiyonunu yeniden dışa aktaralım:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:221
 msgid ""
 "Listing 7-11: Making a name available for any code to use from a new scope "
 "with `pub use`"
-msgstr ""
+msgstr "Listeleme 7-11: `pub use` ile bir ismi yeni bir kapsamdan herhangi bir kodun kullanımına sunma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:224
 msgid ""
 "Before this change, external code would have to call the `add_to_waitlist` "
-"function by using the path "
-"`restaurant::front_of_house::hosting::add_to_waitlist()`. Now that this "
-"`use` has re-exported the `hosting` module from the root module, external "
-"code can now use the path `restaurant::hosting::add_to_waitlist()` instead."
-msgstr ""
+"function by using the path `restaurant::front_of_house::hosting::"
+"add_to_waitlist()`. Now that this `use` has re-exported the `hosting` module "
+"from the root module, external code can now use the path `restaurant::"
+"hosting::add_to_waitlist()` instead."
+msgstr "Bu değişiklikten önce, dış kod `add_to_waitlist` fonksiyonunu `restaurant::front_of_house::hosting::add_to_waitlist()` yoluyla çağırmak zorunda kalacaktı. Bu `use` ile `hosting` modülü kök modülden yeniden dışa aktarıldığı için, dış kod artık `restaurant::hosting::add_to_waitlist()` yolunu kullanabilir."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:230
 msgid ""
@@ -6430,32 +8059,37 @@ msgid ""
 "terms. With `use`, we can write our code with one structure but expose a "
 "different structure. Doing so makes our library well organized for "
 "programmers working on the library and programmers calling the library."
-msgstr ""
+msgstr "Yeniden dışa aktarma, kodunuzun iç yapısı kodunuzu çağıran programcıların alan hakkında düşündüğü şekilden farklı olduğunda faydalıdır. Örneğin, bu restoran metaforunda, restoranı işleten insanlar “ön ev” ve “arka ev” hakkında düşünür. Ancak bir restoranı ziyaret eden müşteriler muhtemelen restoranın bölümlerini bu terimlerle düşünmeyecektir. `use` ile, kodumuzu bir yapıda yazabilir ama farklı bir yapıyı sunabiliriz. Bunu yapmak, kütüphanemizi kütüphane üzerinde çalışan programcılar ve kütüphaneyi çağıran programcılar için iyi organize edilmiş hale getirir."
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:239
 msgid "Using External Packages in Cairo with Scarb"
-msgstr ""
+msgstr "Scarb ile Cairo'da Dış Paketleri Kullanma"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:241
 msgid ""
 "You might need to use external packages to leverage the functionality "
 "provided by the community. To use an external package in your project with "
 "Scarb, follow these steps:"
-msgstr ""
+msgstr "Topluluktan sağlanan işlevselliği kullanmak için dış paketlere ihtiyaç duyabilirsiniz. Scarb ile projenizde bir dış paket kullanmak için şu adımları izleyin:"
+
 
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:243
 msgid ""
 "The dependencies system is still a work in progress. You can check the "
-"official "
-"[documentation](https://docs.swmansion.com/scarb/docs/guides/dependencies.html)."
-msgstr ""
+"official [documentation](https://docs.swmansion.com/scarb/docs/guides/"
+"dependencies.html)."
+msgstr "Bağımlılıklar sistemi hala bir çalışma aşamasındadır. Resmi [belgelere](https://docs.swmansion.com/scarb/docs/guides/dependencies.html) bakabilirsiniz."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:3
 msgid ""
 "So far, all the examples in this chapter defined multiple modules in one "
 "file. When modules get large, you might want to move their definitions to a "
 "separate file to make the code easier to navigate."
-msgstr ""
+msgstr "Şu ana kadar bu bölümdeki tüm örnekler, birden fazla modülü tek bir dosyada tanımladı. Modüller büyüdükçe, kodu daha kolay gezinebilir hale getirmek için tanımlarını ayrı bir dosyaya taşımak isteyebilirsiniz."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:7
 msgid ""
@@ -6463,7 +8097,8 @@ msgid ""
 "restaurant modules. We’ll extract modules into files instead of having all "
 "the modules defined in the crate root file. In this case, the crate root "
 "file is _src/lib.cairo_."
-msgstr ""
+msgstr "Örneğin, birden fazla restoran modülü içeren Listeleme 7-11'deki koddan başlayalım. Tüm modülleri kutu kök dosyasında tanımlamak yerine, modülleri dosyalara ayıklayacağız. Bu durumda, kutu kök dosyası _src/lib.cairo_'dur."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:12
 msgid ""
@@ -6472,13 +8107,15 @@ msgid ""
 "the `mod front_of_house;` declaration, so that _src/lib.cairo_ contains the "
 "code shown in Listing 7-12. Note that this won’t compile until we create the "
 "_src/front_of_house.cairo_ file in Listing 7-13."
-msgstr ""
+msgstr "İlk olarak, `front_of_house` modülünü kendi dosyasına ayıklayacağız. `front_of_house` modülü için kıvırcık parantezler içindeki kodu kaldırın, yalnızca `mod front_of_house;` bildirimini bırakın, böylece _src/lib.cairo_ Listeleme 7-12'de gösterildiği gibi kodu içerir. Listeleme 7-13'teki _src/front_of_house.cairo_ dosyasını oluşturana kadar bu derlenmeyecektir."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:30
 msgid ""
 "Listing 7-12: Declaring the `front_of_house` module whose body will be in "
 "_src/front_of_house.cairo_"
-msgstr ""
+msgstr "Listeleme 7-12: Gövdesi _src/front_of_house.cairo_'da olacak `front_of_house` modülünü bildirme"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:33
 msgid ""
@@ -6486,18 +8123,21 @@ msgid ""
 "_src/front_of_house.cairo_, as shown in Listing 7-13. The compiler knows to "
 "look in this file because it came across the module declaration in the crate "
 "root with the name `front_of_house`."
-msgstr ""
+msgstr "Daha sonra, kıvırcık parantezler içindeki kodu _src/front_of_house.cairo_ adlı yeni bir dosyaya yerleştirin, Listeleme 7-13'te gösterildiği gibi. Derleyici, modül bildirimini kutu kökünde `front_of_house` adıyla karşılaştığı için bu dosyada kodu aramak için nereye bakacağını bilir."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:38
 #: src/ch07-05-separating-modules-into-different-files.md:66
 msgid "Filename: src/front_of_house.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/front_of_house.cairo"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:46
 msgid ""
-"Listing 7-13: Definitions inside the `front_of_house` module in "
-"_src/front_of_house.cairo_"
-msgstr ""
+"Listing 7-13: Definitions inside the `front_of_house` module in _src/"
+"front_of_house.cairo_"
+msgstr "Listeleme 7-13: `front_of_house` modülü içindeki tanımlar _src/front_of_house.cairo_'da"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:49
 msgid ""
@@ -6506,40 +8146,46 @@ msgid ""
 "(and knows where in the module tree the code resides because of where you’ve "
 "put the `mod` statement), other files in your project should refer to the "
 "loaded file’s code using a path to where it was declared, as covered in the "
-"[“Paths for Referring to an Item in the Module "
-"Tree”](ch06-03-paths-for-referring-to-an-item-in-the-module-tree.html)"
-msgstr ""
+"[“Paths for Referring to an Item in the Module Tree”](ch06-03-paths-for-"
+"referring-to-an-item-in-the-module-tree.html)"
+msgstr "Bir dosyayı `mod` bildirimi kullanarak yüklemeniz yalnızca modül ağacınızda _bir kez_ gereklidir. Derleyici dosyanın projenin bir parçası olduğunu bildiği zaman (ve `mod` ifadesini nereye koyduğunuzdan dolayı kodun modül ağacında nerede bulunduğunu bildiği için), projenizdeki diğer dosyalar yüklenen dosyanın koduna, modül ağacında nerede bildirildiğine dair bir yolu kullanarak atıfta bulunmalıdır."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:54
 msgid ""
 " section. In other words, `mod` is _not_ an “include” operation that you may "
 "have seen in other programming languages."
-msgstr ""
+msgstr "Diğer bir deyişle, `mod` diğer programlama dillerinde görebileceğiniz bir “include” işlemi _değildir_."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:58
 msgid ""
 "Next, we’ll extract the `hosting` module to its own file. The process is a "
 "bit different because `hosting` is a child module of `front_of_house`, not "
 "of the root module. We’ll place the file for `hosting` in a new directory "
-"that will be named for its ancestors in the module tree, in this case "
-"_src/front_of_house/_."
-msgstr ""
+"that will be named for its ancestors in the module tree, in this case _src/"
+"front_of_house/_."
+msgstr "`hosting` modülünü kendi dosyasına ayıracağız. İşlem biraz farklıdır çünkü `hosting`, kök modülün değil, `front_of_house`'un çocuk modülüdür. `hosting` dosyasını, bu durumda _src/front_of_house/_ olacak şekilde, modül ağacındaki atalarının adıyla adlandırılacak yeni bir dizine yerleştireceğiz."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:63
 msgid ""
 "To start moving `hosting`, we change _src/front_of_house.cairo_ to contain "
 "only the declaration of the `hosting` module:"
-msgstr ""
+msgstr "`hosting`'i taşımaya başlamak için, _src/front_of_house.cairo_ içinde yalnızca `hosting` modülünün bildirimini içerecek şekilde değiştiririz:"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:72
 msgid ""
 "Then we create a _src/front_of_house_ directory and a file _hosting.cairo_ "
 "to contain the definitions made in the `hosting` module:"
-msgstr ""
+msgstr "Ardından `hosting` modülünde yapılan tanımları içerecek _hosting.cairo_ adında bir dosya ve _src/front_of_house_ dizini oluştururuz:"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:75
 msgid "Filename: src/front_of_house/hosting.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/front_of_house/hosting.cairo"
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:81
 msgid ""
@@ -6548,7 +8194,8 @@ msgid ""
 "crate root, and not declared as a child of the `front_of_house` module. The "
 "compiler’s rules for which files to check for which modules’ code means the "
 "directories and files more closely match the module tree."
-msgstr ""
+msgstr "Eğer _hosting.cairo_ dosyasını _src_ dizinine koysaydık, derleyici _hosting.cairo_ kodunun, `front_of_house` modülünün bir çocuğu olarak değil, kutu kökünde bildirilmiş bir `hosting` modülünde olmasını beklerdi. Derleyicinin hangi dosyaları hangi modüllerin kodları için kontrol edeceği kuralları, dizinlerin ve dosyaların modül ağacını daha yakından takip etmesini sağlar."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:87
 msgid ""
@@ -6557,16 +8204,18 @@ msgid ""
 "without any modification, even though the definitions live in different "
 "files. This technique lets you move modules to new files as they grow in "
 "size."
-msgstr ""
+msgstr "Her modülün kodunu ayrı bir dosyaya taşıdık ve modül ağacı aynı kaldı. `eat_at_restaurant` içindeki fonksiyon çağrıları, tanımlar farklı dosyalarda yaşasa bile herhangi bir değişiklik olmadan çalışacaktır. Bu teknik, modüller büyüdükçe yeni dosyalara taşınmasını sağlar."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:92
 msgid ""
-"Note that the `use restaurant::front_of_house::hosting` statement in "
-"_src/lib.cairo_ also hasn’t changed, nor does `use` have any impact on what "
-"files are compiled as part of the crate. The `mod` keyword declares modules, "
-"and Cairo looks in a file with the same name as the module for the code that "
+"Note that the `use restaurant::front_of_house::hosting` statement in _src/"
+"lib.cairo_ also hasn’t changed, nor does `use` have any impact on what files "
+"are compiled as part of the crate. The `mod` keyword declares modules, and "
+"Cairo looks in a file with the same name as the module for the code that "
 "goes into that module."
-msgstr ""
+msgstr "Ayrıca, _src/lib.cairo_ içindeki `use restaurant::front_of_house::hosting` ifadesi de değişmedi, `use` ifadesi kutunun bir parçası olarak hangi dosyaların derlendiği üzerinde herhangi bir etkiye sahip değil. `mod` anahtar kelimesi modülleri bildirir ve Cairo, modülle aynı adı taşıyan bir dosyada o modül için kodu arar."
+
 
 #: src/ch07-05-separating-modules-into-different-files.md:100
 msgid ""
@@ -6575,33 +8224,38 @@ msgid ""
 "do this by specifying absolute or relative paths. These paths can be brought "
 "into scope with a `use` statement so you can use a shorter path for multiple "
 "uses of the item in that scope. Module code is public by default."
-msgstr ""
+msgstr "Cairo, bir paketi birden fazla kutuya ve bir kutuyu modüllere bölmek için size olanak tanır, böylece bir modülde tanımlanan öğelere başka bir modülden atıfta bulunabilirsiniz. Bunu yapmak için mutlak veya göreceli yolları belirtebilirsiniz. Bu yollar, bir `use` ifadesi ile kapsama alınabilir, böylece o kapsamdaki öğenin birden fazla kullanımı için daha kısa bir yol kullanabilirsiniz. Modül kodu varsayılan olarak halkadır."
+
 
 #: src/ch08-00-generic-types-and-traits.md:1
 msgid "Generic Types and Traits"
-msgstr ""
+msgstr "Genel Türler ve Traitler"
+
 
 #: src/ch08-00-generic-types-and-traits.md:3
 msgid ""
 "Every programming language has tools for effectively handling the "
-"duplication of concepts. In Cairo, one such tool is generics: abstract "
-"stand-ins for concrete types or other properties. We can express the "
-"behavior of generics or how they relate to other generics without knowing "
-"what will be in their place when compiling and running the code."
-msgstr ""
+"duplication of concepts. In Cairo, one such tool is generics: abstract stand-"
+"ins for concrete types or other properties. We can express the behavior of "
+"generics or how they relate to other generics without knowing what will be "
+"in their place when compiling and running the code."
+msgstr "Her programlama dilinde, kavramların çoğaltılmasını etkili bir şekilde ele almanın araçları vardır. Cairo'da, bu araçlardan biri genel türlerdir: somut türler veya diğer özellikler için soyut yer tutucular. Genel türlerin davranışını veya diğer genel türlerle nasıl ilişkili olduklarını, kodu derleme ve çalıştırma sırasında yerlerinde ne olacağını bilmeksizin ifade edebiliriz."
+
 
 #: src/ch08-00-generic-types-and-traits.md:5
 msgid ""
 "Functions, structs, enums and traits can incorporate generic types as part "
 "of their definition instead of a concrete type like `u32` or "
 "`ContractAddress`."
-msgstr ""
+msgstr "Fonksiyonlar, yapılar, enumlar ve traitler, `u32` veya `ContractAddress` gibi somut bir tür yerine genel türleri tanımlarının bir parçası olarak kapsayabilir."
+
 
 #: src/ch08-00-generic-types-and-traits.md:7
 msgid ""
 "Generics allow us to replace specific types with a placeholder that "
 "represents multiple types to remove code duplication."
-msgstr ""
+msgstr "Genel türler, belirli türlerle kod tekrarını ortadan kaldırmak için yer tutucu olarak kullanılmamıza olanak tanır."
+
 
 #: src/ch08-00-generic-types-and-traits.md:9
 msgid ""
@@ -6610,7 +8264,8 @@ msgid ""
 "duplication at compile level still exists. This may be of importance if you "
 "are writing Starknet contracts and using a generic for multiple types which "
 "will cause contract size to increment."
-msgstr ""
+msgstr "Genel bir tür yerine her somut tür için derleyici yeni bir tanım oluşturur, bu da programcı için geliştirme süresini azaltır, ancak derleme seviyesinde hala kod tekrarı vardır. Eğer Starknet sözleşmeleri yazıyorsanız ve birden fazla tür için genel bir tür kullanıyorsanız, bu, sözleşme boyutunun artması nedeniyle önemli olabilir."
+
 
 #: src/ch08-00-generic-types-and-traits.md:11
 msgid ""
@@ -6618,7 +8273,8 @@ msgid ""
 "can combine traits with generic types to constrain a generic type to accept "
 "only those types that have a particular behavior, as opposed to just any "
 "type."
-msgstr ""
+msgstr "Daha sonra, davranışı genel bir şekilde tanımlamak için traitleri nasıl kullanacağınızı öğreneceksiniz. Genel türlerle traitleri birleştirerek, genel bir türü yalnızca belirli bir davranışa sahip olan türlerle sınırlayabilirsiniz, yalnızca herhangi bir tür yerine."
+
 
 #: src/ch08-01-generic-data-types.md:3
 msgid ""
@@ -6627,7 +8283,8 @@ msgid ""
 "types. In Cairo we can use generics when defining functions, structs, enums, "
 "traits, implementations and methods! In this chapter we are going to take a "
 "look at how to effectively use generic types with all of them."
-msgstr ""
+msgstr "Genel türlerle tanım oluştururken, tanımların, örneğin yapılar ve fonksiyonlar gibi öğe bildirimleri için genel türleri kullanırız. Böylece bunları birçok farklı somut veri tipi ile kullanabiliriz. Cairo'da fonksiyonlar, yapılar, enumlar, traitler, uygulamalar ve metodlar tanımlarken genel türleri kullanabiliriz! Bu bölümde, hepsiyle genel türleri nasıl etkili bir şekilde kullanacağımıza bakacağız."
+
 
 #: src/ch08-01-generic-data-types.md:7
 msgid ""
@@ -6638,7 +8295,8 @@ msgid ""
 "we need to perform this operation for lists of different types, then we "
 "would have to redefine the function each time. Luckily we can implement the "
 "function once using generics and move on to other tasks."
-msgstr ""
+msgstr "Genel türleri kullanan bir fonksiyon tanımlarken, genel türleri fonksiyon imzasına yerleştiririz, genellikle parametre ve dönüş değerinin veri tiplerini belirttiğimiz yerde. Örneğin, iki `Array` öğesi verildiğinde en büyüğünü döndüren bir fonksiyon oluşturmak istediğimizi hayal edin. Bu işlemi farklı türlerdeki listeler için gerçekleştirmemiz gerekiyorsa, her seferinde fonksiyonu yeniden tanımlamamız gerekirdi. Neyse ki, genel türleri kullanarak fonksiyonu bir kez uygulayabilir ve diğer görevlere geçebiliriz."
+
 
 #: src/ch08-01-generic-data-types.md:10
 msgid "// Specify generic type T between the angulars\n"
@@ -6661,7 +8319,7 @@ msgid ""
 "compiler must first know how to drop `T`. This can be fixed by specifying in "
 "the function signature of `largest_list` that `T` must implement the drop "
 "trait. The correct function definition of `largest_list` is as follows:"
-msgstr ""
+msgstr "`largest_list` fonksiyonu, aynı türden iki listeyi karşılaştırır ve daha fazla elemana sahip olanı döndürüp diğerini atar. Önceki kodu derlediğinizde, genel bir tür için bir dizi bırakma işlemiyle ilgili tanımlanmış traitler olmadığını söyleyen bir hata ile başarısız olacağını fark edeceksiniz. Bu, derleyicinin `main` fonksiyonunu çalıştırırken bir `Array<T>`'nin bırakılabilir olduğunu garanti edememesinden kaynaklanır. `T` türündeki bir diziyi bırakabilmek için, derleyicinin önce `T`'yi nasıl bırakacağını bilmelidir. Bu, `largest_list` fonksiyonunun imzasında `T`'nin bırakma traitini uygulaması gerektiğini belirterek düzeltilebilir. `largest_list` fonksiyonunun doğru tanımı şu şekildedir:"
 
 #: src/ch08-01-generic-data-types.md:49
 msgid ""
@@ -6669,11 +8327,12 @@ msgid ""
 "that whatever generic type is placed there, it must be droppable. The `main` "
 "function remains unchanged, the compiler is smart enough to deduce which "
 "concrete type is being used and if it implements the `Drop` trait."
-msgstr ""
+msgstr "Yeni `largest_list` fonksiyonu, tanımında, oraya yerleştirilen genel tür ne olursa olsun, bırakılabilir olması gerektiği gereksinimini içerir. `main` fonksiyonu değişmeden kalır, derleyici kullanılan somut türü ve `Drop` traitini uygulayıp uygulamadığını akıllıca çıkarabilir."
 
 #: src/ch08-01-generic-data-types.md:51
 msgid "Constraints for Generic Types"
-msgstr ""
+msgstr "Genel Türler için Kısıtlamalar"
+
 
 #: src/ch08-01-generic-data-types.md:53
 msgid ""
@@ -6685,7 +8344,8 @@ msgid ""
 "arguments of `largest_list`. While `TDrop` was added to satisfy the "
 "compiler's requirements, we can also add constraints to benefit our function "
 "logic."
-msgstr ""
+msgstr "Genel türler tanımlanırken, onlar hakkında bilgi sahibi olmak faydalıdır. Genel bir türün hangi traitleri uyguladığını bilmek, fonksiyon mantığında onları daha etkili bir şekilde kullanmamıza olanak tanır, bunun maliyeti ise fonksiyonla kullanılabilecek genel türleri kısıtlamaktır. Bunu daha önce, `largest_list`'in genel argümanlarına `TDrop` uygulamasını ekleyerek gördük. `TDrop`, derleyicinin gereksinimlerini karşılamak için eklenmiş olsa da, fonksiyon mantığımızı yararlandırmak için de kısıtlamalar ekleyebiliriz."
+
 
 #: src/ch08-01-generic-data-types.md:55
 msgid ""
@@ -6693,7 +8353,8 @@ msgid ""
 "find the smallest element among them. Initially, we know that for an element "
 "of type `T` to be comparable, it must implement the `PartialOrd` trait. The "
 "resulting function would be:"
-msgstr ""
+msgstr "Bir `T` genel türünden elemanların listesini verdiğimizde, aralarından en küçüğünü bulmak istediğimizi hayal edin. Başlangıçta, bir `T` türünden elemanın karşılaştırılabilir olması için `PartialOrd` traitini uygulaması gerektiğini biliyoruz. Sonuç fonksiyon şöyle olurdu:"
+
 
 #: src/ch08-01-generic-data-types.md:58
 msgid ""
@@ -6729,7 +8390,8 @@ msgid ""
 "`@Array<T>`, we no longer need to drop it at the end of the execution and so "
 "we don't require to implement the `Drop` trait for `T` as well. Why it does "
 "not compile then?"
-msgstr ""
+msgstr "`smallest_element` fonksiyonu, `PartialOrd` traitini uygulayan bir genel tür `T` kullanır, `Array<T>`'nin bir anlık görüntüsünü parametre olarak alır ve en küçük elemanın bir kopyasını döndürür. Parametre `@Array<T>` türünde olduğu için, yürütmenin sonunda onu bırakmamız gerekmez ve dolayısıyla `T` için de `Drop` traitini uygulamamız gerekmez. O zaman neden derlenmiyor?"
+
 
 #: src/ch08-01-generic-data-types.md:92
 msgid ""
@@ -6742,18 +8404,19 @@ msgid ""
 "then add both `Drop` and `Copy` traits implementation for the function to be "
 "correct. After updating the`smallest_element` function the resulting code "
 "would be:"
-msgstr ""
+msgstr "`list` üzerinde dizinleme yapıldığında, değer, dizinlenen öğenin bir anlık görüntüsü sonucunu verir, `@T` için `PartialOrd` uygulanmadıkça öğeyi `*` kullanarak anlık görüntüden çıkarmamız gerekir. `*` işlemi, `@T`'den `T`'ye bir kopya gerektirir, bu da `T`'nin `Copy` özelliğini uygulaması gerektiği anlamına gelir. `@T` türünden bir öğeyi `T`'ye kopyaladıktan sonra, bırakılması gereken `T` türünde değişkenler vardır, bu da `T` için `Drop` özelliğinin de uygulanması gerektiğini gerektirir. Fonksiyonun doğru olması için hem `Drop` hem de `Copy` özelliklerinin uygulanması gerekir. `smallest_element` fonksiyonunu güncelledikten sonra sonuç kod şu olacaktır:"
+
 
 #: src/ch08-01-generic-data-types.md:112
 msgid "Anonymous Generic Implementation Parameter (`+` operator)"
-msgstr ""
+msgstr "Anonim Genel Uygulama Parametresi (`+` operatörü)"
 
 #: src/ch08-01-generic-data-types.md:114
 msgid ""
 "Until now, we have always specified a name for each implementation of the "
 "required generic trait: `TPartialOrd` for `PartialOrd<T>`, `TDrop` for "
 "`Drop<T>`, and `TCopy` for `Copy<T>`."
-msgstr ""
+msgstr "Şimdiye kadar, gereken genel özelliklerin her biri için bir isim belirttik: `PartialOrd<T>` için `TPartialOrd`, `Drop<T>` için `TDrop` ve `Copy<T>` için `TCopy`."
 
 #: src/ch08-01-generic-data-types.md:116
 msgid ""
@@ -6762,17 +8425,17 @@ msgid ""
 "operator to specify that the generic type must implement a trait without "
 "naming the implementation. This is referred to as an _anonymous generic "
 "implementation parameter_."
-msgstr ""
+msgstr "Ancak, çoğu zaman, fonksiyon gövdesinde uygulamayı kullanmayız; sadece bir kısıtlama olarak kullanırız. Bu durumlarda, genel türün bir özelliği uygulaması gerektiğini belirtmek için `+` operatörünü kullanabilir ve uygulamaya bir isim vermeyebiliriz. Buna _anonim genel uygulama parametresi_ denir."
 
 #: src/ch08-01-generic-data-types.md:118
 msgid ""
 "For example, `+PartialOrd<T>` is equivalent to `impl TPartialOrd: "
 "PartialOrd<T>`."
-msgstr ""
+msgstr "`+PartialOrd<T>`, `impl TPartialOrd: PartialOrd<T>` ile eşdeğerdir."
 
 #: src/ch08-01-generic-data-types.md:120
 msgid "We can rewrite the `smallest_element` function signature as follows:"
-msgstr ""
+msgstr "`smallest_element` fonksiyonun imzasını şu şekilde yeniden yazabiliriz:"
 
 #: src/ch08-01-generic-data-types.md:138
 msgid "Structs"
@@ -6787,13 +8450,13 @@ msgid ""
 "definition where we would otherwise specify concrete data types. The next "
 "code example shows the definition `Wallet<T>` which has a `balance` field of "
 "type `T`."
-msgstr ""
+msgstr "Yapıları, bir veya daha fazla alan için genel tür parametresi kullanacak şekilde `<>` sözdizimini kullanarak tanımlayabiliriz, fonksiyon tanımlarına benzer şekilde. Önce yapı adının hemen ardından açı parantezleri içinde tür parametresinin adını belirtiriz. Daha sonra yapı tanımında, aksi takdirde somut veri türlerini belirteceğimiz yerde genel türü kullanırız. Aşağıdaki kod örneği, `T` türünde bir `balance` alanına sahip olan `Wallet<T>` tanımını göstermektedir."
 
 #: src/ch08-01-generic-data-types.md:154
 msgid ""
 "The above code derives the `Drop` trait for the `Wallet` type automatically. "
 "It is equivalent to writing the following code:"
-msgstr ""
+msgstr "Yukarıdaki kod, `Wallet` türü için `Drop` özelliğini otomatik olarak türetilir. Bu, aşağıdaki kodu yazmakla eşdeğerdir:"
 
 #: src/ch08-01-generic-data-types.md:168
 msgid ""
@@ -6802,28 +8465,28 @@ msgid ""
 "define, just like functions, an additional generic type for `WalletDrop` "
 "saying that `T` implements the `Drop` trait as well. We are basically saying "
 "that the struct `Wallet<T>` is droppable as long as `T` is also droppable."
-msgstr ""
+msgstr "`Wallet` için `Drop` uygulamasının `derive` makrosunu kullanmaktan kaçınıyoruz ve bunun yerine kendi `WalletDrop` uygulamamızı tanımlıyoruz. Fonksiyonlar gibi, `WalletDrop` için ek bir genel tür tanımlamamız gerektiğini unutmayın, `T`'nin `Drop` özelliğini uyguladığını söyleyin. Esasında, `Wallet<T>` yapısının, `T` bırakılabilir olduğu sürece bırakılabilir olduğunu söylüyoruz."
 
 #: src/ch08-01-generic-data-types.md:170
 msgid ""
 "Finally, if we want to add a field to `Wallet` representing its address and "
 "we want that field to be different than `T` but generic as well, we can "
 "simply add another generic type between the `<>`:"
-msgstr ""
+msgstr "Son olarak, `Wallet`'a, `T`'den farklı ancak aynı zamanda genel olan bir adres alanı eklemek istiyorsak, `<>` arasına başka bir genel tür ekleyebiliriz:"
 
 #: src/ch08-01-generic-data-types.md:184
 msgid ""
 "We add to `Wallet` struct definition a new generic type `U` and then assign "
 "this type to the new field member `address`. Notice that the derive "
 "attribute for the `Drop` trait works for `U` as well."
-msgstr ""
+msgstr "`Wallet` yapı tanımına `U` adında yeni bir genel tür ekler ve bu türü yeni alan üyesi `address`'e atarız. `Drop` özelliğinin türetme özelliğinin `U` için de çalıştığına dikkat edin."
 
 #: src/ch08-01-generic-data-types.md:188
 msgid ""
 "As we did with structs, we can define enums to hold generic data types in "
 "their variants. For example the `Option<T>` enum provided by the Cairo core "
 "library:"
-msgstr ""
+msgstr "Yapılarla yaptığımız gibi, enumları da varyantlarında genel veri türlerini tutacak şekilde tanımlayabiliriz. Örneğin, Cairo çekirdek kütüphanesi tarafından sağlanan `Option<T>` enumu:"
 
 #: src/ch08-01-generic-data-types.md:197
 msgid ""
@@ -6832,13 +8495,13 @@ msgid ""
 "value. By using the `Option<T>` enum, it is possible for us to express the "
 "abstract concept of an optional value and because the value has a generic "
 "type `T` we can use this abstraction with any type."
-msgstr ""
+msgstr "`Option<T>` enumu, `T` türü üzerinden genelleştirilmiştir ve iki varyanta sahiptir: `Some`, `T` türünde bir değer tutar ve `None` herhangi bir değer tutmaz. `Option<T>` enumunu kullanarak, bir değerin isteğe bağlı kavramını soyut bir şekilde ifade edebiliriz ve çünkü değer genel bir `T` türündedir, bu soyutlamayı her türle kullanabiliriz."
 
 #: src/ch08-01-generic-data-types.md:199
 msgid ""
 "Enums can use multiple generic types as well, like definition of the "
 "`Result<T, E>` enum that the core library provides:"
-msgstr ""
+msgstr "Enumlar birden fazla genel türü de kullanabilir, çekirdek kütüphanenin sağladığı `Result<T, E>` enumunun tanımı gibi:"
 
 #: src/ch08-01-generic-data-types.md:208 src/ch10-02-recoverable-errors.md:18
 msgid ""
@@ -6847,18 +8510,18 @@ msgid ""
 "value of type `E`. This definition makes it convenient to use the `Result` "
 "enum anywhere we have an operation that might succeed (by returning a value "
 "of type `T`) or fail (by returning a value of type `E`)."
-msgstr ""
+msgstr "`Result<T, E>` enumu iki genel tür, `T` ve `E` içerir ve iki varyanta sahiptir: `Ok`, `T` türünde bir değer tutar ve `Err`, `E` türünde bir değer tutar. Bu tanım, bir işlemin başarılı olabileceği (bir `T` türünde değer döndürerek) veya başarısız olabileceği (bir `E` türünde değer döndürerek) herhangi bir yerde `Result` enumunu kullanmayı uygun hale getirir."
 
 #: src/ch08-01-generic-data-types.md:210
 msgid "Generic Methods"
-msgstr ""
+msgstr "Genel Metodlar"
 
 #: src/ch08-01-generic-data-types.md:212
 msgid ""
 "We can implement methods on structs and enums, and use the generic types in "
 "their definition, too. Using our previous definition of `Wallet<T>` struct, "
 "we define a `balance` method for it:"
-msgstr ""
+msgstr "Yapılar ve enumlar üzerinde metodlar uygulayabilir ve tanımlarında genel türleri de kullanabiliriz. Önceki `Wallet<T>` yapısının tanımını kullanarak, onun için bir `balance` metodu tanımlayalım:"
 
 #: src/ch08-01-generic-data-types.md:236
 msgid ""
@@ -6867,7 +8530,7 @@ msgid ""
 "`Wallet`. Then we give an implementation for the trait in `WalletImpl<T>`. "
 "Note that you need to include a generic type in both definitions of the "
 "trait and the implementation."
-msgstr ""
+msgstr "Önce, `T` genel türü kullanan `WalletTrait<T>` traitini tanımlarız. Bu, `Wallet`'dan `balance` alanının bir anlık görüntüsünü döndüren bir metod tanımlar. Daha sonra `WalletImpl<T>`'de trait için bir uygulama veririz. Trait ve uygulamanın her ikisinin tanımlarında da genel bir türü dahil etmeniz gerektiğini unutmayın."
 
 #: src/ch08-01-generic-data-types.md:238
 msgid ""
@@ -6876,7 +8539,8 @@ msgid ""
 "instances rather than `Wallet<T>`. In the code example we define an "
 "implementation for wallets which have a concrete type of `u128` for the "
 "`balance` field."
-msgstr ""
+msgstr "Tür üzerinde metotlar tanımlarken genel türler için kısıtlamalar da belirtebiliriz. Örneğin, `Wallet<T>` yerine yalnızca `Wallet<u128>` örnekleri için metotlar uygulayabiliriz. Kod örneğinde, `balance` alanının somut türü `u128` olan cüzdanlar için bir uygulama tanımlıyoruz."
+
 
 #: src/ch08-01-generic-data-types.md:245
 msgid "/// Generic trait for wallets\n"
@@ -6893,7 +8557,7 @@ msgid ""
 "mutable variable in order for it to be able to update its balance. If we "
 "were to change the initialization of `w` by changing the type of `balance` "
 "the previous code wouldn't compile."
-msgstr ""
+msgstr "Yeni `receive` metodu, bir `Wallet<u128>` örneğinin bakiye boyutunu artırır. `w`'yi mutable bir değişken yaparak `main` fonksiyonunu değiştirdiğimize dikkat edin, böylece bakiyesini güncelleyebilir. `w`'nin başlatılmasını `balance` türünü değiştirerek değiştirirsek, önceki kod derlenmez."
 
 #: src/ch08-01-generic-data-types.md:279
 msgid ""
@@ -6901,11 +8565,11 @@ msgid ""
 "Using the past implementation from `Wallet<U, V>` we are going to define a "
 "trait that picks two wallets of different generic types and create a new one "
 "with a generic type of each. First, let's rewrite the struct definition:"
-msgstr ""
+msgstr "Cairo, genel traitler içinde genel metotlar tanımlamamıza da olanak tanır. `Wallet<U, V>`'den geçmiş uygulamayı kullanarak, farklı genel türlerdeki iki cüzdanı alıp her birinin genel türüyle yeni bir tane oluşturan bir trait tanımlayacağız. İlk olarak, yapı tanımını yeniden yazalım:"
 
 #: src/ch08-01-generic-data-types.md:288
 msgid "Next we are going to naively define the mixup trait and implementation:"
-msgstr ""
+msgstr "Şimdi karışım traitini ve uygulamasını naifçe tanımlayacağız:"
 
 #: src/ch08-01-generic-data-types.md:291
 msgid "// This does not compile!\n"
@@ -6922,21 +8586,21 @@ msgid ""
 "generic types specifying that they will implement the `Drop` trait in order "
 "for the compiler to know how to drop instances of `Wallet<T, U>`. The "
 "updated implementation is as follow:"
-msgstr ""
+msgstr "`WalletMixTrait<T1, U1>` traiti ile `mixup<T2, U2>` metodlarını oluşturuyoruz ki bu, `Wallet<T1, U1>` ve `Wallet<T2, U2>` örnekleri verildiğinde yeni bir `Wallet<T1, U2>` oluşturur. `mixup` imzası belirtildiği gibi, hem `self` hem de `other` fonksiyonun sonunda bırakılıyor, bu kodun derlenmemesinin nedenidir. Başından beri takip ediyorsanız, derleyicinin `Wallet<T, U>` örneklerini nasıl bırakacağını bilmek için tüm genel türler için `Drop` traitini uygulayacaklarına dair bir gereksinim eklememiz gerektiğini biliyor olmalısınız. Güncellenmiş uygulama şu şekildedir:"
 
 #: src/ch08-01-generic-data-types.md:322
 msgid ""
 "We add the requirements for `T1` and `U1` to be droppable on `WalletMixImpl` "
 "declaration. Then we do the same for `T2` and `U2`, this time as part of "
 "`mixup` signature. We can now try the `mixup` function:"
-msgstr ""
+msgstr "`WalletMixImpl` deklarasyonunda `T1` ve `U1`'in bırakılabilir olması gerektiği gereksinimlerini ekliyoruz. Sonra aynısını `T2` ve `U2` için yapıyoruz, bu sefer `mixup` imzasının bir parçası olarak. Artık `mixup` fonksiyonunu deneyebiliriz:"
 
 #: src/ch08-01-generic-data-types.md:336
 msgid ""
 "We first create two instances: one of `Wallet<bool, u128>` and the other of "
 "`Wallet<felt252, u8>`. Then, we call `mixup` and create a new `Wallet<bool, "
 "u8>` instance."
-msgstr ""
+msgstr "İlk olarak, biri `Wallet<bool, u128>` ve diğeri `Wallet<felt252, u8>` olmak üzere iki örnek oluşturuyoruz. Sonra, `mixup`'ı çağırıp yeni bir `Wallet<bool, u8>` örneği oluşturuyoruz."
 
 #: src/ch08-02-traits-in-cairo.md:3
 msgid ""
@@ -6946,13 +8610,13 @@ msgid ""
 "particular type has and can share with other types. We can use traits to "
 "define shared behavior in an abstract way. We can use _trait bounds_ to "
 "specify that a generic type can be any type that has certain behavior."
-msgstr ""
+msgstr "Bir trait, bir tip tarafından uygulanabilecek bir metodlar kümesini tanımlar. Bu trait uygulandığında, bu metodlar tipin örnekleri üzerinde çağrılabilir. Bir trait bir genel tiple birleştiğinde, belirli bir tipin sahip olduğu ve diğer tiplerle paylaşabileceği işlevselliği tanımlar. Traitleri, soyut bir şekilde paylaşılan davranışı tanımlamak için kullanabiliriz. Genel bir türün yalnızca belirli bir davranışa sahip olan herhangi bir tür olabileceğini belirtmek için _trait sınırları_ kullanabiliriz."
 
 #: src/ch08-02-traits-in-cairo.md:7
 msgid ""
 "Note: Traits are similar to a feature often called interfaces in other "
 "languages, although with some differences."
-msgstr ""
+msgstr "Not: Traitler, diğer dillerde genellikle arayüzler olarak adlandırılan bir özelliğe benzer, ancak bazı farklılıklarla."
 
 #: src/ch08-02-traits-in-cairo.md:9
 msgid ""
@@ -6961,11 +8625,11 @@ msgid ""
 "[previous chapter](./ch08-01-generic-data-types.md), and we will use them in "
 "this chapter to demonstrate how traits can be used to define shared behavior "
 "for generic types."
-msgstr ""
+msgstr "Traitler genel türler kabul etmeyecek şekilde yazılabilirken, genel türlerle kullanıldıklarında en faydalı olurlar. Genel türleri [önceki bölümde](./ch08-01-generic-data-types.md) zaten ele aldık ve bu bölümde, genel türler için paylaşılan davranışı tanımlamak üzere traitlerin nasıl kullanılabileceğini göstermek için onları kullanacağız."
 
 #: src/ch08-02-traits-in-cairo.md:11
 msgid "Defining a Trait"
-msgstr ""
+msgstr "Bir Trait Tanımlama"
 
 #: src/ch08-02-traits-in-cairo.md:13
 msgid ""
@@ -6973,7 +8637,7 @@ msgid ""
 "Different types share the same behavior if we can call the same methods on "
 "all of those types. Trait definitions are a way to group method signatures "
 "together to define a set of behaviors necessary to accomplish some purpose."
-msgstr ""
+msgstr "Bir tipin davranışı, o tipe çağrılabilen metodlardan oluşur. Farklı tipler, tüm bu tipler üzerinde aynı metodları çağırabildiğimizde aynı davranışı paylaşır. Trait tanımları, belirli bir amaç gerçekleştirmek için gerekli olan bir dizi davranışı tanımlamak için metod imzalarını bir araya toplama yoludur."
 
 #: src/ch08-02-traits-in-cairo.md:15
 msgid ""
@@ -6981,7 +8645,7 @@ msgid ""
 "story in a particular location. We can define a trait `Summary` that "
 "describes the behavior of something that can summarize the `NewsArticle` "
 "type."
-msgstr ""
+msgstr "Örneğin, belirli bir konumdaki bir haber hikayesini tutan `NewsArticle` adında bir yapıya sahip olduğumuzu söyleyelim. `NewsArticle` türünü özetleyebilecek bir davranışı tanımlayan `Summary` adında bir trait tanımlayabiliriz."
 
 #: src/ch08-02-traits-in-cairo.md:32
 msgid "\"{:?} by {:?} ({:?})\""
@@ -6991,7 +8655,7 @@ msgstr ""
 msgid ""
 "Here, we declare a trait using the trait keyword and then the trait’s name, "
 "which is `Summary` in this case."
-msgstr ""
+msgstr "Burada, trait anahtar kelimesi kullanılarak bir trait bildirilir ve ardından trait'in adı, bu durumda `Summary` gelir."
 
 #: src/ch08-02-traits-in-cairo.md:45
 msgid ""
@@ -7000,19 +8664,20 @@ msgid ""
 "`fn summarize(self: @NewsArticle) -> ByteArray`. After the method signature, "
 "instead of providing an implementation within curly brackets, we use a "
 "semicolon."
-msgstr ""
+msgstr "Süslü parantezlerin içinde, bu trait'i uygulayan tiplerin davranışlarını tanımlayan metod imzalarını bildiririz, bu durumda `fn summarize(self: @NewsArticle) -> ByteArray`'dır. Metod imzasından sonra, süslü parantezler içinde bir uygulama sağlamak yerine bir noktalı virgül kullanırız."
 
 #: src/ch08-02-traits-in-cairo.md:47
 msgid ""
 "Note: the `ByteArray` type is the type used to represent Strings in Cairo."
-msgstr ""
+msgstr "Not:`ByteArray` tipi, Cairo'da String'leri temsil etmek için kullanılan tiptir."
 
 #: src/ch08-02-traits-in-cairo.md:49
 msgid ""
 "As the trait is not generic, the `self` parameter is not generic either and "
 "is of type `@NewsArticle`. This means that the `summarize` method can only "
 "be called on instances of `NewsArticle`."
-msgstr ""
+msgstr "Trait genel olmadığı için, `self` parametresi de genel değildir ve `@NewsArticle` tipindedir. Bu, `summarize` metodunun yalnızca `NewsArticle` örnekleri üzerinde çağrılabilir olduğu anlamına gelir."
+
 
 #: src/ch08-02-traits-in-cairo.md:51
 msgid ""
@@ -7022,7 +8687,7 @@ msgid ""
 "type, and we’ll request that summary by calling a summarize method on an "
 "instance. By defining the `Summary` trait on generic type `T`, we can "
 "implement the `summarize` method on any type we want to be able to summarize."
-msgstr ""
+msgstr "Şimdi, `NewsArticle` veya `Tweet` örneğinde saklanabilecek verilerin özetlerini gösterebilecek bir medya toplayıcı kütüphane kutusu olan `aggregator` oluşturmak istediğimizi düşünelim. Bunu yapmak için her türden bir özet gerekiyor ve bu özeti bir örnekte summarize metodunu çağırarak isteyeceğiz. `Summary` trait'ini genel tür `T` üzerinde tanımlayarak, özetlemek istediğimiz herhangi bir tür üzerinde `summarize` metodunu uygulayabiliriz."
 
 #: src/ch08-02-traits-in-cairo.md:70 src/ch08-02-traits-in-cairo.md:146
 #: src/ch08-02-traits-in-cairo.md:222
@@ -7062,8 +8727,8 @@ msgstr ""
 #: src/ch08-02-traits-in-cairo.md:101 src/ch08-02-traits-in-cairo.md:177
 #: src/ch08-02-traits-in-cairo.md:253
 msgid ""
-"\"Crypto is full of short-term maximizing projects. \\n"
-" @Starknet and @StarkWareLtd are about long-term vision maximization.\""
+"\"Crypto is full of short-term maximizing projects. \\n @Starknet and "
+"@StarkWareLtd are about long-term vision maximization.\""
 msgstr ""
 
 #: src/ch08-02-traits-in-cairo.md:104 src/ch08-02-traits-in-cairo.md:180
@@ -7085,7 +8750,8 @@ msgstr ""
 msgid ""
 "A `Summary` trait that consists of the behavior provided by a `summarize` "
 "method"
-msgstr ""
+msgstr "`summarize` metodunu sağlayan davranışlardan oluşan bir `Summary` trait'i"
+
 
 #: src/ch08-02-traits-in-cairo.md:115
 msgid ""
@@ -7093,17 +8759,17 @@ msgid ""
 "behavior for the body of the method. The compiler will enforce that any type "
 "that has the Summary trait will have the method summarize defined with this "
 "signature exactly."
-msgstr ""
+msgstr "Bu trait'i uygulayan her genel tür, metodun gövdesi için kendi özel davranışını sağlamalıdır. Derleyici, Summary trait'ine sahip her türün bu imzaya tam olarak sahip summarize metodunu tanımladığını zorlayacaktır."
 
 #: src/ch08-02-traits-in-cairo.md:117
 msgid ""
 "A trait can have multiple methods in its body: the method signatures are "
 "listed one per line and each line ends in a semicolon."
-msgstr ""
+msgstr "Bir tip üzerine bir trait uygulamak"
 
 #: src/ch08-02-traits-in-cairo.md:119
 msgid "Implementing a Trait on a type"
-msgstr ""
+msgstr "Bir tip üzerine bir trait uygulamak"
 
 #: src/ch08-02-traits-in-cairo.md:121
 msgid ""
@@ -7114,7 +8780,7 @@ msgid ""
 "create the return value of `summarize`. For the `Tweet` struct, we define "
 "`summarize` as the username followed by the entire text of the tweet, "
 "assuming that tweet content is already limited to 280 characters."
-msgstr ""
+msgstr "`Summary` trait'inin metodlarının istenen imzalarını tanımladığımıza göre, medya toplayıcımızdaki tipler üzerinde bunu uygulayabiliriz. Sonraki kod parçacığı, `summarize`'ın dönüş değerini oluşturmak için başlığı, yazarı ve konumu kullanan `NewsArticle` yapısı üzerinde `Summary` trait'inin bir uygulamasını gösterir. `Tweet` yapısı için, `summarize`'ı, tweetin tam metnini takip eden kullanıcı adı olarak tanımlarız, tweet içeriğinin zaten 280 karakterle sınırlı olduğunu varsayarız."
 
 #: src/ch08-02-traits-in-cairo.md:189
 msgid ""
@@ -7123,7 +8789,7 @@ msgid ""
 "then use the `of` keyword, and then specify the name of the trait we are "
 "writing the implementation for. If the implementation is for a generic type, "
 "we place the generic type name in the angle brackets after the trait name."
-msgstr ""
+msgstr "Bir tip üzerinde bir trait uygulamak, normal metotları uygulamaya benzer. Fark, `impl`'den sonra uygulamanın adını koyduktan sonra `of` anahtar kelimesini kullanmamız ve uygulama yazdığımız trait'in adını belirtmemizdir. Uygulama genel bir tip içinse, trait adının ardından açı parantezleri içinde genel tip adını yerleştiririz."
 
 #: src/ch08-02-traits-in-cairo.md:194
 msgid ""
@@ -7131,7 +8797,7 @@ msgid ""
 "definition has defined. Instead of adding a semicolon after each signature, "
 "we use curly brackets and fill in the method body with the specific behavior "
 "that we want the methods of the trait to have for the particular type."
-msgstr ""
+msgstr "`impl` bloğu içinde, trait tanımının belirlediği metod imzalarını koyarız. Her imzanın ardından bir noktalı virgül yerine süslü parantezler kullanırız ve metod gövdesini o belirli tip için trait metodlarının sahip olmasını istediğimiz özel davranışla doldururuz."
 
 #: src/ch08-02-traits-in-cairo.md:199
 msgid ""
@@ -7140,21 +8806,21 @@ msgid ""
 "`NewsArticle` and `Tweet` in the same way we call regular methods. The only "
 "difference is that the user must bring the trait into scope as well as the "
 "types. Here’s an example of how a crate could use our `aggregator` crate:"
-msgstr ""
+msgstr "Kütüphane `Summary` trait'ini `NewsArticle` ve `Tweet` üzerinde uyguladığından, kutuyu kullananlar, `NewsArticle` ve `Tweet` örnekleri üzerinde trait metodlarını normal metodları çağırdığımız gibi çağırabilir. Tek fark, kullanıcının hem trait'i hem de tipleri kapsama alması gerektiğidir. İşte bir kutunun `aggregator` kutumuzu nasıl kullanabileceğine dair bir örnek:"
 
 #: src/ch08-02-traits-in-cairo.md:265
 msgid "This code prints the following:"
-msgstr ""
+msgstr "Bu kod şunu yazdırır:"
 
 #: src/ch08-02-traits-in-cairo.md:274
 msgid ""
 "Other crates that depend on the `aggregator` crate can also bring the "
 "`Summary` trait into scope to implement `Summary` on their own types."
-msgstr ""
+msgstr "`aggregator` kutusuna bağlı diğer kutular da `Summary` trait'ini kapsama alanına alarak kendi tiplerinde `Summary`'i uygulayabilir."
 
 #: src/ch08-02-traits-in-cairo.md:304
 msgid "Implementing a trait, without writing its declaration."
-msgstr ""
+msgstr "Bir trait'i, onun bildirimini yazmadan uygulama."
 
 #: src/ch08-02-traits-in-cairo.md:306
 msgid ""
@@ -7164,27 +8830,27 @@ msgid ""
 "corresponding to the implementation automatically. Remember to add `Trait` "
 "as a suffix to your trait name, as the compiler will create the trait by "
 "adding a `Trait` suffix to the implementation name."
-msgstr ""
+msgstr "İlgili trait'i tanımlamadan doğrudan uygulamalar yazabilirsiniz. Bu, uygulama içinde `#[generate_trait]` özniteliğini kullanarak mümkün olur, bu da derleyicinin uygulamaya karşılık gelen trait'i otomatik olarak oluşturmasını sağlar. Trait adınıza `Trait` soneki eklemeyi unutmayın, çünkü derleyici uygulama adına `Trait` sonekini ekleyerek trait'i oluşturacaktır."
 
 #: src/ch08-02-traits-in-cairo.md:325
 msgid ""
 "In the aforementioned code, there is no need to manually define the trait. "
 "The compiler will automatically handle its definition, dynamically "
 "generating and updating it as new functions are introduced."
-msgstr ""
+msgstr "Yukarıda bahsedilen kodda, trait'i manuel olarak tanımlamaya gerek yoktur. Derleyici, tanımını otomatik olarak yönetir, yeni fonksiyonlar tanıtıldıkça dinamik olarak oluşturur ve günceller."
 
 #: src/ch08-02-traits-in-cairo.md:329
 msgid "Managing and using external trait implementations"
-msgstr ""
+msgstr "Dış trait uygulamalarını yönetme ve kullanma"
 
 #: src/ch08-02-traits-in-cairo.md:331
 msgid ""
-"To use traits methods, you need to make sure the correct "
-"traits/implementation(s) are imported. In the code above we imported "
-"`PrintTrait` from `debug` with `use core::debug::PrintTrait;` to use the "
-"`print()` methods on supported types. All traits included in the prelude "
-"don't need to be explicitly imported and are freely accessible."
-msgstr ""
+"To use traits methods, you need to make sure the correct traits/"
+"implementation(s) are imported. In the code above we imported `PrintTrait` "
+"from `debug` with `use core::debug::PrintTrait;` to use the `print()` "
+"methods on supported types. All traits included in the prelude don't need to "
+"be explicitly imported and are freely accessible."
+msgstr "Trait metotlarını kullanmak için, doğru trait/uygulama(lar)ın içe aktarıldığından emin olmanız gerekir. Yukarıdaki kodda `print()` metodlarını desteklenen tiplerde kullanabilmek için `use core::debug::PrintTrait;` ile `debug`'dan `PrintTrait`'i içe aktardık. Prelude'da yer alan tüm trait'ler açıkça içe aktarılmaya gerek duymaz ve serbestçe erişilebilir."
 
 #: src/ch08-02-traits-in-cairo.md:333
 msgid ""
@@ -7192,14 +8858,14 @@ msgid ""
 "implementation if they are declared in separate modules. If `CircleGeometry` "
 "was in a separate module/file `circle` then to use `boundary` on `circ: "
 "Circle`, we'd need to import `CircleGeometry` in addition to `ShapeGeometry`."
-msgstr ""
+msgstr "Bazı durumlarda, sadece trait'i değil, ayrı modüllerde bildirilmişlerse uygulamayı da içe aktarmanız gerekebilir. `CircleGeometry` ayrı bir modül/dosya `circle` içindeyse, `circ: Circle` üzerinde `boundary` kullanmak için `ShapeGeometry`'in yanı sıra `CircleGeometry`'i de içe aktarmanız gerekir."
 
 #: src/ch08-02-traits-in-cairo.md:336
 msgid ""
 "If the code was organized into modules like this, where the implementation "
 "of a trait was defined in a different module than the trait itself, "
 "explicitly importing the relevant implementation is required."
-msgstr ""
+msgstr "Kod bu şekilde modüllere ayrılmışsa, yani bir trait'in uygulaması trait'in kendisiyle farklı bir modülde tanımlanmışsa, ilgili uygulamanın açıkça içe aktarılması gerekir."
 
 #: src/ch08-02-traits-in-cairo.md:340
 msgid "// struct Circle { ... } and struct Rectangle { ... }\n"
@@ -7218,44 +8884,44 @@ msgstr ""
 
 #: src/ch08-02-traits-in-cairo.md:373
 msgid "To make it work, in addition to,"
-msgstr ""
+msgstr "Bunu düzeltmek için, ek olarak,"
 
 #: src/ch08-02-traits-in-cairo.md:379
 msgid ""
 "you will need to import `CircleGeometry` explicitly. Note that you do not "
 "need to import `RectangleGeometry`, as it is defined in the same module as "
 "the imported trait, and thus is automatically resolved."
-msgstr ""
+msgstr "`CircleGeometry`'i açıkça içe aktarmanız gerekir. `RectangleGeometry`'i içe aktarmaya gerek yoktur, çünkü imported trait ile aynı modülde tanımlandığı için otomatik olarak çözülür."
 
 #: src/ch09-01-how-to-write-tests.md:3 src/ch09-01-how-to-write-tests.md:13
 msgid "The Anatomy of a Test Function"
-msgstr ""
+msgstr "Bir Test Fonksiyonunun Anatomisi"
 
 #: src/ch09-01-how-to-write-tests.md:5
 msgid ""
 "Tests are Cairo functions that verify that the non-test code is functioning "
 "in the expected manner. The bodies of test functions typically perform these "
 "three actions:"
-msgstr ""
+msgstr "Testler, test dışı kodun beklenen şekilde işlev gördüğünü doğrulayan Cairo fonksiyonlarıdır. Test fonksiyonlarının gövdeleri tipik olarak bu üç eylemi gerçekleştirir:"
 
 #: src/ch09-01-how-to-write-tests.md:7
 msgid "Set up any needed data or state."
-msgstr ""
+msgstr "Gerekli herhangi bir veriyi veya durumu kurun."
 
 #: src/ch09-01-how-to-write-tests.md:8
 msgid "Run the code you want to test."
-msgstr ""
+msgstr "Test etmek istediğiniz kodu çalıştırın."
 
 #: src/ch09-01-how-to-write-tests.md:9
 msgid "Assert the results are what you expect."
-msgstr ""
+msgstr "Sonuçların beklediğiniz gibi olduğunu doğrulayın."
 
 #: src/ch09-01-how-to-write-tests.md:11
 msgid ""
 "Let’s look at the features Cairo provides specifically for writing tests "
 "that take these actions, which include the `test` attribute, the `assert!` "
 "macro, and the `should_panic` attribute."
-msgstr ""
+msgstr "Bu eylemleri gerçekleştirmek için Cairo'nun özellikle test yazmak için sağladığı özelliklere, `test` özelliğine, `assert!` makrosuna ve `should_panic` özelliğine bakalım."
 
 #: src/ch09-01-how-to-write-tests.md:15
 msgid ""
@@ -7266,19 +8932,19 @@ msgid ""
 "you run your tests with the `scarb cairo-test` command, Scarb runs Cairo's "
 "test runner binary that runs the annotated functions and reports on whether "
 "each test function passes or fails."
-msgstr ""
+msgstr "En basit haliyle, Cairo'da bir test, `test` özelliği ile etiketlenmiş bir fonksiyondur. Öznitelikler, Cairo kod parçaları hakkında meta verilerdir; bir örnek, Bölüm 5'te yapılarla kullandığımız derive özelliğidir. Bir fonksiyonu test fonksiyonuna dönüştürmek için, `fn` satırından önce `#[test]` ekleyin. Testlerinizi `scarb cairo-test` komutuyla çalıştırdığınızda, Scarb, Cairo'nun test koşucu ikilisini çalıştırır, bu da etiketlenmiş fonksiyonları çalıştırır ve her test fonksiyonunun geçip geçmediği üzerine rapor verir."
 
 #: src/ch09-01-how-to-write-tests.md:17
 msgid ""
 "Let's create a new project called `adder` that will add two numbers using "
 "Scarb with the command `scarb new adder`:"
-msgstr ""
+msgstr "`adder` adında iki sayıyı ekleyecek yeni bir proje oluşturalım ve `scarb new adder` komutuyla Scarb kullanalım:"
 
 #: src/ch09-01-how-to-write-tests.md:26
 msgid ""
 "In _lib.cairo_, let's remove the existing content and add a first test, as "
 "shown in Listing 9-1."
-msgstr ""
+msgstr "_lib.cairo_'da, mevcut içeriği kaldıralım ve Listeleme 9-1'de gösterildiği gibi ilk testi ekleyelim."
 
 #: src/ch09-01-how-to-write-tests.md:34 src/ch09-01-how-to-write-tests.md:68
 #: src/ch09-01-how-to-write-tests.md:630 src/ch09-01-how-to-write-tests.md:668
@@ -7288,7 +8954,7 @@ msgstr ""
 
 #: src/ch09-01-how-to-write-tests.md:38
 msgid "Listing 9-1: A test module and function"
-msgstr ""
+msgstr "Listeleme 9-1: Bir test modülü ve fonksiyonu"
 
 #: src/ch09-01-how-to-write-tests.md:40
 msgid ""
@@ -7298,24 +8964,24 @@ msgid ""
 "non-test functions in the tests module to help set up common scenarios or "
 "perform common operations, so we always need to indicate which functions are "
 "tests."
-msgstr ""
+msgstr "Şimdilik, ilk iki satırı göz ardı edelim ve fonksiyona odaklanalım. `#[test]` notasyonuna dikkat edin: bu öznitelik, bu fonksiyonun bir test fonksiyonu olduğunu belirtir, böylece test koşucusu bu fonksiyonu bir test olarak işlemesi gerektiğini bilir. Test modülünde, yaygın senaryoları kurmak veya yaygın işlemleri gerçekleştirmek için yardımcı olacak test olmayan fonksiyonlar da bulunabilir, bu yüzden hangi fonksiyonların test olduğunu her zaman belirtmemiz gerekir."
 
 #: src/ch09-01-how-to-write-tests.md:42
 msgid ""
 "The example function body uses the `assert!` macro, which contains the "
 "result of adding 2 and 2, equals 4. This assertion serves as an example of "
 "the format for a typical test. Let’s run it to see that this test passes."
-msgstr ""
+msgstr "Örnek fonksiyon gövdesi, 2 ile 2'nin toplamının 4'e eşit olduğunu içeren `assert!` makrosunu kullanır. Bu doğrulama, tipik bir testin formatı için bir örnek olarak hizmet eder. Bunu çalıştırıp bu testin geçtiğini görelim."
 
 #: src/ch09-01-how-to-write-tests.md:44
 msgid ""
 "The `scarb cairo-test` command runs all tests founds in our project, as "
 "shown in Listing 9-2."
-msgstr ""
+msgstr "`scarb cairo-test` komutu, projemizde bulunan tüm testleri çalıştırır, Listeleme 9-2'de gösterildiği gibi."
 
 #: src/ch09-01-how-to-write-tests.md:54
 msgid "Listing 9-2: The output from running a test"
-msgstr ""
+msgstr "Listeleme 9-2: Bir testi çalıştırmanın çıktısı"
 
 #: src/ch09-01-how-to-write-tests.md:56
 msgid ""
@@ -7325,7 +8991,7 @@ msgid ""
 "summary `test result: ok.` means that all the tests passed, and the portion "
 "that reads `1 passed; 0 failed` totals the number of tests that passed or "
 "failed."
-msgstr ""
+msgstr "`scarb cairo-test`, testi derleyip çalıştırdı. `1 tests running` satırını görüyoruz. Sonraki satır test fonksiyonunun adını, yani `it_works`'u ve bu testin çalıştırılmasının sonucunun `ok` olduğunu gösteriyor. Genel özet `test sonucu: ok.` tüm testlerin geçtiğini ve `1 passed; 0 failed` kısmı geçen veya başarısız olan testlerin sayısını toplar."
 
 #: src/ch09-01-how-to-write-tests.md:58
 msgid ""
@@ -7338,19 +9004,19 @@ msgid ""
 "we’ll cover that in the [Running Single Tests](#running-single-tests) "
 "section. We also haven’t filtered the tests being run, so the end of the "
 "summary shows `0 filtered out`."
-msgstr ""
+msgstr "Bir testin belirli bir durumda çalışmaması için görmezden gelinerek işaretlenebilir; bunu bu bölümün sonraki kısımlarında [Bazı Testleri Özellikle İstenmedikçe Görmezden Gelme](#ignoring-some-tests-unless-specifically-requested) bölümünde ele alacağız. Burada bunu yapmadığımız için, özet `0 ignored` gösteriyor. `scarb cairo-test` komutuna bir argüman geçirerek sadece isminde bir dizeyle eşleşen bir testi çalıştırabiliriz; buna filtreleme denir ve bunu [Tek Testleri Çalıştırma](#running-single-tests) bölümünde ele alacağız. Çalıştırılan testleri filtrelemedik, bu yüzden özetin sonu `0 filtered out` gösteriyor."
 
 #: src/ch09-01-how-to-write-tests.md:60
 msgid ""
 "Let’s start to customize the test to our own needs. First change the name of "
 "the `it_works` function to a different name, such as `exploration`, like so:"
-msgstr ""
+msgstr "Şimdi testi kendi ihtiyaçlarımıza göre özelleştirmeye başlayalım. İlk olarak, `it_works` fonksiyonunun adını, örneğin `exploration` gibi farklı bir isme değiştirin, şöyle:"
 
 #: src/ch09-01-how-to-write-tests.md:72
 msgid ""
 "Then run `scarb cairo-test` again. The output now shows `exploration` "
 "instead of `it_works`:"
-msgstr ""
+msgstr "Sonra `scarb cairo-test`'i tekrar çalıştırın. Çıktı şimdi `it_works` yerine `exploration` gösteriyor:"
 
 #: src/ch09-01-how-to-write-tests.md:81
 msgid ""
@@ -7359,7 +9025,7 @@ msgid ""
 "new thread, and when the main thread sees that a test thread has died, the "
 "test is marked as failed. Enter the new test as a function named `another`, "
 "so your _src/lib.cairo_ file looks like Listing 9-3."
-msgstr ""
+msgstr "Şimdi başka bir test ekleyelim, ama bu sefer başarısız olacak bir test yapalım! Test fonksiyonları içindeki bir şey paniklediğinde testler başarısız olur. Her test yeni bir thread'de çalıştırılır ve ana thread bir test thread'inin öldüğünü gördüğünde, test başarısız olarak işaretlenir. Yeni testi `another` adında bir fonksiyon olarak girin, böylece _src/lib.cairo_ dosyanız Listeleme 9-3 gibi görünsün."
 
 #: src/ch09-01-how-to-write-tests.md:87
 msgid "\"Make this test fail\""
@@ -7367,11 +9033,11 @@ msgstr ""
 
 #: src/ch09-01-how-to-write-tests.md:92
 msgid "Listing 9-3: Adding a second test that will fail"
-msgstr ""
+msgstr "Listeleme 9-3: Başarısız olacak ikinci bir testin eklenmesi"
 
 #: src/ch09-01-how-to-write-tests.md:104
 msgid "Listing 9-4: Test results when one test passes and one test fails"
-msgstr ""
+msgstr "Listeleme 9-4: Bir testin geçtiği ve bir testin başarısız olduğu durumda test sonuçları"
 
 #: src/ch09-01-how-to-write-tests.md:106
 msgid ""
@@ -7381,23 +9047,23 @@ msgid ""
 "that `another` failed because it panicked with "
 "`[1725643816656041371866211894343434536761780588 ('Make this test fail'), ]` "
 "in the _src/lib.cairo_ file."
-msgstr ""
+msgstr "`ok` yerine, `adder::lib::tests::another` satırı `fail` gösteriyor. Bireysel sonuçlarla özet arasında yeni bir bölüm beliriyor. Her test başarısızlığının detaylı nedenini gösteriyor. Bu durumda, `another`'ın _src/lib.cairo_ dosyasında `Make this test fail` ile paniklediği için başarısız olduğu detaylarını alıyoruz."
 
 #: src/ch09-01-how-to-write-tests.md:108
 msgid ""
 "The summary line displays at the end: overall, our test result is `FAILED`. "
 "We had one test pass and one test fail."
-msgstr ""
+msgstr "Sonuç satırı sonunda şunu gösterir: genel olarak, test sonucumuz `FAILED`. Bir test geçti ve bir test başarısız oldu."
 
 #: src/ch09-01-how-to-write-tests.md:110
 msgid ""
 "Now that you’ve seen what the test results look like in different scenarios, "
 "let’s look at some functions that are useful in tests."
-msgstr ""
+msgstr "Şimdi farklı senaryolarda test sonuçlarının nasıl göründüğünü gördüğünüze göre, testlerde kullanışlı bazı fonksiyonlara bakalım."
 
 #: src/ch09-01-how-to-write-tests.md:112
 msgid "Checking Results with the `assert!` macro"
-msgstr ""
+msgstr "`assert!` makrosu ile Sonuçları Kontrol Etme"
 
 #: src/ch09-01-how-to-write-tests.md:114
 msgid ""
@@ -7408,7 +9074,7 @@ msgid ""
 "macro calls `panic()` to cause the test to fail with a message we defined as "
 "the second argument. Using the `assert!` macro helps us check that our code "
 "is functioning in the way we intend."
-msgstr ""
+msgstr "Cairo tarafından sağlanan `assert!` makrosu, bir testteki bazı koşulların `true` olarak değerlendirilmesini sağlamak istediğinizde kullanışlıdır. `assert!` makrosuna birinci argüman olarak bir Boolean değerlendiren bir ifade veririz. Değer `true` ise, hiçbir şey olmaz ve test geçer. Değer `false` ise, `assert!` makrosu `panic()` çağırarak testin tanımladığımız bir mesajla başarısız olmasına neden olur. `assert!` makrosunu kullanmak, kodumuzun niyet ettiğimiz şekilde işlev gösterdiğini kontrol etmemize yardımcı olur."
 
 #: src/ch09-01-how-to-write-tests.md:116
 msgid ""
@@ -7416,13 +9082,13 @@ msgid ""
 "we used a `Rectangle` struct and a `can_hold` method, which are repeated "
 "here in Listing 9-5. Let’s put this code in the _src/lib.cairo_ file, then "
 "write some tests for it using the `assert!` macro."
-msgstr ""
+msgstr "[Bölüm 5, Listeleme 5-13](ch05-03-method-syntax.md#multiple-impl-blocks)’te kullandığımız `Rectangle` yapısını ve `can_hold` metodunu burada tekrar kullanıyoruz. Bu kodu _src/lib.cairo_ dosyasına koyalım, sonra `assert!` makrosunu kullanarak bazı testler yazalım."
 
 #: src/ch09-01-how-to-write-tests.md:137
 msgid ""
 "Listing 9-5: Using the `Rectangle` struct and its `can_hold` method from "
 "Chapter 5"
-msgstr ""
+msgstr "Listeleme 9-5: Bölüm 5'ten `Rectangle` yapısının ve `can_hold` metodunun kullanılması"
 
 #: src/ch09-01-how-to-write-tests.md:139
 msgid ""
@@ -7431,7 +9097,7 @@ msgid ""
 "`can_hold` method by creating a `Rectangle` instance that has a width of `8` "
 "and a height of `7` and asserting that it can hold another `Rectangle` "
 "instance that has a width of `5` and a height of `1`."
-msgstr ""
+msgstr "`can_hold` metodu bir `bool` döndürür, bu da onun `assert!` makrosu için mükemmel bir kullanım durumu olduğu anlamına gelir. Listeleme 9-6'da, `can_hold` metodunu çalıştıran bir test yazıyoruz. `8` genişliğinde ve `7` yüksekliğinde bir `Rectangle` örneği oluşturup `5` genişliğinde ve `1` yüksekliğinde başka bir `Rectangle` örneğini tutabileceğini doğrulayarak."
 
 #: src/ch09-01-how-to-write-tests.md:176 src/ch09-01-how-to-write-tests.md:184
 #: src/ch09-01-how-to-write-tests.md:241 src/ch09-01-how-to-write-tests.md:249
@@ -7442,16 +9108,16 @@ msgstr ""
 msgid ""
 "Listing 9-6: A test for `can_hold` that checks whether a larger rectangle "
 "can indeed hold a smaller rectangle"
-msgstr ""
+msgstr "Listeleme 9-6: Daha büyük bir dikdörtgenin gerçekten daha küçük bir dikdörtgeni tutup tutamayacağını kontrol eden `can_hold` için bir test"
 
 #: src/ch09-01-how-to-write-tests.md:193
 msgid ""
-"Note that we’ve added two new lines inside the tests module: `use "
-"super::Rectangle;` and `use super::RectangleTrait;`. The tests module is a "
-"regular module that follows the usual visibility rules. Because the tests "
-"module is an inner module, we need to bring the code under test in the outer "
-"module into the scope of the inner module."
-msgstr ""
+"Note that we’ve added two new lines inside the tests module: `use super::"
+"Rectangle;` and `use super::RectangleTrait;`. The tests module is a regular "
+"module that follows the usual visibility rules. Because the tests module is "
+"an inner module, we need to bring the code under test in the outer module "
+"into the scope of the inner module."
+msgstr "Testler modülü içinde `use super::Rectangle;` ve `use super::RectangleTrait;` olmak üzere iki yeni satır ekledik. Testler modülü, normal görünürlük kurallarını takip eden düzenli bir modüldür. Testler modülü bir iç modül olduğu için, dış modüldeki test altındaki kodu iç modülün kapsamına getirmemiz gerekiyor."
 
 #: src/ch09-01-how-to-write-tests.md:195
 msgid ""
@@ -7459,20 +9125,20 @@ msgid ""
 "`Rectangle` instances that we need. Then we called the `assert!` macro and "
 "passed it the result of calling `larger.can_hold(@smaller)`. This expression "
 "is supposed to return `true`, so our test should pass. Let’s find out!"
-msgstr ""
+msgstr "Testimizi `larger_can_hold_smaller` olarak adlandırdık ve ihtiyacımız olan iki `Rectangle` örneğini oluşturduk. Sonra `assert!` makrosunu çağırdık ve ona `larger.can_hold(@smaller)` çağrısının sonucunu geçtik. Bu ifade `true` döndürmesi beklenir, bu yüzden testimiz geçmelidir. Hadi öğrenelim!"
 
 #: src/ch09-01-how-to-write-tests.md:204
 msgid ""
 "It does pass! Let’s add another test, this time asserting that a smaller "
 "rectangle cannot hold a larger rectangle:"
-msgstr ""
+msgstr "Geçiyor! Şimdi, bu sefer daha küçük bir dikdörtgenin daha büyük bir dikdörtgeni tutamayacağını belirten başka bir test ekleyelim:"
 
 #: src/ch09-01-how-to-write-tests.md:256
 msgid ""
 "Because the correct result of the `can_hold` function in this case is "
 "`false`, we need to negate that result before we pass it to the `assert!` "
 "macro. As a result, our test will pass if `can_hold` returns false:"
-msgstr ""
+msgstr "`can_hold` fonksiyonunun bu durumda doğru sonucu `false` olduğu için, sonucu `assert!` makrosuna geçmeden önce bu sonucu tersine çevirmemiz gerekiyor. Sonuç olarak, testimiz `can_hold` `false` döndürdüğünde geçer:"
 
 #: src/ch09-01-how-to-write-tests.md:266
 msgid ""
@@ -7480,22 +9146,22 @@ msgid ""
 "introduce a bug in our code. We’ll change the implementation of the "
 "`can_hold` method by replacing the greater-than sign with a less-than sign "
 "when it compares the widths:"
-msgstr ""
+msgstr "İki geçen test! Şimdi kodumuzda bir hata tanıttığımızda test sonuçlarımıza ne olacağını görelim. `can_hold` metodunun uygulanmasını değiştirerek genişlikleri karşılaştırırken büyük işaretini küçük işaretiyle değiştirelim:"
 
 #: src/ch09-01-how-to-write-tests.md:280
 msgid "Running the tests now produces the following:"
-msgstr ""
+msgstr "Testleri şimdi çalıştırmak aşağıdakileri üretir:"
 
 #: src/ch09-01-how-to-write-tests.md:293
 msgid ""
 "Our tests caught the bug! Because `larger.width` is `8` and `smaller.width` "
 "is `5`, the comparison of the widths in `can_hold` now returns `false`: `8` "
 "is not less than `5`."
-msgstr ""
+msgstr "Testlerimiz hatayı yakaladı! `larger.width` `8` ve `smaller.width` `5` olduğu için, `can_hold` içindeki genişliklerin karşılaştırması artık `false` dönüyor: `8` `5`'ten küçük değildir."
 
 #: src/ch09-01-how-to-write-tests.md:295
 msgid "Testing Equality with the `assert_eq!` and `assert_ne!` Macros"
-msgstr ""
+msgstr "`assert_eq!` ve `assert_ne!` Makroları ile Eşitliği Test Etme"
 
 #: src/ch09-01-how-to-write-tests.md:297
 msgid ""
@@ -7510,39 +9176,40 @@ msgid ""
 "conversely, the `assert!` macro only indicates that it got a `false` value "
 "for the `==` expression, without printing the values that led to the `false` "
 "value."
-msgstr ""
+msgstr "Fonksiyonelliği doğrulamanın yaygın bir yolu, test altındaki kodun sonucu ile kodun döndürmesi beklenen değer arasında eşitlik testidir. Bunu `assert!` makrosunu kullanarak ve `==` operatörünü kullanan bir ifadeyi geçirerek yapabilirsiniz. Ancak, bu kadar yaygın bir test olduğu için, standart kütüphane bu testi daha uygun bir şekilde yapmak için `assert_eq!` ve `assert_ne!` olmak üzere bir çift makro sağlar. Bu makrolar, sırasıyla, iki argümanı eşitlik veya eşitsizlik için karşılaştırır. Ayrıca, doğrulama başarısız olduğunda iki değeri de yazdırırlar, bu da testin neden başarısız olduğunu görmeyi kolaylaştırır; tersine, `assert!` makrosu, `==` ifadesi için `false` bir değer aldığını belirtirken, `false` değerine yol açan değerleri yazdırmaz."
 
 #: src/ch09-01-how-to-write-tests.md:308
 msgid ""
 "In Listing 9-7, we write a function named `add_two` that adds `2` to its "
 "parameter, then we test this function using the `assert_eq!` macro."
-msgstr ""
+msgstr "Listeleme 9-7'de, parametresine `2` ekleyen `add_two` adında bir fonksiyon yazıyoruz, sonra bu fonksiyonu `assert_eq!` makrosunu kullanarak test ediyoruz."
 
 #: src/ch09-01-how-to-write-tests.md:329
-msgid "Listing 9-7: Testing the function `add_two` using the `assert_eq!` macro"
-msgstr ""
+msgid ""
+"Listing 9-7: Testing the function `add_two` using the `assert_eq!` macro"
+msgstr "Listeleme 9-7: `add_two` fonksiyonunu `assert_eq!` makrosu kullanarak test etme"
 
 #: src/ch09-01-how-to-write-tests.md:332
 msgid "Let’s check that it passes!"
-msgstr ""
+msgstr "Geçtiğini kontrol edelim!"
 
 #: src/ch09-01-how-to-write-tests.md:341
 msgid ""
 "We pass `4` as the argument to `assert_eq!`, which is equal to the result of "
 "calling `add_two(2)`. The line for this test is `test tests::it_adds_two ... "
 "ok`, and the `ok` text indicates that our test passed!"
-msgstr ""
+msgstr "`assert_eq!`'e argüman olarak `4` geçiriyoruz, bu `add_two(2)` çağrısının sonucuna eşittir. Bu testin satırı `test tests::it_adds_two ... ok` ve `ok` metni testimizin geçtiğini gösterir."
 
 #: src/ch09-01-how-to-write-tests.md:345
 msgid ""
 "Let’s introduce a bug into our code to see what `assert_eq!` looks like when "
 "it fails. Change the implementation of the `add_two` function to instead add "
 "`3`:"
-msgstr ""
+msgstr "Kodumuza bir hata sokarak `assert_eq!`'in başarısız olduğunda nasıl göründüğünü görelim. `add_two` fonksiyonunun uygulamasını `2` yerine `3` ekleyecek şekilde değiştirin:"
 
 #: src/ch09-01-how-to-write-tests.md:354
 msgid "Run the tests again:"
-msgstr ""
+msgstr "Testleri tekrar çalıştırın:"
 
 #: src/ch09-01-how-to-write-tests.md:356
 msgid ""
@@ -7569,7 +9236,7 @@ msgid ""
 "the `left` argument was `4` but the `right` argument, where we had "
 "`add_two(2)`, was `5`. You can imagine that this would be especially helpful "
 "when we have a lot of tests going on."
-msgstr ""
+msgstr "Testimiz hatayı yakaladı! `it_adds_two` testi şu mesajla başarısız oldu: ``\"assertion `4 == add_two(2)` failed``. Bize başarısız olan doğrulamanın ``\"assertion `left == right` failed`` olduğunu ve `left` ve `right` değerlerinin sırasıyla `left: left_value` ve `right: right_value` olarak sonraki satırlarda yazdırıldığını söyler. Bu, hata ayıklamaya başlamamıza yardımcı olur: `left` argümanı `4` fakat `add_two(2)` yerine kullanılan `right` argümanı `5` idi. Bir sürü testimiz olduğunda bunun özellikle yararlı olduğunu hayal edebilirsiniz."
 
 #: src/ch09-01-how-to-write-tests.md:375
 msgid ""
@@ -7580,7 +9247,7 @@ msgid ""
 "and the value the code produces doesn’t matter. We could write the assertion "
 "in this test as `assert_eq!(add_two(2), 4)`, which would result in the same "
 "failure message that displays `` assertion failed: `(left == right)` ``."
-msgstr ""
+msgstr "Bazı dillerde ve test çerçevelerinde, eşitlik doğrulama fonksiyonlarına `expected` ve `actual` denir ve argümanların sırası önemlidir. Ancak, Cairo'da, bunlara `left` ve `right` denir ve beklenen değeri ve kodun ürettiği değeri belirttiğimiz sıra önemli değildir. Bu testteki doğrulamayı `assert_eq!(add_two(2), 4)` olarak yazabilirdik, bu da ``assertion failed: `(left == right)` `` hatasıyla aynı başarısızlık mesajını üretirdi."
 
 #: src/ch09-01-how-to-write-tests.md:383
 msgid ""
@@ -7591,7 +9258,7 @@ msgid ""
 "to change its input in some way, but the way in which the input is changed "
 "depends on the day of the week that we run our tests, the best thing to "
 "assert might be that the output of the function is not equal to the input."
-msgstr ""
+msgstr "`assert_ne!` makrosu, verdiğimiz iki değer eşit olmadığında geçer ve eşit olduklarında başarısız olur. Bu makro, bir değerin _ne olacağından_ emin olmadığımız ama kesinlikle _ne olmaması gerektiğini_ bildiğimiz durumlar için en yararlıdır. Örneğin, bir fonksiyonun girdisini kesinlikle değiştireceğini garanti ettiğimiz ama girdinin nasıl değiştirildiğinin testlerimizi çalıştırdığımız haftanın gününe bağlı olduğu durumlar için, fonksiyonun çıktısının girdiye eşit _olmaması_ gerektiğini doğrulamak en iyi şey olabilir."
 
 #: src/ch09-01-how-to-write-tests.md:391
 msgid ""
@@ -7605,42 +9272,40 @@ msgid ""
 "`Debug` to print the values when the assertion fails. Because both traits "
 "are derivable traits this is usually as straightforward as adding the "
 "`#[derive(Drop, Debug, PartialEq)]` annotation to your struct or enum "
-"definition. See Appendix C, [“Derivable "
-"Traits”](./appendix-03-derivable-traits.md), for more details about these "
-"and other derivable traits."
-msgstr ""
+"definition. See Appendix C, [“Derivable Traits”](./appendix-03-derivable-"
+"traits.md), for more details about these and other derivable traits."
+msgstr "`assert_eq!` ve `assert_ne!` makroları altında, sırasıyla `==` ve `!=` operatörlerini kullanır. Doğrulamalar başarısız olduğunda, bu makrolar argümanlarını hata ayıklama biçimlendirmesi kullanarak yazdırır, bu da karşılaştırılan değerlerin `PartialEq` ve `Debug` trait'lerini uygulaması gerektiği anlamına gelir. Tüm ilkel tipler ve çoğu çekirdek kütüphane tipi bu trait'leri uygular. Kendi tanımladığınız yapılar ve enumlar için, bu türlerin eşitliğini doğrulamak üzere `PartialEq`'i uygulamanız gerekir. Ayrıca, doğrulama başarısız olduğunda değerleri yazdırmak için `Debug`'ı da uygulamanız gerekir. Her iki trait de türetilebilir trait'ler olduğu için, bu genellikle yapınız veya enumunuzun tanımına `#[derive(Drop, Debug, PartialEq)]` notasyonunu eklemek kadar basittir. Bu ve diğer türetilebilir trait'ler hakkında daha fazla bilgi için Ek C'ye bakın, [“Türetilebilir Trait'ler”](./appendix-03-derivable-traits.md)."
 
 #: src/ch09-01-how-to-write-tests.md:405
 msgid "Adding Custom Failure Messages"
-msgstr ""
+msgstr "Özel Başarısızlık Mesajları Ekleme"
 
 #: src/ch09-01-how-to-write-tests.md:407
 msgid ""
 "You can also add a custom message to be printed with the failure message as "
 "optional arguments to the `assert!`, `assert_eq!`, and `assert_ne!` macros. "
 "Any arguments specified after the required arguments are passed along to the "
-"`format!` macro (discussed in [Chapter 11 - "
-"Macros](./ch11-02-macros.md#format-macro) in the `format!` section), so you "
-"can pass a format string that contains `{}` placeholders and values to go in "
-"those placeholders. Custom messages are useful for documenting what an "
-"assertion means; when a test fails, you’ll have a better idea of what the "
-"problem is with the code."
-msgstr ""
+"`format!` macro (discussed in [Chapter 11 - Macros](./ch11-02-macros."
+"md#format-macro) in the `format!` section), so you can pass a format string "
+"that contains `{}` placeholders and values to go in those placeholders. "
+"Custom messages are useful for documenting what an assertion means; when a "
+"test fails, you’ll have a better idea of what the problem is with the code."
+msgstr "`assert!`, `assert_eq!` ve `assert_ne!` makrolarına isteğe bağlı argümanlar olarak başarısızlık mesajıyla birlikte yazdırılacak özel bir mesaj da ekleyebilirsiniz. Gerekli argümanlardan sonra belirtilen herhangi bir argüman, `format!` makrosuna (Bölüm 11'de tartışılan [Bölüm 11 - Makrolar](./ch11-02-macros.md#format-macro) bölümünde) aktarılır, bu yüzden `{}` yer tutucuları içeren bir biçimlendirme dizesi ve bu yer tutuculara gidecek değerler geçirebilirsiniz. Özel mesajlar, bir doğrulamanın ne anlama geldiğini belgelemek için yararlıdır; bir test başarısız olduğunda, kodla ilgili sorunun ne olduğuna dair daha iyi bir fikriniz olur."
 
 #: src/ch09-01-how-to-write-tests.md:415
 msgid ""
 "Let’s add a custom failure message composed of a format string with a "
 "placeholder filled in with the actual value we got from the `add_two` "
 "function:"
-msgstr ""
+msgstr "`add_two` fonksiyonundan aldığımız gerçek değerle doldurulan bir biçim dizesinden oluşan özel bir başarısızlık mesajı ekleyelim:"
 
 #: src/ch09-01-how-to-write-tests.md:426
 msgid "\"Expected {}, got add_two(2)={}\""
-msgstr ""
+msgstr "\"Beklenen {}, add_two(2)={} aldık\""
 
 #: src/ch09-01-how-to-write-tests.md:431
 msgid "Now when we run the test, we’ll get a more informative error message:"
-msgstr ""
+msgstr "Şimdi testi çalıştırdığımızda daha bilgilendirici bir hata mesajı alacağız:"
 
 #: src/ch09-01-how-to-write-tests.md:433
 msgid ""
@@ -7662,11 +9327,11 @@ msgstr ""
 msgid ""
 "We can see the value we actually got in the test output, which would help us "
 "debug what happened instead of what we were expecting to happen."
-msgstr ""
+msgstr "Test çıktısında aldığımız gerçek değeri görebiliriz, bu da beklediğimiz yerine ne olduğunu anlamamıza yardımcı olur."
 
 #: src/ch09-01-how-to-write-tests.md:448
 msgid "Checking for panics with `should_panic`"
-msgstr ""
+msgstr "`should_panic` ile Panikleri Kontrol Etme"
 
 #: src/ch09-01-how-to-write-tests.md:450
 msgid ""
@@ -7676,45 +9341,45 @@ msgid ""
 "`Guess` instances will contain only values between `1` and `100`. We can "
 "write a test that ensures that attempting to create a `Guess` instance with "
 "a value outside that range panics."
-msgstr ""
+msgstr "Dönüş değerlerini kontrol etmenin yanı sıra, kodumuzun beklediğimiz gibi hata koşullarını ele aldığından emin olmak da önemlidir. Örneğin, Listeleme 9-8'de yer alan Guess türünü düşünün. `Guess` kullanımı diğer kodların `Guess` örneklerinin yalnızca `1` ile `100` arasında değerler içereceği garantisi üzerine kuruludur. Bu aralık dışında bir değerle `Guess` örneği oluşturmayı denemenin panikle sonuçlanacağını garanti eden bir test yazabiliriz."
 
 #: src/ch09-01-how-to-write-tests.md:452
 msgid ""
 "We do this by adding the attribute `should_panic` to our test function. The "
 "test passes if the code inside the function panics; the test fails if the "
 "code inside the function doesn’t panic."
-msgstr ""
+msgstr "Bunu yapmak için test fonksiyonumuza `should_panic` özniteliğini ekliyoruz. Fonksiyon içindeki kod paniklediğinde test geçer; fonksiyon içindeki kod paniklemezse test başarısız olur."
 
 #: src/ch09-01-how-to-write-tests.md:454
 msgid ""
 "Listing 9-8 shows a test that checks that the error conditions of "
 "`GuessTrait::new` happen when we expect them to."
-msgstr ""
+msgstr "Listeleme 9-8, `GuessTrait::new`'un hata koşullarının beklediğimiz zamanlarda gerçekleştiğini kontrol eden bir testi göstermektedir."
 
 #: src/ch09-01-how-to-write-tests.md:471 src/ch09-01-how-to-write-tests.md:516
 msgid "\"Guess must be >= 1 and <= 100\""
-msgstr ""
+msgstr "\"Guess >= 1 ve <= 100 olmalıdır\""
 
 #: src/ch09-01-how-to-write-tests.md:490
 msgid "Listing 9-8: Testing that a condition will cause a panic"
-msgstr ""
+msgstr "Listeleme 9-8: Bir koşulun panikle sonuçlanacağını test etme"
 
 #: src/ch09-01-how-to-write-tests.md:492
 msgid ""
 "We place the `#[should_panic]` attribute after the `#[test]` attribute and "
 "before the test function it applies to. Let’s look at the result when this "
 "test passes:"
-msgstr ""
+msgstr "`#[should_panic]` özniteliğini `#[test]` özniteliğinden sonra ve uygulandığı test fonksiyonundan önce yerleştiriyoruz. Bu testin geçtiği durumda sonucu inceleyelim:"
 
 #: src/ch09-01-how-to-write-tests.md:501
 msgid ""
 "Looks good! Now let’s introduce a bug in our code by removing the condition "
 "that the new function will panic if the value is greater than `100`:"
-msgstr ""
+msgstr "İyi görünüyor! Şimdi kodumuza bir hata sokarak yeni fonksiyonun değeri `100`'den büyükse panikleme koşulunu kaldıralım:"
 
 #: src/ch09-01-how-to-write-tests.md:526
 msgid "When we run the test in Listing 9-8, it will fail:"
-msgstr ""
+msgstr "Listeleme 9-8'deki testi çalıştırdığımızda başarısız olur:"
 
 #: src/ch09-01-how-to-write-tests.md:537
 msgid ""
@@ -7722,7 +9387,7 @@ msgid ""
 "test function, we see that it’s annotated with `#[should_panic]`. The "
 "failure we got means that the code in the test function did not cause a "
 "panic."
-msgstr ""
+msgstr "Bu durumda çok yardımcı bir mesaj almıyoruz, ancak test fonksiyonuna baktığımızda `#[should_panic]` ile notlandırıldığını görüyoruz. Aldığımız başarısızlık, test fonksiyonundaki kodun bir panikle sonuçlanmadığı anlamına gelir."
 
 #: src/ch09-01-how-to-write-tests.md:539
 msgid ""
@@ -7734,7 +9399,7 @@ msgid ""
 "consider the modified code for `Guess` in Listing 9-9 where the new function "
 "panics with different messages depending on whether the value is too small "
 "or too large."
-msgstr ""
+msgstr "`should_panic` kullanılan testler kesin olmayabilir. Bir `should_panic` testi, beklediğimiz nedenle değil de başka bir nedenle test paniklediğinde bile geçer. `should_panic` testlerini daha kesin hale getirmek için, `should_panic` özniteliğine isteğe bağlı bir expected parametresi ekleyebiliriz. Test donanımı, başarısızlık mesajının sağlanan metni içerdiğinden emin olur. Örneğin, `Guess` için Listeleme 9-9'da değiştirilmiş kodu düşünün, burada yeni fonksiyon değer çok küçük veya çok büyükse farklı mesajlarla panikler."
 
 #: src/ch09-01-how-to-write-tests.md:558 src/ch09-01-how-to-write-tests.md:594
 msgid "\"Guess must be >= 1\""
@@ -7749,7 +9414,7 @@ msgstr ""
 msgid ""
 "Listing 9-9: Testing for a panic with a panic message containing the error "
 "message string"
-msgstr ""
+msgstr "Listeleme 9-9: Hata mesajı dizesini içeren bir panik ile test etme"
 
 #: src/ch09-01-how-to-write-tests.md:584
 msgid ""
@@ -7757,18 +9422,18 @@ msgid ""
 "attribute’s expected parameter is the array of string of the message that "
 "the `Guess::new` function panics with. We need to specify the entire panic "
 "message that we expect."
-msgstr ""
+msgstr "Bu test, `should_panic` özniteliğinin beklenen parametresine koyduğumuz değer `Guess::new` fonksiyonunun paniklediği mesajın bir dizi dizesi olduğu için geçer. Beklediğimiz tüm panik mesajını belirtmemiz gerekiyor."
 
 #: src/ch09-01-how-to-write-tests.md:586
 msgid ""
 "To see what happens when a `should_panic` test with an expected message "
 "fails, let’s again introduce a bug into our code by swapping the bodies of "
 "the if `value < 1` and the else if `value > 100` blocks:"
-msgstr ""
+msgstr "Beklenen bir mesajla `should_panic` testinin başarısız olduğunda ne olduğunu görmek için, kodumuza tekrar bir hata sokarak `value < 1` ve `value > 100` bloklarının gövdelerini değiştirelim:"
 
 #: src/ch09-01-how-to-write-tests.md:602
 msgid "This time when we run the `should_panic` test, it will fail:"
-msgstr ""
+msgstr "Bu sefer `should_panic` testini çalıştırdığımızda başarısız olacak:"
 
 #: src/ch09-01-how-to-write-tests.md:614
 msgid ""
@@ -7776,11 +9441,11 @@ msgid ""
 "expected, but the panic message did not include the expected string. The "
 "panic message that we did get in this case was `Guess must be >= 1`. Now we "
 "can start figuring out where our bug is!"
-msgstr ""
+msgstr "Başarısızlık mesajı, bu testin beklediğimiz gibi panikle sonuçlandığını, ancak panik mesajının beklenen dizeyi içermediğini gösterir. Bu durumda aldığımız panik mesajı `Guess >= 1 olmalıdır` idi. Şimdi hatamızın nerede olduğunu bulmaya başlayabiliriz!"
 
 #: src/ch09-01-how-to-write-tests.md:616
 msgid "Running Single Tests"
-msgstr ""
+msgstr "Tek Testleri Çalıştırma"
 
 #: src/ch09-01-how-to-write-tests.md:618
 msgid ""
@@ -7789,13 +9454,13 @@ msgid ""
 "pertaining to that code. You can choose which tests to run by passing `scarb "
 "cairo-test` an option `-f` (for \"filter\"), followed by the name of the "
 "test you want to run as an argument."
-msgstr ""
+msgstr "Bazen, tam bir test paketini çalıştırmak uzun zaman alabilir. Belirli bir alandaki kod üzerinde çalışıyorsanız, yalnızca o kodla ilgili testleri çalıştırmak isteyebilirsiniz. Hangi testleri çalıştıracağınızı seçmek için, `scarb cairo-test` komutuna `-f` (\"filtre\" için) seçeneğini takip eden bir argüman olarak çalıştırmak istediğiniz testin adını verebilirsiniz."
 
 #: src/ch09-01-how-to-write-tests.md:620
 msgid ""
 "To demonstrate how to run a single test, we’ll first create two test "
 "functions, as shown in Listing 9-10, and choose which ones to run."
-msgstr ""
+msgstr "Tek bir testi çalıştırma şeklini göstermek için, Listeleme 9-10'da gösterildiği gibi önce iki test fonksiyonu oluşturacağız ve hangilerini çalıştıracağımızı seçeceğiz."
 
 #: src/ch09-01-how-to-write-tests.md:636
 msgid "\"result is not 5\""
@@ -7803,30 +9468,30 @@ msgstr ""
 
 #: src/ch09-01-how-to-write-tests.md:641
 msgid "Listing 9-10: Two tests with two different names"
-msgstr ""
+msgstr "Listeleme 9-10: İki farklı adı olan iki test"
 
 #: src/ch09-01-how-to-write-tests.md:643
 msgid ""
 "We can pass the name of any test function to `cairo-test` to run only that "
 "test using the `-f` flag:"
-msgstr ""
+msgstr "`cairo-test`'e herhangi bir test fonksiyonunun adını `-f` bayrağı ile birlikte geçirerek yalnızca o testi çalıştırabiliriz:"
 
 #: src/ch09-01-how-to-write-tests.md:652
 msgid ""
 "Only the test with the name `add_two_and_two` ran; the other test didn’t "
 "match that name. The test output lets us know we had one more test that "
 "didn’t run by displaying 1 filtered out at the end."
-msgstr ""
+msgstr "Yalnızca `add_two_and_two` adına sahip test çalıştı; diğer test bu adla eşleşmedi. Test çıktısı sonunda 1 filtrelenmiş olduğunu göstererek daha fazla çalıştırılmayan bir testimiz olduğunu bize bildiriyor."
 
 #: src/ch09-01-how-to-write-tests.md:654
 msgid ""
 "We can also specify part of a test name, and any test whose name contains "
 "that value will be run."
-msgstr ""
+msgstr "Ayrıca bir test adının bir kısmını belirtebiliriz ve adında o değeri içeren herhangi bir test çalıştırılır."
 
 #: src/ch09-01-how-to-write-tests.md:656
 msgid "Ignoring Some Tests Unless Specifically Requested"
-msgstr ""
+msgstr "Belirli İstekler Dışında Bazı Testleri Yoksayma"
 
 #: src/ch09-01-how-to-write-tests.md:658
 msgid ""
@@ -7835,7 +9500,7 @@ msgid ""
 "than listing as arguments all tests you do want to run, you can instead "
 "annotate the time-consuming tests using the `ignore` attribute to exclude "
 "them, as shown here:"
-msgstr ""
+msgstr "Bazen bazı özel testlerin çalıştırılması çok zaman alabilir, bu yüzden `scarb cairo-test`'in çoğu çalıştırmasında bunları dışlamak isteyebilirsiniz. Çalıştırmak istediğiniz tüm testleri argüman olarak listelemek yerine, aşağıda gösterildiği gibi zaman alan testleri `ignore` özniteliği ile notlandırarak dışlayabilirsiniz:"
 
 #: src/ch09-01-how-to-write-tests.md:673
 msgid "// code that takes an hour to run\n"
@@ -7845,11 +9510,11 @@ msgstr ""
 msgid ""
 "After `#[test]` we add the `#[ignore]` line to the test we want to exclude. "
 "Now when we run our tests, `it_works` runs, but `expensive_test` doesn’t:"
-msgstr ""
+msgstr "`#[test]`'den sonra istediğimiz testi dışlamak için `#[ignore]` satırını ekliyoruz. Şimdi testlerimizi çalıştırdığımızda, `it_works` çalışır, ancak `expensive_test` çalışmaz:"
 
 #: src/ch09-01-how-to-write-tests.md:688
 msgid "The `expensive_test` function is listed as ignored."
-msgstr ""
+msgstr "`expensive_test` fonksiyonu yoksayıldı olarak listelenmiştir."
 
 #: src/ch09-01-how-to-write-tests.md:690
 msgid ""
@@ -7857,11 +9522,11 @@ msgid ""
 "ignored tests and you have time to wait for the results, you can run `scarb "
 "cairo-test --include-ignored` to run all tests whether they’re ignored or "
 "not."
-msgstr ""
+msgstr "Yoksayılan testlerin sonuçlarını kontrol etmenin ve sonuçları beklemek için zamanınız olduğunda, `scarb cairo-test --include-ignored` komutunu çalıştırarak ister yoksayılan ister yoksayılmayan tüm testleri çalıştırabilirsiniz."
 
 #: src/ch09-01-how-to-write-tests.md:692
 msgid "Testing recursive functions or loops"
-msgstr ""
+msgstr "Özyinelemeli fonksiyonları veya döngüleri test etme"
 
 #: src/ch09-01-how-to-write-tests.md:694
 msgid ""
@@ -7872,7 +9537,7 @@ msgid ""
 "large enough, but you can override it by adding the "
 "`#[available_gas(<Number>)]` attribute on the test function. The following "
 "example shows how to use it:"
-msgstr ""
+msgstr "Özyinelemeli fonksiyonları veya döngüleri test ederken, test varsayılan olarak tüketeceği maksimum gaz miktarıyla başlatılır. Bu, sonsuz döngüleri çalıştırmayı veya çok fazla gaz tüketmeyi önler ve uygulamalarınızın verimliliğini ölçmenize yardımcı olabilir. Bu değer makul derecede büyük kabul edilir, ancak test fonksiyonuna `#[available_gas(<Sayı>)]` özniteliğini ekleyerek bunu geçersiz kılabilirsiniz. Aşağıdaki örnek bunun nasıl kullanılacağını gösterir:"
 
 #: src/ch09-01-how-to-write-tests.md:716
 msgid "\"result is not 55\""
@@ -7880,13 +9545,13 @@ msgstr ""
 
 #: src/ch09-01-how-to-write-tests.md:721
 msgid "Benchmarking the gas usage of a specific operation"
-msgstr ""
+msgstr "Belirli bir işlemin gaz kullanımını ölçme"
 
 #: src/ch09-01-how-to-write-tests.md:723
 msgid ""
 "When you want to benchmark the gas usage of a specific operation, you can "
 "use the following pattern in your test function."
-msgstr ""
+msgstr "Belirli bir işlemin gaz kullanımını ölçmek istediğinizde, test fonksiyonunuzda aşağıdaki deseni kullanabilirsiniz."
 
 #: src/ch09-01-how-to-write-tests.md:728 src/ch09-01-how-to-write-tests.md:755
 msgid "/// code we want to bench.\n"
@@ -7900,20 +9565,20 @@ msgstr ""
 msgid ""
 "The following example shows how to use it to test the gas function of the "
 "`sum_n` function above."
-msgstr ""
+msgstr "Aşağıdaki örnek, yukarıdaki `sum_n` fonksiyonunun gaz fonksiyonunu test etmek için bunun nasıl kullanılacağını gösterir."
 
 #: src/ch09-01-how-to-write-tests.md:762
 msgid ""
 "The value printed when running `scarb cairo-test` is the amount of gas that "
 "was consumed by the operation benchmarked."
-msgstr ""
+msgstr "`scarb cairo-test`'i çalıştırdığımızda yazdırılan değer, ölçülen işlem tarafından tüketilen gaz miktarıdır."
 
 #: src/ch09-01-how-to-write-tests.md:775
 msgid ""
 "Here, the gas usage of the `sum_n` function is 96760 (decimal representation "
 "of the hex number). The total amount consumed by the test is slightly higher "
 "at 98030, due to some extra steps required to run the entire test function."
-msgstr ""
+msgstr "Burada, `sum_n` fonksiyonunun gaz kullanımı 96760'dır (onaltılık sayının ondalık gösterimi). Testin toplam tükettiği miktar, tüm test fonksiyonunu çalıştırmak için gerekli bazı ek adımlar nedeniyle biraz daha yüksek, 98030'dur."
 
 #: src/ch09-02-test-organization.md:3
 msgid ""
@@ -7924,17 +9589,17 @@ msgid ""
 "good practice to start organizing your code as if it were. Integration tests "
 "use your code in the same way any other external code would, using only the "
 "public interface and potentially exercising multiple modules per test."
-msgstr ""
+msgstr "Testleri iki ana kategoriye göre düşüneceğiz: birim testleri ve entegrasyon testleri. Birim testleri küçük ve daha odaklıdır, bir seferde bir modülü izole olarak test eder ve özel fonksiyonları test edebilir. Cairo henüz kamu/özel fonksiyonlar/al...
 
 #: src/ch09-02-test-organization.md:5
 msgid ""
 "Writing both kinds of tests is important to ensure that the pieces of your "
 "library are doing what you expect them to, separately and together."
-msgstr ""
+msgstr "Her iki tür testi yazmak da, kütüphanenizin parçalarının ayrı ve birlikte beklediğiniz gibi çalıştığından emin olmak için önemlidir."
 
 #: src/ch09-02-test-organization.md:7
 msgid "Unit Tests"
-msgstr ""
+msgstr "Birim Testleri"
 
 #: src/ch09-02-test-organization.md:9
 msgid ""
@@ -7942,17 +9607,17 @@ msgid ""
 "rest of the code to quickly pinpoint where code is and isn’t working as "
 "expected. You’ll put unit tests in the `src` directory in each file with the "
 "code that they’re testing."
-msgstr ""
+msgstr "Birim testlerinin amacı, kodun her birimini geri kalan koddan bağımsız olarak test etmektir, böylece kodun beklenen şekilde çalışıp çalışmadığını hızlı bir şekilde belirleyebiliriz. Birim testlerini, test ettikleri kodla aynı dosyada `src` dizininde yer alır."
 
 #: src/ch09-02-test-organization.md:11
 msgid ""
 "The convention is to create a module named tests in each file to contain the "
 "test functions and to annotate the module with `cfg(test)`."
-msgstr ""
+msgstr "Konvansiyon, test fonksiyonlarını içeren tests adında bir modül oluşturmak ve modülü `cfg(test)` ile not etmektir."
 
 #: src/ch09-02-test-organization.md:13
 msgid "The Tests Module and `#[cfg(test)]`"
-msgstr ""
+msgstr "Testler Modülü ve `#[cfg(test)]`"
 
 #: src/ch09-02-test-organization.md:15
 msgid ""
@@ -7964,13 +9629,13 @@ msgid ""
 "directory, they don’t need the `#[cfg(test)]` annotation. However, because "
 "unit tests go in the same files as the code, you’ll use `#[cfg(test)]` to "
 "specify that they shouldn’t be included in the compiled result."
-msgstr ""
+msgstr "`#[cfg(test)]` notasyonu tests modülüne, yalnızca `scarb cairo-test` çalıştırdığınızda test kodunu derleyip çalıştırmasını, `cairo-run` çalıştırdığınızda ise çalıştırmamasını söyler. Bu, sadece kütüphaneyi oluşturmak istediğinizde derleme süresinden tasarruf sağlar ve testler dahil edilmediğinden sonuçlanan derlenmiş artefaktta yer tasarrufu sağlar. Entegrasyon testlerinin farklı bir dizinde yer alması gerektiğini göreceksiniz, bu yüzden `#[cfg(test)]` notasyonuna ihtiyaç duymazlar. Ancak, birim testleri kodla aynı dosyalarda yer aldığı için, derlenmiş sonuçta dahil edilmemeleri gerektiğini belirtmek için `#[cfg(test)]` kullanacaksınız."
 
 #: src/ch09-02-test-organization.md:17
 msgid ""
 "Recall that when we created the new `adder` project in the first section of "
 "this chapter, we wrote this first test:"
-msgstr ""
+msgstr "Bu bölümün başında yeni `adder` projesini oluşturduğumuzda, bu ilk testi yazmıştık:"
 
 #: src/ch09-02-test-organization.md:32
 msgid ""
@@ -7978,14 +9643,14 @@ msgid ""
 "following item should only be included given a certain configuration option. "
 "In this case, the configuration option is `test`, which is provided by Cairo "
 "for compiling and running tests. By using the `cfg` attribute, Cairo "
-"compiles our test code only if we actively run the tests with `scarb "
-"cairo-test`. This includes any helper functions that might be within this "
-"module, in addition to the functions annotated with `#[test]`."
-msgstr ""
+"compiles our test code only if we actively run the tests with `scarb cairo-"
+"test`. This includes any helper functions that might be within this module, "
+"in addition to the functions annotated with `#[test]`."
+msgstr "`cfg` yapılandırma anlamına gelir ve Cairo'ya, belirli bir yapılandırma seçeneği verildiğinde takip eden öğenin yalnızca dahil edilmesi gerektiğini söyler. Bu durumda, yapılandırma seçeneği `test`, testleri derlemek ve çalıştırmak için Cairo tarafından sağlanan bir yapılandırmadır. `cfg` notasyonunu kullanarak, testlerimizi aktif olarak `scarb cairo-test` ile çalıştırdığımızda test kodumuzu derler. Bu, `#[test]` ile not edilen fonksiyonların yanı sıra, bu modül içindeki herhangi bir yardımcı fonksiyonu da içerir."
 
 #: src/ch09-02-test-organization.md:34
 msgid "Integration Tests"
-msgstr ""
+msgstr "Entegrasyon Testleri"
 
 #: src/ch09-02-test-organization.md:36
 msgid ""
@@ -7995,21 +9660,21 @@ msgid ""
 "problems when integrated, so test coverage of the integrated code is "
 "important as well. To create integration tests, you first need a `tests` "
 "directory."
-msgstr ""
+msgstr "Entegrasyon testleri, kütüphanenizi herhangi bir başka kodun yapacağı gibi kullanır. Amaçları, kütüphanenizin birçok parçasının doğru şekilde birlikte çalışıp çalışmadığını test etmektir. Tek başına doğru çalışan kod birimleri birleştirildiğinde sorunlar yaşayabilir, bu yüzden entegre edilmiş kodun test kapsamı da önemlidir. Entegrasyon testleri oluşturmak için öncelikle bir `tests` dizinine ihtiyacınız vardır."
 
 #: src/ch09-02-test-organization.md:38
 msgid "The `tests` Directory"
-msgstr ""
+msgstr "`tests` Dizini"
 
 #: src/ch09-02-test-organization.md:66
 msgid "Filename: src/tests.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/tests.cairo"
 
 #: src/ch09-02-test-organization.md:68
 msgid ""
 "Enter the code in Listing 9-11 into the _src/tests/integration_test.cairo_ "
 "file:"
-msgstr ""
+msgstr "_src/tests/integration_test.cairo_ dosyasına Listeleme 9-11'deki kodu girin:"
 
 #: src/ch09-02-test-organization.md:75
 msgid "\"internal_adder failed\""
@@ -8017,30 +9682,30 @@ msgstr ""
 
 #: src/ch09-02-test-organization.md:79
 msgid "Filename: src/tests/integration_test.cairo"
-msgstr ""
+msgstr "Dosya Adı: src/tests/integration_test.cairo"
 
 #: src/ch09-02-test-organization.md:81
 msgid ""
 "We need to bring our tested functions into each test file scope. For that "
 "reason we add `use adder::it_adds_two` at the top of the code, which we "
 "didn’t need in the unit tests."
-msgstr ""
+msgstr "Test edilen fonksiyonları her test dosyası kapsamına dahil etmemiz gerekiyor. Bu sebeple kodun en üstüne `use adder::it_adds_two` ekliyoruz, bu birim testlerde gerekli değildi."
 
 #: src/ch09-02-test-organization.md:83
 msgid ""
 "Then, to run all of our integration tests, we can just add a filter to only "
 "run tests whose path contains \"integration_tests\"."
-msgstr ""
+msgstr "Daha sonra, tüm entegrasyon testlerimizi çalıştırmak için yalnızca \"integration_tests\" içeren yolu filtrelemek üzere bir filtre ekleyebiliriz."
 
 #: src/ch09-02-test-organization.md:94
 msgid ""
 "The result of the tests is the same as what we've been seeing: one line for "
 "each test."
-msgstr ""
+msgstr "Test sonuçları, gördüğümüz gibi, her test için bir satır gösteriyor."
 
 #: src/ch10-00-error-handling.md:1
 msgid "Error handling"
-msgstr ""
+msgstr "Hata Yönetimi"
 
 #: src/ch10-00-error-handling.md:3
 msgid ""
@@ -8054,7 +9719,7 @@ msgid ""
 "error handling features. These concepts are crucial for building robust "
 "applications that can effectively handle unexpected situations, ensuring "
 "your code is ready for production."
-msgstr ""
+msgstr "Bu bölümde, Cairo tarafından sağlanan çeşitli hata yönetimi tekniklerini keşfedeceğiz, bu teknikler sadece kodunuzdaki potansiyel sorunları ele almanıza olanak tanımakla kalmaz, aynı zamanda programlarınızı daha esnek ve bakımı kolay hale getirmenizi de kolaylaştırır. Result enumu ile desen eşleştirmeyi, daha ergonomik hata yayılımı için ? operatörünü kullanmayı ve kurtarılabilir hataları ele almak için unwrap veya expect yöntemlerini kullanmayı içeren farklı hata yönetimi yaklaşımlarını inceleyerek, Cairo'nun hata yönetimi özelliklerine dair daha derin bir anlayış kazanacaksınız. Bu kavramlar, beklenmedik durumları etkili bir şekilde ele alabilen sağlam uygulamalar oluşturmak için hayati öneme sahiptir, böylece kodunuz üretime hazır hale gelir."
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:3
 msgid ""
@@ -8065,7 +9730,7 @@ msgid ""
 "triggered in Cairo: inadvertently, through actions causing the code to panic "
 "(e.g., accessing an array beyond its bounds), or deliberately, by invoking "
 "the panic function."
-msgstr ""
+msgstr "Cairo'da, program yürütülmesi sırasında beklenmedik sorunlar ortaya çıkabilir ve çalışma zamanı hatalarına neden olabilir. Core kütüphanesinden panic fonksiyonu, bu hatalar için bir çözüm sunmaz, ancak oluşumlarını kabul eder ve programı sonlandırır. Cairo'de bir panic, iki ana yolla tetiklenebilir: kodun paniklemesine neden olan eylemler yoluyla istem dışı olarak veya panic fonksiyonunu çağırarak kasıtlı olarak. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:5
 msgid ""
@@ -8074,13 +9739,13 @@ msgid ""
 "an error message and performs an unwind process where all variables are "
 "dropped and dictionaries squashed to ensure the soundness of the program to "
 "safely terminate the execution."
-msgstr ""
+msgstr "Bir panik meydana geldiğinde, programın aniden sonlanmasına yol açar. `panic` fonksiyonu, bir hata mesajı sağlamak için kullanılabilecek bir dizi alır ve programın güvenli bir şekilde sonlandırılabilmesi için tüm değişkenlerin düşürülmesini ve sözlüklerin sıkıştırılmasını sağlayan bir geri sarma işlemi gerçekleştirir. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:7
 msgid ""
 "Here is how we can `panic` from inside a program and return the error code "
 "`2`:"
-msgstr ""
+msgstr "İşte bir programın içinden `panic` yapmanın ve hata kodu `2`'yi döndürmenin nasıl olacağı: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:18
 #: src/ch10-01-unrecoverable-errors-with-panic.md:54
@@ -8089,13 +9754,13 @@ msgstr ""
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:22
 msgid "Running the program will produce the following output:"
-msgstr ""
+msgstr "Programı çalıştırmak aşağıdaki çıktıyı üretir: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:29
 msgid ""
 "As you can notice in the output, the print statement is never reached, as "
 "the program terminates after encountering the `panic` statement."
-msgstr ""
+msgstr "Çıktıda görebileceğiniz gibi, `panic` ifadesiyle karşılaştıktan sonra program sonlandığı için print ifadesine hiç ulaşılmaz. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:31
 msgid ""
@@ -8105,29 +9770,29 @@ msgid ""
 "more concise expression of intent. By using `panic_with_felt252`, developers "
 "can panic in a one-liner by providing a felt252 error message as an "
 "argument, making the code more readable and maintainable."
-msgstr ""
+msgstr "Cairo'da panik yapmanın alternatif ve daha idiyomatik bir yolu, `panic_with_felt252` fonksiyonunu kullanmaktır. Bu fonksiyon, dizi tanımlama sürecinin bir soyutlaması olarak hizmet eder ve genellikle niyetin daha net ve daha özlü bir şekilde ifade edilmesi nedeniyle tercih edilir. `panic_with_felt252` kullanarak, geliştiriciler bir felt252 hata mesajını argüman olarak sağlayarak tek satırda panik yapabilirler, bu da kodu daha okunabilir ve bakımı daha kolay hale getirir. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:33
 msgid "Let's consider an example:"
-msgstr ""
+msgstr "Bir Örnek Düşünelim: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:43
 msgid ""
 "Executing this program will yield the same error message as before. In that "
 "case, if there is no need for an array and multiple values to be returned "
 "within the error, so `panic_with_felt252` is a more succinct alternative."
-msgstr ""
+msgstr "Bu programı çalıştırmak, öncekiyle aynı hata mesajını verecektir. Bu durumda, bir diziye ve hata içinde birden çok değere ihtiyaç duyulmuyorsa, `panic_with_felt252` daha özlü bir alternatiftir. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:45
 msgid "`panic!` macro"
-msgstr ""
+msgstr "`panic!` makrosu "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:47
 msgid ""
 "`panic!` macro can be really helpful. The previous example returning the "
 "error code 2 shows how convenient `panic!` macro is. There is no need to "
 "create an array and pass it as argument like `panic` function."
-msgstr ""
+msgstr "`panic!` makrosu gerçekten yardımcı olabilir. Önceki örnekte hata kodu 2'nin dönüşü, `panic!` makrosunun ne kadar uygun olduğunu gösterir. `panic` fonksiyonu gibi bir dizi oluşturup argüman olarak geçme ihtiyacı yoktur. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:52
 msgid "\"2\""
@@ -8139,7 +9804,7 @@ msgid ""
 "which is ultimately the panic error, to be a literal longer than 31 bytes. "
 "This is because `panic!` takes a string as parameter. For example, the "
 "following line of code will successfully compile: "
-msgstr ""
+msgstr "`panic_with_felt252` fonksiyonunun aksine, `panic!` kullanımı, sonunda panik hatasına dönüşecek olan girdinin, 31 bayttan daha uzun bir metin olmasına izin verir. Bu, `panic!`'in parametre olarak bir dizi alması nedeniyledir. Örneğin, aşağıdaki kod satırı başarıyla derlenecektir: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:61
 msgid "\"the error for panic! macro is not limited to 31 characters anymore\""
@@ -8147,14 +9812,14 @@ msgstr ""
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:64
 msgid "nopanic notation"
-msgstr ""
+msgstr "nopanic notasyonu "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:66
 msgid ""
 "You can use the `nopanic` notation to indicate that a function will never "
 "panic. Only `nopanic` functions can be called in a function annotated as "
 "`nopanic`."
-msgstr ""
+msgstr "Bir fonksiyonun asla panik yapmayacağını belirtmek için `nopanic` notasyonunu kullanabilirsiniz. Yalnızca `nopanic` fonksiyonları, `nopanic` olarak not edilmiş bir fonksiyonda çağrılabilir. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:68
 #: src/ch10-01-unrecoverable-errors-with-panic.md:103
@@ -8165,26 +9830,26 @@ msgstr ""
 #: src/appendix-03-derivable-traits.md:126
 #: src/appendix-03-derivable-traits.md:163
 msgid "Example:"
-msgstr ""
+msgstr "Örnek:"
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:76
 msgid "Wrong example:"
-msgstr ""
+msgstr "Yanlış örnek: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:84
 msgid ""
 "If you write the following function that includes a function that may panic "
 "you will get the following error:"
-msgstr ""
+msgstr "Eğer aşağıdaki gibi panik yapabilecek bir fonksiyon içeren bir fonksiyon yazarsanız, aşağıdaki hatayı alırsınız: "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:97
 msgid ""
 "Note that there are two functions that may panic here, assert and equality."
-msgstr ""
+msgstr "Unutmayın ki burada panik yapabilecek iki fonksiyon var, assert ve eşitlik. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:99
 msgid "panic_with attribute"
-msgstr ""
+msgstr "panic_with özelliği "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:101
 msgid ""
@@ -8194,7 +9859,7 @@ msgid ""
 "function. It will create a wrapper for your annotated function which will "
 "panic if the function returns `None` or `Err`, the panic function will be "
 "called with the given data."
-msgstr ""
+msgstr "`panic_with` özelliğini, bir `Option` veya `Result` döndüren bir fonksiyonu işaretlemek için kullanabilirsiniz. Bu özellik, panik nedeni olarak geçirilen verilerin yanı sıra sarıcı bir fonksiyon için bir isim olmak üzere iki argüman alır. Annotasyon yapılan fonksiyonunuz için bir sarıcı oluşturur ve fonksiyon `None` veya `Err` döndürürse, verilen verilerle panik fonksiyonu çağrılır. "
 
 #: src/ch10-01-unrecoverable-errors-with-panic.md:116
 msgid "// this returns None\n"
@@ -8206,7 +9871,7 @@ msgstr ""
 
 #: src/ch10-02-recoverable-errors.md:1
 msgid "Recoverable Errors with `Result`"
-msgstr ""
+msgstr "Kurtarılabilir Hatalar ile `Result` "
 
 #: src/ch10-02-recoverable-errors.md:5
 msgid ""
@@ -8216,22 +9881,22 @@ msgid ""
 "and the operation overflows because the sum exceeds the maximum "
 "representable value, you might want to return an error or a wrapped result "
 "instead of causing undefined behavior or terminating the process."
-msgstr ""
+msgstr "Çoğu hata, programın tamamen durmasını gerektirecek kadar ciddi değildir. Bazen, bir fonksiyon başarısız olduğunda, kolayca yorumlayıp yanıt verebileceğiniz bir nedenle başarısız olur. Örneğin, iki büyük tamsayı eklemeye çalıştığınızda ve işlem, toplam maksimum temsil edilebilir değeri aştığı için taşarsa, tanımsız davranışa neden olmak veya işlemi sonlandırmak yerine bir hata veya sarılı bir sonuç döndürmek isteyebilirsiniz. "
 
 #: src/ch10-02-recoverable-errors.md:7
 msgid "The `Result` enum"
-msgstr ""
+msgstr "`Result` enumu "
 
 #: src/ch10-02-recoverable-errors.md:9
 msgid ""
 "Recall from [“Generic data types”](ch08-01-generic-data-types.md#enums) in "
 "Chapter 8 that the `Result` enum is defined as having two variants, `Ok` and "
 "`Err`, as follows:"
-msgstr ""
+msgstr "8. Bölümdeki [“Genel veri tipleri”](ch08-01-generic-data-types.md#enums) bölümünden hatırlayacağınız gibi `Result` enumu, `Ok` ve `Err` olmak üzere iki varyanta sahip olarak tanımlanmıştır: "
 
 #: src/ch10-02-recoverable-errors.md:20
 msgid "The `ResultTrait`"
-msgstr ""
+msgstr "`ResultTrait` "
 
 #: src/ch10-02-recoverable-errors.md:22
 msgid ""
@@ -8239,7 +9904,7 @@ msgid ""
 "enum, such as unwrapping values, checking whether the `Result` is `Ok` or "
 "`Err`, and panicking with a custom message. The `ResultTraitImpl` "
 "implementation defines the logic of these methods."
-msgstr ""
+msgstr "`ResultTrait` özelliği, `Result<T, E>` enumu ile çalışmak için yöntemler sağlar, örneğin değerleri açma, `Result`'un `Ok` veya `Err` olup olmadığını kontrol etme ve özel bir mesajla panik yapma. `ResultTraitImpl` uygulaması, bu yöntemlerin mantığını tanımlar. "
 
 #: src/ch10-02-recoverable-errors.md:40
 msgid ""
@@ -8252,7 +9917,7 @@ msgid ""
 "panicking, giving you more control and context over the panic. On the other "
 "hand, the `unwrap` method panics with a default error message, providing "
 "less information about the cause of the panic."
-msgstr ""
+msgstr "`expect` ve `unwrap` yöntemleri, her ikisi de `Result<T, E>`'yi `Ok` varyantında olduğunda `T` tipindeki değeri çıkarmaya çalıştıkları için benzerdir. `Result` `Ok(x)` ise, her iki yöntem de değer `x`'i döndürür. Ancak, iki yöntem arasındaki temel fark, `Result` `Err` varyantında olduğunda gösterilen davranıştadır. `expect` yöntemi, panik yapılırken kullanılacak özel bir hata mesajı (felt252 değeri olarak) sağlamanıza izin verir, bu da panik üzerinde daha fazla kontrol ve bağlam sağlar. Öte yandan, `unwrap` yöntemi, varsayılan bir hata mesajı ile panik yapar ve panik nedeni hakkında daha az bilgi sağlar. "
 
 #: src/ch10-02-recoverable-errors.md:42
 msgid ""
@@ -8264,7 +9929,8 @@ msgid ""
 "and context over the panic. On the other hand, the `unwrap_err` method "
 "panics with a default error message, providing less information about the "
 "cause of the panic."
-msgstr ""
+msgstr "`expect_err` ve `unwrap_err` tam tersi davranışa sahiptir. `Result` `Err(x)` ise, her iki yöntem de değer `x`'i döndürür. Ancak, iki yöntem arasındaki temel fark, `Result::Ok()` durumundadır. `expect_err` yöntemi, panik yapılırken kullanılacak özel bir hata mesajı (felt252 değeri olarak) sağlamanıza izin verir, bu da panik üzerinde daha fazla kontrol ve bağlam sağlar. Öte yandan, `unwrap_err` yöntemi, varsayılan bir hata mesajı ile panik yapar ve panik nedeni hakkında daha az bilgi sağlar. "
+
 
 #: src/ch10-02-recoverable-errors.md:44
 msgid ""
@@ -8273,27 +9939,27 @@ msgid ""
 "constraints in the Cairo language. These constraints indicate that the "
 "associated functions require an implementation of the `Drop` trait for the "
 "generic types `T` and `E`, respectively."
-msgstr ""
+msgstr "Dikkatli bir okuyucu, ilk dört metod imzasında `<+Drop<T>>` ve `<+Drop<E>>` ifadelerini fark etmiş olabilir. Bu sözdizimi, Cairo dilinde genel tip kısıtlamalarını temsil eder. Bu kısıtlamalar, ilişkili fonksiyonların `T` ve `E` genel tipleri için `Drop` özelliğinin bir uygulamasını gerektirdiğini belirtir. "
 
 #: src/ch10-02-recoverable-errors.md:46
 msgid ""
 "Finally, the `is_ok` and `is_err` methods are utility functions provided by "
 "the `ResultTrait` trait to check the variant of a `Result` enum value."
-msgstr ""
+msgstr "Son olarak, `is_ok` ve `is_err` metodları, bir `Result` enum değerinin varyantını kontrol etmek için `ResultTrait` özelliği tarafından sağlanan yardımcı fonksiyonlardır. "
 
 #: src/ch10-02-recoverable-errors.md:48
 msgid ""
 "`is_ok` takes a snapshot of a `Result<T, E>` value and returns `true` if the "
 "`Result` is the `Ok` variant, meaning the operation was successful. If the "
 "`Result` is the `Err` variant, it returns `false`."
-msgstr ""
+msgstr "`is_ok`, bir `Result<T, E>` değerinin anlık görüntüsünü alır ve `Result` `Ok` varyantıysa, yani işlem başarılı olduysa `true` döner. `Result` `Err` varyantıysa, `false` döner. "
 
 #: src/ch10-02-recoverable-errors.md:50
 msgid ""
 "`is_err` takes a snapshot to a `Result<T, E>` value and returns `true` if "
 "the `Result` is the `Err` variant, meaning the operation encountered an "
 "error. If the `Result` is the `Ok` variant, it returns `false`."
-msgstr ""
+msgstr "`is_err`, bir `Result<T, E>` değerine bir anlık görüntü alır ve `Result` `Err` varyantıysa, yani işlem bir hatayla karşılaştıysa `true` döner. `Result` `Ok` varyantıysa, `false` döner. "
 
 #: src/ch10-02-recoverable-errors.md:52
 msgid ""
@@ -8301,32 +9967,32 @@ msgid ""
 "an operation without consuming the Result value, allowing you to perform "
 "additional operations or make decisions based on the variant without "
 "unwrapping it."
-msgstr ""
+msgstr "Bu metodlar, Sonuç değerini tüketmeden bir işlemin başarısını veya başarısızlığını kontrol etmek istediğinizde yardımcı olur, bu da sizi varyantı açmadan ek işlemler yapmaya veya kararlar almaya olanak tanır. "
 
 #: src/ch10-02-recoverable-errors.md:54
 msgid ""
-"You can find the implementation of the `ResultTrait` "
-"[here](https://github.com/starkware-libs/cairo/blob/main/corelib/src/result.cairo#L20)."
-msgstr ""
+"You can find the implementation of the `ResultTrait` [here](https://github."
+"com/starkware-libs/cairo/blob/main/corelib/src/result.cairo#L20)."
+msgstr "`ResultTrait` uygulamasını [burada](https://github.com/starkware-libs/cairo/blob/main/corelib/src/result.cairo#L20) bulabilirsiniz. "
 
 #: src/ch10-02-recoverable-errors.md:58
 msgid "It is always easier to understand with examples."
-msgstr ""
+msgstr "Örneklerle anlamak her zaman daha kolaydır. "
 
 #: src/ch10-02-recoverable-errors.md:60
 msgid "Have a look at this function signature:"
-msgstr ""
+msgstr "Bu fonksiyon imzasına bir göz atın: "
 
 #: src/ch10-02-recoverable-errors.md:66
 msgid ""
 "It takes two u128 integers, a and b, and returns a `Result<u128, u128>` "
 "where the `Ok` variant holds the sum if the addition does not overflow, and "
 "the `Err` variant holds the overflowed value if the addition does overflow."
-msgstr ""
+msgstr "İki u128 tamsayı, a ve b alır ve toplama taşmazsa `Ok` varyantında toplamı tutan, toplama taşarsa `Err` varyantında taşan değeri tutan bir `Result<u128, u128>` döndürür. "
 
 #: src/ch10-02-recoverable-errors.md:68
 msgid "Now, we can use this function elsewhere. For instance:"
-msgstr ""
+msgstr "Şimdi, bu fonksiyonu başka bir yerde kullanabiliriz. Örneğin: "
 
 #: src/ch10-02-recoverable-errors.md:79
 msgid ""
@@ -8337,27 +10003,27 @@ msgid ""
 "returns `Option::Some(r)` containing the sum. If the result is `Err(r)`, it "
 "returns `Option::None` to indicate that the operation has failed due to "
 "overflow. The function does not panic in case of an overflow."
-msgstr ""
+msgstr "Burada, iki u128 tamsayı, a ve b alır ve bir `Option<u128>` döndürür. `u128_overflowing_add` tarafından döndürülen `Result`u kullanarak toplama işleminin başarısını veya başarısızlığını belirler. Eşleşme ifadesi, `u128_overflowing_add`tan `Result`u kontrol eder. Sonuç `Ok(r)` ise, toplamı içeren `Option::Some(r)` döndürür. Sonuç `Err(r)` ise, işlemin taşma nedeniyle başarısız olduğunu belirtmek için `Option::None` döndürür. Fonksiyon, taşma durumunda panik yapmaz. "
 
 #: src/ch10-02-recoverable-errors.md:81
 msgid "Let's take another example demonstrating the use of `unwrap`."
-msgstr ""
+msgstr "`unwrap` kullanımını gösteren başka bir örneğe bakalım. "
 
 #: src/ch10-02-recoverable-errors.md:92
 msgid "Listing 10-1: Using the Result type"
-msgstr ""
+msgstr "Listeleme 10-1: Result tipini kullanma "
 
 #: src/ch10-02-recoverable-errors.md:94
 msgid ""
 "In this example, the `parse_u8` function takes a `felt252` integer and tries "
 "to convert it into a `u8` integer using the `try_into` method. If "
-"successful, it returns `Result::Ok(value)`, otherwise it returns "
-"`Result::Err('Invalid integer')`."
-msgstr ""
+"successful, it returns `Result::Ok(value)`, otherwise it returns `Result::"
+"Err('Invalid integer')`."
+msgstr "Bu örnekte, `parse_u8` fonksiyonu bir `felt252` tamsayısını alır ve `try_into` metodunu kullanarak bunu bir `u8` tamsayısına dönüştürmeye çalışır. Başarılı olursa, `Result::Ok(değer)` döndürür, aksi takdirde `Result::Err('Geçersiz tamsayı')` döndürür. "
 
 #: src/ch10-02-recoverable-errors.md:96
 msgid "Our two test cases are:"
-msgstr ""
+msgstr "İki test vakamız şunlardır:"
 
 #: src/ch10-02-recoverable-errors.md:112
 msgid "// should not panic\n"
@@ -8373,40 +10039,40 @@ msgid ""
 "`unwrap` method not to panic. The second test function attempts to convert a "
 "value that is out of the `u8` range, expecting the `unwrap` method to panic "
 "with the error message 'Invalid integer'."
-msgstr ""
+msgstr "İlk test, `felt252`den `u8`e geçerli bir dönüşümü test eder ve `unwrap` metodunun panik yapmamasını bekler. İkinci test fonksiyonu, `u8` aralığının dışında bir değeri dönüştürmeyi dener ve `unwrap` metodunun 'Geçersiz tamsayı' hata mesajıyla panik yapmasını bekler. "
 
 #: src/ch10-02-recoverable-errors.md:130
 msgid "The `?` operator"
-msgstr ""
+msgstr "`?` operatörü"
 
 #: src/ch10-02-recoverable-errors.md:132
 msgid ""
 "The last operator we will talk about is the `?` operator. The `?` operator "
 "is used for more idiomatic and concise error handling. When you use the `?` "
 "operator on a `Result` or `Option` type, it will do the following:"
-msgstr ""
+msgstr "Son olarak bahsedeceğimiz operatör `?` operatörüdür. `?` operatörü, daha özdeş ve özlü hata işleme için kullanılır. Bir `Result` veya `Option` türü üzerinde `?` operatörünü kullandığınızda, aşağıdakileri yapacaktır: "
 
 #: src/ch10-02-recoverable-errors.md:134
 msgid ""
 "If the value is `Result::Ok(x)` or `Option::Some(x)`, it will return the "
 "inner value `x` directly."
-msgstr ""
+msgstr "Değer `Result::Ok(x)` veya `Option::Some(x)` ise, iç değeri `x`'i doğrudan döndürür. "
 
 #: src/ch10-02-recoverable-errors.md:135
 msgid ""
 "If the value is `Result::Err(e)` or `Option::None`, it will propagate the "
 "error or `None` by immediately returning from the function."
-msgstr ""
+msgstr "Değer `Result::Err(e)` veya `Option::None` ise, hatayı veya `None`'ı hemen fonksiyondan dönerek yayılır. "
 
 #: src/ch10-02-recoverable-errors.md:137
 msgid ""
 "The `?` operator is useful when you want to handle errors implicitly and let "
 "the calling function deal with them."
-msgstr ""
+msgstr "`?` operatörü, hataları dolaylı olarak ele almak ve çağıran fonksiyonun bunlarla ilgilenmesine izin vermek istediğinizde kullanışlıdır. "
 
 #: src/ch10-02-recoverable-errors.md:139
 msgid "Here is an example."
-msgstr ""
+msgstr "İşte bir örnek. "
 
 #: src/ch10-02-recoverable-errors.md:144 src/ch10-02-recoverable-errors.md:166
 msgid "// DO SOMETHING\n"
@@ -8414,18 +10080,18 @@ msgstr ""
 
 #: src/ch10-02-recoverable-errors.md:150
 msgid "Listing 10-1: Using the `?` operator"
-msgstr ""
+msgstr "Listeleme 10-1: `?` operatörünü kullanma "
 
 #: src/ch10-02-recoverable-errors.md:152
 msgid ""
 "`do_something_with_parse_u8` function takes a `felt252` value as input and "
 "calls `parse_u8`. The `?` operator is used to propagate the error, if any, "
 "or unwrap the successful value."
-msgstr ""
+msgstr "`do_something_with_parse_u8` fonksiyonu bir `felt252` değerini girdi olarak alır ve `parse_u8`'i çağırır. Hata varsa yaymak veya başarılı değeri açmak için `?` operatörü kullanılır. "
 
 #: src/ch10-02-recoverable-errors.md:154
 msgid "And with a little test case:"
-msgstr ""
+msgstr "Ve küçük bir test vakası ile: "
 
 #: src/ch10-02-recoverable-errors.md:178
 msgid "\"Result: {}\""
@@ -8437,7 +10103,7 @@ msgstr ""
 
 #: src/ch10-02-recoverable-errors.md:186
 msgid "The console will print the error \"Invalid Integer\"."
-msgstr ""
+msgstr "Konsol, "Geçersiz Tamsayı" hatasını yazdıracaktır. "
 
 #: src/ch10-02-recoverable-errors.md:192
 msgid ""
@@ -8447,7 +10113,7 @@ msgid ""
 "values, respectively. The `ResultTrait` provides methods for working with "
 "`Result<T, E>`, such as unwrapping values, checking if the result is `Ok` or "
 "`Err`, and panicking with custom messages."
-msgstr ""
+msgstr "Cairo'da, kurtarılabilir hataların, iki varyantı olan Result enum'u kullanılarak ele alınabildiğini gördük: `Ok` ve `Err`. `Result<T, E>` enum'u genel olup, `T` ve `E` türleri sırasıyla başarılı ve hata değerlerini temsil eder. `ResultTrait`, değerleri açma, sonucun `Ok` veya `Err` olup olmadığını kontrol etme ve özel mesajlarla panik yapma gibi `Result<T, E>` ile çalışmak için metodlar sağlar. "
 
 #: src/ch10-02-recoverable-errors.md:194
 msgid ""
@@ -8457,11 +10123,11 @@ msgid ""
 "unwrapping the successful value. This allows for more concise and clear "
 "error handling, where the caller is responsible for managing errors raised "
 "by the called function."
-msgstr ""
+msgstr "Kurtarılabilir hataları ele almak için, bir fonksiyon `Result` türünde bir değer döndürebilir ve bir işlemin başarısı veya başarısızlığını ele almak için desen eşleştirme kullanabilir. `?` operatörü, hatayı dolaylı olarak ele almak veya başarılı değeri açmak için kullanılabilir. Bu, daha özlü ve net hata işleme sağlar, burada çağıran, çağrılan fonksiyon tarafından yükseltilen hataları yönetmekten sorumludur. "
 
 #: src/ch11-00-advanced-features.md:3
 msgid "Now, let's learn about more advanced features offered by Cairo."
-msgstr ""
+msgstr "Şimdi, Cairo tarafından sunulan daha ileri özellikleri öğrenelim. "
 
 #: src/ch11-01-operator-overloading.md:3
 msgid ""
@@ -8471,7 +10137,7 @@ msgid ""
 "types. This can make the syntax of the code more intuitive, by enabling "
 "operations on user-defined types to be expressed in the same way as "
 "operations on primitive types."
-msgstr ""
+msgstr "Operatör aşırı yüklemesi, bazı programlama dillerinde standart operatörlerin, örneğin toplama (+), çıkarma (-), çarpma (\\*), ve bölme (/), kullanıcı tanımlı türlerle çalışacak şekilde yeniden tanımlanmasına izin veren bir özelliktir. Bu, kullanıcı tanımlı türlerdeki işlemlerin, ilkel türlerdeki işlemlerle aynı şekilde ifade edilebilmesini sağlayarak kodun sözdizimini daha sezgisel hale getirebilir."
 
 #: src/ch11-01-operator-overloading.md:5
 msgid ""
@@ -8482,14 +10148,14 @@ msgid ""
 "Misuse can lead to confusion, making the code more difficult to maintain, "
 "for example when there is no semantic meaning to the operator being "
 "overloaded."
-msgstr ""
+msgstr "Cairo'da, operatör aşırı yüklemesi belirli özelliklerin uygulanması yoluyla gerçekleştirilir. Her operatörün ilişkili bir özelliği vardır ve o operatörü aşırı yüklemek, bir özel tür için bu özelliğin bir uygulamasını sağlamayı içerir. Ancak, operatör aşırı yüklemesini dikkatli kullanmak esastır. Kötüye kullanım, operatörün aşırı yüklenmesine semantik bir anlamın olmaması durumunda olduğu gibi, kodun daha zor bakımını yapılabilir hale getirerek kafa karışıklığına yol açabilir."
 
 #: src/ch11-01-operator-overloading.md:8
 msgid ""
 "Consider an example where two `Potions` need to be combined. `Potions` have "
 "two data fields, mana and health. Combining two `Potions` should add their "
 "respective fields."
-msgstr ""
+msgstr "İki `Potions`un birleştirilmesi gereken bir örneği düşünün. `Potions`un iki veri alanı vardır, mana ve sağlık. İki `Potions`un birleştirilmesi, ilgili alanlarının toplanmasını sağlamalıdır. "
 
 #: src/ch11-01-operator-overloading.md:26
 msgid "// Both potions were combined with the `+` operator.\n"
@@ -8501,7 +10167,7 @@ msgid ""
 "The add function takes two arguments: `lhs` and `rhs` (left and right-hand "
 "side). The function body returns a new `Potion` instance, its field values "
 "being a combination of `lhs` and `rhs`."
-msgstr ""
+msgstr "Yukarıdaki kodda, `Potion` türü için `Add` özelliğini uyguluyoruz. add fonksiyonu iki argüman alır: `lhs` ve `rhs` (sol ve sağ taraf). Fonksiyon gövdesi, `lhs` ve `rhs`'nin bir kombinasyonu olan yeni bir `Potion` örneği döndürür. "
 
 #: src/ch11-01-operator-overloading.md:34
 msgid ""
@@ -8509,54 +10175,54 @@ msgid ""
 "specification of the concrete type being overloaded. The overloaded generic "
 "trait is `Add<T>`, and we define a concrete implementation for the type "
 "`Potion` with `Add<Potion>`."
-msgstr ""
+msgstr "Örnekte gösterildiği gibi, bir operatörün aşırı yüklenmesi, aşırı yüklenen somut türün belirtilmesini gerektirir. Aşırı yüklenen genel özellik `Add<T>`'dir ve `Potion` türü için `Add<Potion>` ile somut bir uygulama tanımlıyoruz. "
 
 #: src/ch11-02-macros.md:3
 msgid ""
 "The Cairo language has some plugins that allows developers to simplify their "
 "code. They are called `inline_macros` and are a way of writing code that "
 "generates other code."
-msgstr ""
+msgstr "Cairo dilinde, geliştiricilerin kodlarını basitleştirmelerine olanak tanıyan bazı eklentiler vardır. Bunlara `inline_macros` denir ve diğer kodu üreten kodu yazmanın bir yolu olarak adlandırılırlar. "
 
 #: src/ch11-02-macros.md:5
 msgid "`print!` and `println!` macros"
-msgstr ""
+msgstr "`print!` ve `println!` makroları"
 
 #: src/ch11-02-macros.md:7
 msgid "Two macros are available for printing values:"
-msgstr ""
+msgstr "Değerleri yazdırmak için kullanılabilen iki makro vardır:"
 
 #: src/ch11-02-macros.md:8
 msgid "`println!` which prints on a new line "
-msgstr ""
+msgstr "`println!` yeni bir satırda yazdırır"
 
 #: src/ch11-02-macros.md:9
 msgid "`print!` with inline printing"
-msgstr ""
+msgstr "`print!` ile satır içi yazdırma"
 
 #: src/ch11-02-macros.md:11
 msgid ""
 "Both can be used with curly brackets as placeholders that hold a value in "
 "place:"
-msgstr ""
+msgstr "Her ikisi de değer yer tutucuları olarak süslü parantezlerle birlikte kullanılabilir:"
 
 #: src/ch11-02-macros.md:12
 msgid ""
 "When printing the value of a variable, the variable name can go inside the "
 "curly brackets."
-msgstr ""
+msgstr "Bir değişkenin değerini yazdırırken, değişken adı süslü parantezlerin içine gidebilir."
 
 #: src/ch11-02-macros.md:13
 msgid ""
 "When printing the result of evaluating an expression, use empty curly "
-"brackets in the format string, then follow the format string with a "
-"comma-separated list of expressions to print in each empty curly bracket "
+"brackets in the format string, then follow the format string with a comma-"
+"separated list of expressions to print in each empty curly bracket "
 "placeholder in the same order."
-msgstr ""
+msgstr "Bir ifadenin değerlendirilmesi sonucunu yazdırırken, biçim dizgisinde boş süslü parantezler kullanın, ardından her boş süslü parantez yer tutucusuna aynı sırayla yazdırılacak ifadelerin virgülle ayrılmış listesini biçim dizgisinin ardından takip edin."
 
 #: src/ch11-02-macros.md:15
 msgid "`consteval_int!` macro"
-msgstr ""
+msgstr "`consteval_int!` makrosu"
 
 #: src/ch11-02-macros.md:17
 msgid ""
@@ -8564,33 +10230,33 @@ msgid ""
 "result of a computation of integers. To compute a constant expression and "
 "use its result at compile time, it is required to use the `consteval_int!` "
 "macro."
-msgstr ""
+msgstr "Bazı durumlarda, bir geliştirici tamsayıların bir hesaplamasının sonucu olan bir sabiti bildirmeye ihtiyaç duyabilir. Sabit bir ifadeyi hesaplamak ve sonucunu derleme zamanında kullanmak için `consteval_int!` makrosunu kullanmak gereklidir."
 
 #: src/ch11-02-macros.md:19
 msgid "Here is an example of `consteval_int!`:"
-msgstr ""
+msgstr "`consteval_int!` örneği:"
 
 #: src/ch11-02-macros.md:25
 msgid "This will be interpreted as `const a: felt252 = 8;` by the compiler."
-msgstr ""
+msgstr "Bu, derleyici tarafından `const a: felt252 = 8;` olarak yorumlanacaktır."
 
 #: src/ch11-02-macros.md:29
 msgid "Please refer to the [Arrays](./ch03-01-arrays.md) page."
-msgstr ""
+msgstr "Lütfen [Diziler](./ch03-01-arrays.md) sayfasına bakınız."
 
 #: src/ch11-02-macros.md:31
 msgid "`panic!`, `assert!` and `assert_eq!` macros macro"
-msgstr ""
+msgstr "`panic!`, `assert!` ve `assert_eq!` makroları"
 
 #: src/ch11-02-macros.md:33
 msgid ""
-"See [Unrecoverable Errors with "
-"panic](./ch10-01-unrecoverable-errors-with-panic.md) page."
-msgstr ""
+"See [Unrecoverable Errors with panic](./ch10-01-unrecoverable-errors-with-"
+"panic.md) page."
+msgstr "[Geridönüşümsüz Hatalarla panic](./ch10-01-unrecoverable-errors-with-panic.md) sayfasına bakınız."
 
 #: src/ch11-02-macros.md:35
 msgid "`format!` macro"
-msgstr ""
+msgstr "`format!` makrosu"
 
 #: src/ch11-02-macros.md:37
 msgid ""
@@ -8600,7 +10266,7 @@ msgid ""
 "operator or the `format!` macro.  The version of the code using `format!` is "
 "much easier to read, and the code generated by the `format!` macro uses "
 "snapshots so that this call doesn’t take ownership of any of its parameters."
-msgstr ""
+msgstr "`format!` makrosu `println!` gibi çalışır, ancak çıktıyı ekrana yazdırmak yerine, içeriği ile bir `ByteArray` döndürür. Aşağıdaki örnekte, `+` operatörü veya `format!` makrosu kullanılarak dizgi birleştirme işlemi yapılıyor. `format!` makrosunu kullanan kodun versiyonu çok daha okunaklıdır ve `format!` makrosu tarafından üretilen kod, bu çağrının parametrelerinin hiçbirine sahiplik yapmaması için anlık görüntüler kullanır."
 
 #: src/ch11-02-macros.md:46 src/ch11-02-macros.md:52
 msgid "\"tic\""
@@ -8614,12 +10280,13 @@ msgstr ""
 msgid "\"toe\""
 msgstr ""
 
-#: src/ch11-02-macros.md:49 src/ch11-02-macros.md:49
+#: src/ch11-02-macros.md:49
 msgid "\"-\""
 msgstr ""
 
 #: src/ch11-02-macros.md:50
-msgid "// using + operator consumes the strings, so they can't be used again!\n"
+msgid ""
+"// using + operator consumes the strings, so they can't be used again!\n"
 msgstr ""
 
 #: src/ch11-02-macros.md:55
@@ -8642,29 +10309,29 @@ msgstr ""
 
 #: src/ch11-02-macros.md:62
 msgid "`write!` macro"
-msgstr ""
+msgstr "`write!` makrosu"
 
 #: src/ch11-02-macros.md:64
 msgid ""
 "The `write!` and `writeln!` are two macros which are used to emit the format "
 "string to a specified stream. This macro takes 2 arguments:"
-msgstr ""
+msgstr "`write!` ve `writeln!`, biçim dizgisini belirli bir akışa göndermek için kullanılan iki makrodur. Bu makro 2 argüman alır:"
 
 #: src/ch11-02-macros.md:66
 msgid ""
 "a Formatter, which is a struct containing a `ByteArray`, representing the "
 "pending result of formatting (the _stream_)"
-msgstr ""
+msgstr "Bir Formatter, bekleyen biçimlendirme sonucunu (akış) temsil eden bir `ByteArray` içeren bir yapıdır."
 
 #: src/ch11-02-macros.md:67
 msgid "the 'ByteArray' to append to the formatter"
-msgstr ""
+msgstr "formatter'a eklenecek 'ByteArray'"
 
 #: src/ch11-02-macros.md:69
 msgid ""
 "Calling this macro will append the provided `ByteArray` string to the "
 "formatter. Example usage is:"
-msgstr ""
+msgstr "Bu makroyu çağırmak, sağlanan `ByteArray` dizgisini formatter'a ekler. Kullanım örneği:"
 
 #: src/ch11-02-macros.md:75
 msgid "\"hello\""
@@ -8680,7 +10347,7 @@ msgstr ""
 
 #: src/ch11-03-hash.md:1
 msgid "Hashes"
-msgstr ""
+msgstr "Hashler"
 
 #: src/ch11-03-hash.md:3
 msgid ""
@@ -8691,23 +10358,23 @@ msgid ""
 "component in various fields, including data storage, cryptography, and data "
 "integrity verification - and are very often when developing smart contracts, "
 "especially when working with Merkle trees."
-msgstr ""
+msgstr "Temelinde, hashleme, herhangi bir uzunluktaki girdi verilerini (genellikle bir mesaj olarak adlandırılır) tipik olarak bir "hash" olarak adlandırılan sabit boyutta bir değere dönüştürme işlemidir. Bu dönüşüm belirlenimlidir, yani aynı giriş her zaman aynı hash değerini üretir. Hash fonksiyonları, veri depolama, kriptografi ve veri bütünlüğü doğrulama dahil olmak üzere çeşitli alanlarda temel bir bileşendir - ve özellikle Merkle ağaçları ile çalışırken akıllı sözleşmeler geliştirirken çok sık kullanılır."
 
 #: src/ch11-03-hash.md:5
 msgid ""
 "In this chapter, we will present the two hash functions implemented natively "
 "in the Cairo library : `Poseidon` and `Pedersen`. We will discuss about when "
 "and how to use them, and see examples with cairo programs."
-msgstr ""
+msgstr "Bu bölümde, Kahire kitaplığında yerel olarak uygulanan iki hash fonksiyonunu sunacağız: `Poseidon` ve `Pedersen`. Ne zaman ve nasıl kullanılacakları hakkında tartışacağız ve Kahire programları ile örnekler göreceğiz."
 
 #: src/ch11-03-hash.md:7
 msgid "Hash functions in Cairo"
-msgstr ""
+msgstr "Cairo'daki Hash Fonksiyonları"
 
 #: src/ch11-03-hash.md:9
 msgid ""
 "The Cairo core library provides two hash functions: Pedersen and Poseidon."
-msgstr ""
+msgstr "Cairo çekirdek kitaplığı iki hash fonksiyonu sağlar: Pedersen ve Poseidon."
 
 #: src/ch11-03-hash.md:11
 msgid ""
@@ -8720,7 +10387,7 @@ msgid ""
 "the hash function. The difficulty of reversing these operations is what "
 "makes the Pedersen hash function secure and reliable for cryptographic "
 "purposes."
-msgstr ""
+msgstr "Pedersen hash fonksiyonları, eliptik eğri kriptografisine dayanan kriptografik algoritmalarıdır. Bu fonksiyonlar, bir eliptik eğri boyunca noktalar üzerinde işlemler gerçekleştirir - esasen, bu noktaların konumlarıyla matematik yapar - bunları bir yönde yapmak kolay ve geri almak zordur. Bu tek yönlü zorluk, Elips Eğrisi Ayrık Logaritma Problemi (ECDLP) üzerine kuruludur, bu da hash fonksiyonunun güvenliğini sağlayacak kadar çözülmesi zor bir problemdir. Bu işlemlerin tersine çevrilmesinin zorluğu, Pedersen hash fonksiyonunu kriptografik amaçlar için güvenli ve güvenilir kılar."
 
 #: src/ch11-03-hash.md:13
 msgid ""
@@ -8729,13 +10396,13 @@ msgid ""
 "proof systems, including STARKs (so, Cairo). Poseidon uses a method called a "
 "'sponge construction,' which soaks up data and transforms it securely using "
 "a process known as the Hades permutation. Cairo's version of Poseidon is "
-"based on a three element state permutation with [specific "
-"parameters](https://github.com/starkware-industries/poseidon/blob/main/poseidon3.txt)."
-msgstr ""
+"based on a three element state permutation with [specific parameters]"
+"(https://github.com/starkware-industries/poseidon/blob/main/poseidon3.txt)."
+msgstr "Poseidon, cebirsel devrelerde çok verimli olacak şekilde tasarlanmış bir hash fonksiyonları ailesidir. Tasarımı, özellikle STARK'lar (yani, Kahire) dahil olmak üzere Sıfır-Bilgi kanıt sistemleri için özellikle verimlidir. Poseidon, verileri emen ve Hades permütasyonu olarak bilinen bir süreç kullanarak güvenli bir şekilde dönüştüren bir yöntem olan 'sünger yapısı'nı kullanır. Kahire'nin Poseidon versiyonu, [belirli parametreler](https://github.com/starkware-industries/poseidon/blob/main/poseidon3.txt) ile üç elemanlı durum permütasyonuna dayanır."
 
 #: src/ch11-03-hash.md:15
 msgid "When to use them ?"
-msgstr ""
+msgstr "Ne Zaman Kullanılır?"
 
 #: src/ch11-03-hash.md:17
 msgid ""
@@ -8744,7 +10411,7 @@ msgid ""
 "Pedersen to hash the keys of a storage mapping on Starknet). However, as "
 "Poseidon is cheaper and faster than Pedersen when working with STARK proofs "
 "system, it's now the recommended hash function to use in Cairo programs."
-msgstr ""
+msgstr "Pedersen, Starknet'te kullanılan ilk hash fonksiyonuydu ve hala depolama alanındaki değişkenlerin adreslerini hesaplamak için kullanılmaktadır (örneğin, `LegacyMap` Starknet'te bir depolama eşlemesinin anahtarlarını hashlemek için Pedersen kullanır). Ancak, Poseidon STARK kanıt sistemiyle çalışırken Pedersen'den daha ucuz ve daha hızlı olduğundan, şimdi Kahire programlarında kullanılması önerilen hash fonksiyonudur."
 
 #: src/ch11-03-hash.md:21
 msgid ""
@@ -8755,7 +10422,7 @@ msgid ""
 "given that all of the struct's fields are themselves hashable. You cannot "
 "derive the `Hash` trait on a struct that contains un-hashable values, such "
 "as `Array<T>` or a `Felt252Dict<T>`, even if `T` itself is hashable."
-msgstr ""
+msgstr "Çekirdek kitaplık, hash'lerle çalışmayı kolaylaştırır. `Hash` özelliği, `felt252`'ye dönüştürülebilen tüm türler için uygulanır, `felt252` kendisi de dahil. Daha karmaşık türler gibi yapılar için, `Hash` türetilmesi, tercih ettiğiniz hash fonksiyonunu kullanarak kolayca hashlenmelerini sağlar - yapı alanlarının kendileri hashlenebilir olduğu sürece. `Array<T>` veya `Felt252Dict<T>` gibi hashlenemeyen değerler içeren bir yapıda `Hash` özelliği türetilemez, `T` kendisi hashlenebilir olsa bile."
 
 #: src/ch11-03-hash.md:23
 msgid ""
@@ -8764,7 +10431,7 @@ msgid ""
 "that will contain the temporary values of the hash after each application of "
 "the hash function; update the hash state, and finalize it when the "
 "computation is completed. `HashStateTrait` is defined as follows:"
-msgstr ""
+msgstr "`Hash` özelliği, hash'lerle çalışmak için temel metodları tanımlayan `HashStateTrait` ile birlikte gelir. Her bir hash fonksiyonu uygulamasından sonra hash'in geçici değerlerini içerecek bir hash durumunu başlatmanıza, hash durumunu güncellemenize ve hesaplama tamamlandığında sonlandırmanıza izin verirler. `HashStateTrait` şu şekilde tanımlanır:"
 
 #: src/ch11-03-hash.md:26
 msgid "/// A trait for hash state accumulators.\n"
@@ -8783,24 +10450,24 @@ msgid ""
 "To use hashes in your code, you must first import the relevant traits and "
 "functions. In the following example, we will demonstrate how to hash a "
 "struct using both the Pedersen and Poseidon hash functions."
-msgstr ""
+msgstr "Kodunuzda hash'leri kullanmak için, ilgili özellikleri ve fonksiyonları önce içe aktarmanız gerekir. Aşağıdaki örnekte, hem Pedersen hem de Poseidon hash fonksiyonlarını kullanarak bir yapıyı nasıl hashleyeceğimizi göstereceğiz."
 
 #: src/ch11-03-hash.md:42
 msgid ""
-"The first step is to initialize the hash with either `PoseidonTrait::new() "
-"-> HashState` or `PedersenTrait::new(base: felt252) -> HashState` depending "
+"The first step is to initialize the hash with either `PoseidonTrait::new() -"
+"> HashState` or `PedersenTrait::new(base: felt252) -> HashState` depending "
 "on which hash function we want to work with. Then the hash state can be "
 "updated with the `update(self: HashState, value: felt252) -> HashState` or "
 "`update_with(self: S, value: T) -> S` functions as many times as required. "
 "Then the function `finalize(self: HashState) -> felt252` is called on the "
 "hash state and it returns the value of the hash as a `felt252`."
-msgstr ""
+msgstr "İlk adım, hangi hash fonksiyonuyla çalışmak istediğimize bağlı olarak ya `PoseidonTrait::new() -> HashState` ya da `PedersenTrait::new(base: felt252) -> HashState` ile hash'i başlatmaktır. Daha sonra hash durumu, gerektiği kadar `update(self: HashState, value: felt252) -> HashState` veya `update_with(self: S, value: T) -> S` fonksiyonları ile güncellenebilir. Sonra `finalize(self: HashState) -> felt252` fonksiyonu hash durumu üzerinde çağrılır ve hash değeri bir `felt252` olarak döndürülür."
 
 #: src/ch11-03-hash.md:68
 msgid ""
 "As our struct derives the trait HashTrait, we can call the function as "
 "follows for Poseidon hashing :"
-msgstr ""
+msgstr "Yapımız HashTrait özelliğini türettiği için, Poseidon hashleme için fonksiyonu şu şekilde çağırabiliriz:"
 
 #: src/ch11-03-hash.md:92
 msgid ""
@@ -8809,11 +10476,11 @@ msgid ""
 "struct with an arbitrary base state using the `update_with` method, or "
 "serialize the struct into an array to loop through all of its fields and "
 "hash its elements together."
-msgstr ""
+msgstr "Pedersen, bir temel durumla başladığı için Poseidon'dan farklıdır. Bu temel durum `felt252` türünde olmalıdır, bu da bizi ya `update_with` metodunu kullanarak yapıyı keyfi bir temel durumla hashlemeye ya da yapıyı bir diziye seri hale getirip tüm alanlarını döngüye alıp elemanlarını birlikte hashlemeye zorlar."
 
 #: src/ch11-03-hash.md:94
 msgid "Here is a short example for Pedersen hashing :"
-msgstr ""
+msgstr "Pedersen hashleme için kısa bir örnek:"
 
 #: src/ch11-03-hash.md:111
 msgid "// hash1 is the result of hashing a struct with a base state of 0\n"
@@ -8825,7 +10492,7 @@ msgstr ""
 
 #: src/ch11-03-hash.md:133
 msgid "Advanced Hashing: Hashing arrays with Poseidon"
-msgstr ""
+msgstr "İleri Hashleme: Poseidon ile Dizileri Hashleme"
 
 #: src/ch11-03-hash.md:135
 msgid ""
@@ -8834,18 +10501,18 @@ msgid ""
 "`Span<felt252>` you can use the built-in function in poseidon ` "
 "poseidon_hash_span(mut span: Span<felt252>) -> felt252`. Similarly you can "
 "hash `Array<felt252>` by calling `poseidon_hash_span` on its span."
-msgstr ""
+msgstr "Bir fonksiyonun bir `Span<felt252>` içerdiği bir örneğe bakalım. Bir `Span<felt252>` veya bir `Span<felt252>` içeren bir yapıyı hashlemek için, poseidon'da yerleşik olan `poseidon_hash_span(mut span: Span<felt252>) -> felt252` fonksiyonunu kullanabilirsiniz. Benzer şekilde, `Array<felt252>`'nin span'ını çağırarak `poseidon_hash_span` ile hashleyebilirsiniz."
 
 #: src/ch11-03-hash.md:139
 msgid "First let us import the following trait and function :"
-msgstr ""
+msgstr "İlk olarak aşağıdaki özelliği ve fonksiyonu içe aktaralım:"
 
 #: src/ch11-03-hash.md:147
 msgid ""
 "Now we define the structure, as you might have notice we didn't derived the "
 "Hash trait. If you try to derive the Hash trait on this structure it will "
 "rise an error because the structure contains a field not hashable."
-msgstr ""
+msgstr "Şimdi yapıyı tanımlıyoruz, fark etmiş olabileceğiniz gibi Hash özelliğini türetmedik. Bu yapıya Hash özelliğini türetmeye çalışırsanız, yapının hashlenemeyen bir alan içermesi nedeniyle bir hata oluşur."
 
 #: src/ch11-03-hash.md:160
 msgid ""
@@ -8853,7 +10520,7 @@ msgid ""
 "called the function `finalize()` on the HashState to get the computed hash "
 "`hash_felt252`. We used the `poseidon_hash_span` on the `Span` of the "
 "`Array<felt252>` to compute its hash."
-msgstr ""
+msgstr "Bu örnekte, bir HashState (`hash`) başlattık ve güncelledik, ardından hesaplanan hash `hash_felt252`'yi almak için HashState üzerinde `finalize()` fonksiyonunu çağırdık. `Array<felt252>`'nin hash'ini hesaplamak için `Span` üzerinde `poseidon_hash_span` kullandık."
 
 #: src/ch99-00-starknet-smart-contracts.md:3
 msgid ""
@@ -8867,9 +10534,9 @@ msgid ""
 "One of the applications of the Cairo language is to write smart contracts "
 "for the Starknet network. Starknet is a permissionless network that "
 "leverages zk-STARKs technology for scalability. As a Layer-2 scalability "
-"solution for Ethereum, Starknet's goal is to offer fast, secure, and "
-"low-cost transactions. It functions as a Validity Rollup (commonly known as "
-"a zero-knowledge Rollup) and is built on top of the Cairo language and the "
+"solution for Ethereum, Starknet's goal is to offer fast, secure, and low-"
+"cost transactions. It functions as a Validity Rollup (commonly known as a "
+"zero-knowledge Rollup) and is built on top of the Cairo language and the "
 "Starknet VM."
 msgstr ""
 
@@ -8900,8 +10567,8 @@ msgid ""
 "Scarb supports smart contract development for Starknet. To enable this "
 "functionality, you'll need to make some configurations in your `Scarb.toml` "
 "file (see [Installation](./ch01-01-installation.md) for how to install "
-"Scarb). You have to add the `starknet` dependency and add a "
-"`[[target.starknet-contract]]` section to enable contract compilation."
+"Scarb). You have to add the `starknet` dependency and add a `[[target."
+"starknet-contract]]` section to enable contract compilation."
 msgstr ""
 
 #: src/ch99-00-starknet-smart-contracts.md:17
@@ -8927,8 +10594,8 @@ msgstr ""
 #: src/ch99-00-starknet-smart-contracts.md:30
 msgid ""
 "For additional configuration, such as external contract dependencies, please "
-"refer to the [Scarb "
-"documentation](https://docs.swmansion.com/scarb/docs/extensions/starknet/contract-target.html#compiling-external-contracts)."
+"refer to the [Scarb documentation](https://docs.swmansion.com/scarb/docs/"
+"extensions/starknet/contract-target.html#compiling-external-contracts)."
 msgstr ""
 
 #: src/ch99-00-starknet-smart-contracts.md:32
@@ -8965,10 +10632,10 @@ msgstr ""
 #: src/ch99-01-01-introduction-to-smart-contracts.md:10
 msgid ""
 "The programming language used to write smart contracts varies depending on "
-"the blockchain. For example, on Ethereum and the [EVM-compatible "
-"ecosystem](https://ethereum.org/en/developers/docs/evm/), the most commonly "
-"used language is Solidity, while on Starknet, it is Cairo. The way the code "
-"is compiled also differs based on the blockchain. On Ethereum, Solidity is "
+"the blockchain. For example, on Ethereum and the [EVM-compatible ecosystem]"
+"(https://ethereum.org/en/developers/docs/evm/), the most commonly used "
+"language is Solidity, while on Starknet, it is Cairo. The way the code is "
+"compiled also differs based on the blockchain. On Ethereum, Solidity is "
 "compiled into bytecode. On Starknet, Cairo is compiled into Sierra and then "
 "into Cairo Assembly (casm)."
 msgstr ""
@@ -8993,8 +10660,8 @@ msgid ""
 "it is required to know what the other contracts look like. Hence, Ethereum "
 "developers started to build standards for smart contract development, the "
 "`ERCxx`. The two most used and famous standards are the `ERC20`, used to "
-"build tokens like `USDC`, `DAI` or `STARK`, and the `ERC721`, for NFTs "
-"(Non-fungible tokens) like `CryptoPunks` or `Everai`."
+"build tokens like `USDC`, `DAI` or `STARK`, and the `ERC721`, for NFTs (Non-"
+"fungible tokens) like `CryptoPunks` or `Everai`."
 msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:16
@@ -9090,15 +10757,14 @@ msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:48
 msgid ""
-"A famous trilemma ([The Blockchain "
-"Trilemma](https://vitalik.ca/general/2021/04/07/sharding.html#the-scalability-trilemma)) "
-"in the blockchain space states that it is impossible to achieve a high level "
-"of scalability, decentralization, and security simultaneously; trade-offs "
-"must be made. Ethereum is at the intersection of decentralization and "
-"security. Eventually, it was decided that Ethereum's purpose would be to "
-"serve as a secure settlement layer, while complex computations would be "
-"offloaded to other networks built on top of Ethereum. These are called Layer "
-"2s (L2s)."
+"A famous trilemma ([The Blockchain Trilemma](https://vitalik.ca/"
+"general/2021/04/07/sharding.html#the-scalability-trilemma)) in the "
+"blockchain space states that it is impossible to achieve a high level of "
+"scalability, decentralization, and security simultaneously; trade-offs must "
+"be made. Ethereum is at the intersection of decentralization and security. "
+"Eventually, it was decided that Ethereum's purpose would be to serve as a "
+"secure settlement layer, while complex computations would be offloaded to "
+"other networks built on top of Ethereum. These are called Layer 2s (L2s)."
 msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:50
@@ -9117,16 +10783,15 @@ msgid ""
 "that the new state has been correctly computed. This is the purpose of "
 "STARKs, this cryptographic technology could permit validity rollups to scale "
 "significantly more than optimistic rollups. You can learn more about STARKs "
-"from Starkware's Medium "
-"[article](https://medium.com/starkware/starks-starkex-and-starknet-9a426680745a), "
-"which serves as a good primer."
+"from Starkware's Medium [article](https://medium.com/starkware/starks-"
+"starkex-and-starknet-9a426680745a), which serves as a good primer."
 msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:54
 msgid ""
-"Starknet's architecture is thoroughly described in the [Starknet "
-"Book](https://book.starknet.io/chapter_4/index.html), which is a great "
-"resource to learn more about the Starknet network."
+"Starknet's architecture is thoroughly described in the [Starknet Book]"
+"(https://book.starknet.io/chapter_4/index.html), which is a great resource "
+"to learn more about the Starknet network."
 msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:56
@@ -9154,8 +10819,8 @@ msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:60
 msgid ""
-"Learn more about Account Abstraction in the [Starknet "
-"Book](https://book.starknet.io/chapter_5/index.html)."
+"Learn more about Account Abstraction in the [Starknet Book](https://book."
+"starknet.io/chapter_5/index.html)."
 msgstr ""
 
 #: src/ch99-01-01-introduction-to-smart-contracts.md:62
@@ -9174,8 +10839,8 @@ msgstr ""
 msgid ""
 "Starknet contracts are essentially programs that can run on the Starknet OS, "
 "and as such, have access to Starknet's state. For a module to be handled as "
-"a contract by the compiler, it must be annotated with the "
-"`#[starknet::contract]` attribute."
+"a contract by the compiler, it must be annotated with the `#[starknet::"
+"contract]` attribute."
 msgstr ""
 
 #: src/ch99-01-02-a-simple-contract.md:3
@@ -9202,8 +10867,8 @@ msgstr ""
 
 #: src/ch99-01-02-a-simple-contract.md:40
 msgid ""
-"Note: Starknet contracts are defined within "
-"[modules](./ch07-02-defining-modules-to-control-scope.md)."
+"Note: Starknet contracts are defined within [modules](./ch07-02-defining-"
+"modules-to-control-scope.md)."
 msgstr ""
 
 #: src/ch99-01-02-a-simple-contract.md:42
@@ -9456,13 +11121,12 @@ msgstr ""
 
 #: src/ch99-01-03-01-contract-storage.md:117
 msgid ""
-"The storage struct is a "
-"[struct](./ch05-00-using-structs-to-structure-related-data.md) like any "
-"other, except that it **must** be annotated with `#[storage]`. This "
-"annotation tells the compiler to generate the required code to interact with "
-"the blockchain state, and allows you to read and write data from and to "
-"storage. Moreover, this allows you to define storage mappings using the "
-"`LegacyMap` type."
+"The storage struct is a [struct](./ch05-00-using-structs-to-structure-"
+"related-data.md) like any other, except that it **must** be annotated with "
+"`#[storage]`. This annotation tells the compiler to generate the required "
+"code to interact with the blockchain state, and allows you to read and write "
+"data from and to storage. Moreover, this allows you to define storage "
+"mappings using the `LegacyMap` type."
 msgstr ""
 
 #: src/ch99-01-03-01-contract-storage.md:120
@@ -9492,9 +11156,9 @@ msgstr ""
 #: src/ch99-01-03-01-contract-storage.md:127
 msgid ""
 "If the variable is a [mapping](#storing-mappings), the address of the value "
-"at key `k_1,...,k_n` is "
-"`h(...h(h(sn_keccak(variable_name),k_1),k_2),...,k_n)` where ℎ is the "
-"Pedersen hash and the final value is taken `mod (2^251) − 256`."
+"at key `k_1,...,k_n` is `h(...h(h(sn_keccak(variable_name),k_1),k_2),...,"
+"k_n)` where ℎ is the Pedersen hash and the final value is taken `mod (2^251) "
+"− 256`."
 msgstr ""
 
 #: src/ch99-01-03-01-contract-storage.md:128
@@ -9608,10 +11272,10 @@ msgid ""
 "The elements of the struct are stored in the same order as they are defined "
 "in the struct definition. The first element of the struct is stored at the "
 "base address of the struct, which is computed as specified in [Storage "
-"Addresses](#storage-addresses) and can be obtained by calling "
-"`var.address()`, and subsequent elements are stored at addresses contiguous "
-"to the first element. For example, the storage layout for the `owner` "
-"variable of type `Person` will result in the following layout:"
+"Addresses](#storage-addresses) and can be obtained by calling `var."
+"address()`, and subsequent elements are stored at addresses contiguous to "
+"the first element. For example, the storage layout for the `owner` variable "
+"of type `Person` will result in the following layout:"
 msgstr ""
 
 #: src/ch99-01-03-01-contract-storage.md:922
@@ -9736,7 +11400,9 @@ msgstr ""
 #: src/ch99-01-03-01-contract-storage.md:974
 msgid ""
 "For more details about the contract storage layout in the [Starknet "
-"Documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage/#storage_variables)"
+"Documentation](https://docs.starknet.io/documentation/"
+"architecture_and_concepts/Smart_Contracts/contract-storage/"
+"#storage_variables)"
 msgstr ""
 
 #: src/ch99-01-03-02-contract-functions.md:3
@@ -9847,8 +11513,8 @@ msgid ""
 "is a special attribute that tells the compiler to generate a trait "
 "definition for the implementation block. This allows you to get rid of the "
 "boilerplate code of defining a trait and implementing it for the "
-"implementation block. We will see more about this in the [next "
-"section](./ch99-01-03-04-reducing-boilerplate.md)."
+"implementation block. We will see more about this in the [next section](./"
+"ch99-01-03-04-reducing-boilerplate.md)."
 msgstr ""
 
 #: src/ch99-01-03-02-contract-functions.md:113
@@ -9869,8 +11535,8 @@ msgstr ""
 #: src/ch99-01-03-02-contract-functions.md:117
 msgid ""
 "In the case of `#[abi(per_item)]` attribute usage without "
-"`#[generate_trait]`, it will only be possible to include `constructor`, "
-"`l1-handler` and `internal` functions in the trait implementation. Indeed, "
+"`#[generate_trait]`, it will only be possible to include `constructor`, `l1-"
+"handler` and `internal` functions in the trait implementation. Indeed, "
 "`#[abi(per_item)]` only works with a trait that is not defined as a Starknet "
 "interface. Hence, it will be mandatory to create another trait defined as "
 "interface to implement public functions."
@@ -9941,10 +11607,9 @@ msgstr ""
 msgid ""
 "Each event variant has to be a struct of the same name as the variant, and "
 "each variant needs to implement the `starknet::Event` trait itself. "
-"Moreover, the members of these variants must implement the `Serde` trait "
-"(_c.f._ [Appendix C: Serializing with "
-"Serde](./appendix-03-derivable-traits.md)), as keys/data are added to the "
-"event using a serialization process."
+"Moreover, the members of these variants must implement the `Serde` trait (_c."
+"f._ [Appendix C: Serializing with Serde](./appendix-03-derivable-traits."
+"md)), as keys/data are added to the event using a serialization process."
 msgstr ""
 
 #: src/ch99-01-03-03-contract-events.md:41
@@ -9967,8 +11632,8 @@ msgstr ""
 
 #: src/ch99-01-03-03-contract-events.md:46
 msgid ""
-"When emitting the event with `self.emit(StoredName { user: user, name: name "
-"})`, a key corresponding to the name ` StoredName`, specifically "
+"When emitting the event with `self.emit(StoredName { user: user, name: "
+"name })`, a key corresponding to the name ` StoredName`, specifically "
 "`sn_keccak(StoredName)`, is appended to the keys list. `user`is serialized "
 "as key, thanks to the `#[key]` attribute, while address is serialized as "
 "data. After everything is processed, we end up with the following keys and "
@@ -10214,8 +11879,8 @@ msgstr ""
 msgid ""
 "To create a component, first define it in its own module decorated with a "
 "`#[starknet::component]` attribute. Within this module, you can declare a ` "
-"Storage` struct and `Event` enum, as usually done in "
-"[Contracts](./ch99-01-02-a-simple-contract.md)."
+"Storage` struct and `Event` enum, as usually done in [Contracts](./"
+"ch99-01-02-a-simple-contract.md)."
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:42
@@ -10225,9 +11890,8 @@ msgid ""
 "component's logic. You can define the interface of the component by "
 "declaring a trait with the `#[starknet::interface]` attribute, just as you "
 "would with contracts. This interface will be used to enable external access "
-"to the component's functions using the "
-"[Dispatcher](./ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md) "
-"pattern."
+"to the component's functions using the [Dispatcher](./ch99-02-02-contract-"
+"dispatcher-library-dispatcher-and-system-calls.md) pattern."
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:51
@@ -10329,8 +11993,8 @@ msgid ""
 "One of the major differences from a regular smart contract is that access to "
 "storage and events is done via the generic `ComponentState<TContractState>` "
 "type and not `ContractState`. Note that while the type is different, "
-"accessing storage or emitting events is done similarly via "
-"`self.storage_var_name.read()` or `self.emit(...).`"
+"accessing storage or emitting events is done similarly via `self."
+"storage_var_name.read()` or `self.emit(...).`"
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:208
@@ -10421,8 +12085,8 @@ msgstr ""
 msgid ""
 "Add the path to the component's storage and events to the contract's "
 "`Storage` and `Event`. They must match the names provided in step 1 (e.g. "
-"`ownable: ownable_component::Storage` and `OwnableEvent: "
-"ownable_component::Event`)."
+"`ownable: ownable_component::Storage` and `OwnableEvent: ownable_component::"
+"Event`)."
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:250
@@ -10474,8 +12138,8 @@ msgstr ""
 
 #: src/ch99-01-05-00-components.md:323
 msgid ""
-"Developers can focus on their core contract logic while relying on "
-"battle-tested and audited components for everything else."
+"Developers can focus on their core contract logic while relying on battle-"
+"tested and audited components for everything else."
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:326
@@ -10483,8 +12147,8 @@ msgid ""
 "Components can even [depend](./ch99-01-05-02-component-dependencies.md) on "
 "other components by restricting the `TContractstate` they're generic on to "
 "implement the trait of another component. Before we dive into this "
-"mechanism, let's first look at [how components work under the "
-"hood](./ch99-01-05-01-components-under-the-hood)."
+"mechanism, let's first look at [how components work under the hood](./"
+"ch99-01-05-01-components-under-the-hood)."
 msgstr ""
 
 #: src/ch99-01-05-00-components.md:331
@@ -10573,7 +12237,8 @@ msgid "A Primer on Embeddable Impls"
 msgstr ""
 
 #: src/ch99-01-05-01-components-under-the-hood.md:11
-msgid "Before digging into components, we need to understand _embeddable impls_."
+msgid ""
+"Before digging into components, we need to understand _embeddable impls_."
 msgstr ""
 
 #: src/ch99-01-05-01-components-under-the-hood.md:13
@@ -10646,8 +12311,8 @@ msgid ""
 "`Ownable` in any contract that wants to use it. The opposite direction "
 "(`ComponentState<TContractState>` to `ContractState`) is useful for "
 "dependencies (see the `Upgradeable` component depending on an `IOwnable` "
-"implementation example in the [Components dependencies "
-"](./ch99-01-05-02-component-dependencies.md) section."
+"implementation example in the [Components dependencies ](./ch99-01-05-02-"
+"component-dependencies.md) section."
 msgstr ""
 
 #: src/ch99-01-05-01-components-under-the-hood.md:94
@@ -10823,11 +12488,11 @@ msgstr ""
 
 #: src/ch99-01-05-03-testing-components.md:104
 msgid ""
-"In [Components under the "
-"hood](./ch99-01-05-01-components-under-the-hood.md), we saw that components "
-"leveraged genericity to define storage and logic that could be embedded in "
-"multiple contracts. If a contract embeds a component, a `HasComponent` trait "
-"is created in this contract, and the component methods are made available."
+"In [Components under the hood](./ch99-01-05-01-components-under-the-hood."
+"md), we saw that components leveraged genericity to define storage and logic "
+"that could be embedded in multiple contracts. If a contract embeds a "
+"component, a `HasComponent` trait is created in this contract, and the "
+"component methods are made available."
 msgstr ""
 
 #: src/ch99-01-05-03-testing-components.md:106
@@ -10848,8 +12513,8 @@ msgstr ""
 #: src/ch99-01-05-03-testing-components.md:110
 msgid ""
 "First, we need to define a concrete implementation of the generic "
-"`ComponentState` type using a type alias. We will use the "
-"`MockContract::ContractState` type to do so."
+"`ComponentState` type using a type alias. We will use the `MockContract::"
+"ContractState` type to do so."
 msgstr ""
 
 #: src/ch99-01-05-03-testing-components.md:118
@@ -10859,11 +12524,11 @@ msgstr ""
 
 #: src/ch99-01-05-03-testing-components.md:139
 msgid ""
-"We defined the `TestingState` type as an alias of the "
-"`CounterComponent::ComponentState<MockContract::ContractState>` type. By "
-"passing the `MockContract::ContractState` type as a concrete type for "
-"`ComponentState`, we aliased a concrete implementation of the "
-"`ComponentState` struct to `TestingState`."
+"We defined the `TestingState` type as an alias of the `CounterComponent::"
+"ComponentState<MockContract::ContractState>` type. By passing the "
+"`MockContract::ContractState` type as a concrete type for `ComponentState`, "
+"we aliased a concrete implementation of the `ComponentState` struct to "
+"`TestingState`."
 msgstr ""
 
 #: src/ch99-01-05-03-testing-components.md:141
@@ -10997,9 +12662,9 @@ msgstr ""
 
 #: src/ch99-02-01-abis-and-interfaces.md:20
 msgid ""
-"Contract interfaces in Cairo are traits annotated with the "
-"`#[starknet::interface]` attribute. If you are new to traits, check out the "
-"dedicated chapter on [traits](./ch08-02-traits-in-cairo.md)."
+"Contract interfaces in Cairo are traits annotated with the `#[starknet::"
+"interface]` attribute. If you are new to traits, check out the dedicated "
+"chapter on [traits](./ch08-02-traits-in-cairo.md)."
 msgstr ""
 
 #: src/ch99-02-01-abis-and-interfaces.md:22
@@ -11204,7 +12869,8 @@ msgid "Calling Contracts using the Library Dispatcher"
 msgstr ""
 
 #: src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md:172
-msgid "Below's a sample code for calling contracts using the Library Dispatcher."
+msgid ""
+"Below's a sample code for calling contracts using the Library Dispatcher."
 msgstr ""
 
 #: src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md:207
@@ -11230,10 +12896,10 @@ msgstr ""
 
 #: src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md:213
 msgid ""
-"Another way to call other contracts and classes is to use the "
-"`starknet::call_contract_syscall`and `starknet::library_call_syscall` system "
-"calls. The dispatchers we described in the previous sections are high-level "
-"syntaxes for these low-level system calls."
+"Another way to call other contracts and classes is to use the `starknet::"
+"call_contract_syscall`and `starknet::library_call_syscall` system calls. The "
+"dispatchers we described in the previous sections are high-level syntaxes "
+"for these low-level system calls."
 msgstr ""
 
 #: src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md:215
@@ -11424,7 +13090,8 @@ msgid "/// @dev Asserts implementation for the Vote contract\n"
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:147
-msgid "// @dev Internal function that checks if an address is allowed to vote\n"
+msgid ""
+"// @dev Internal function that checks if an address is allowed to vote\n"
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:156
@@ -11447,7 +13114,8 @@ msgid ""
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:172
-msgid "// @dev Internal function to calculate the voting results in percentage\n"
+msgid ""
+"// @dev Internal function to calculate the voting results in percentage\n"
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:191
@@ -11490,9 +13158,8 @@ msgid ""
 "contract. Then, we'll interact with the contract by calling and invoking its "
 "functions. You can also use the Goerli Testnet instead of `katana`. However, "
 "we recommend using `katana` for local development and testing. You can find "
-"the complete tutorial for `katana` in the [Katana: A Local "
-"Node](https://book.starknet.io/ch02-04-katana.html) chapter of the Starknet "
-"Book."
+"the complete tutorial for `katana` in the [Katana: A Local Node](https://"
+"book.starknet.io/ch02-04-katana.html) chapter of the Starknet Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:204
@@ -11501,17 +13168,17 @@ msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:206
 msgid ""
-"`katana` is designed to support local development by the [Dojo "
-"team](https://github.com/dojoengine/dojo/blob/main/crates/katana/README.md). "
-"It will allow you to do everything you need to do with Starknet, but "
-"locally. It is a great tool for development and testing."
+"`katana` is designed to support local development by the [Dojo team](https://"
+"github.com/dojoengine/dojo/blob/main/crates/katana/README.md). It will allow "
+"you to do everything you need to do with Starknet, but locally. It is a "
+"great tool for development and testing."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:208
 msgid ""
 "To install `katana` from the source code, please refer to the [Basic "
-"Installation](https://book.starknet.io/ch02-01-basic-installation.html#katana-node-installation) "
-"chapter of the Starknet Book."
+"Installation](https://book.starknet.io/ch02-01-basic-installation."
+"html#katana-node-installation) chapter of the Starknet Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:210
@@ -11522,9 +13189,9 @@ msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:215
 msgid ""
-"To upgrade `katana`, refer to the [Basic "
-"Installation](https://book.starknet.io/ch02-01-basic-installation.html#katana-node-installation) "
-"chapter of the Starknet Book."
+"To upgrade `katana`, refer to the [Basic Installation](https://book.starknet."
+"io/ch02-01-basic-installation.html#katana-node-installation) chapter of the "
+"Starknet Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:218
@@ -11547,9 +13214,9 @@ msgid ""
 "Before we can interact with the voting contract, we need to prepare the "
 "voter and admin accounts on Starknet. Each voter account must be registered "
 "and sufficiently funded for voting. For a more detailed understanding of how "
-"accounts operate with Account Abstraction, refer to the [Account "
-"Abstraction](https://book.starknet.io/ch04-00-account-abstraction.html) "
-"chapter of the Starknet Book."
+"accounts operate with Account Abstraction, refer to the [Account Abstraction]"
+"(https://book.starknet.io/ch04-00-account-abstraction.html) chapter of the "
+"Starknet Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:247
@@ -11560,9 +13227,9 @@ msgstr ""
 msgid ""
 "Aside from Scarb you will need to have Starkli installed. Starkli is a "
 "command line tool that allows you to interact with Starknet. You can find "
-"the installation instructions in the [Basic "
-"Installation](https://book.starknet.io/ch02-01-basic-installation.html#starkli-installation) "
-"chapter of the Starknet Book."
+"the installation instructions in the [Basic Installation](https://book."
+"starknet.io/ch02-01-basic-installation.html#starkli-installation) chapter of "
+"the Starknet Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:251
@@ -11572,16 +13239,17 @@ msgid ""
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:256
-msgid "To upgrade `starkli` to `1.0.20`, use the `starkliup -v 0.1.20` command."
+msgid ""
+"To upgrade `starkli` to `1.0.20`, use the `starkliup -v 0.1.20` command."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:258
 msgid ""
 "For each smart wallet we'll use, we must create a Signer within the "
 "encrypted keystore and an Account Descriptor. This process is also detailed "
-"in the [Testnet "
-"Deployment](https://book.starknet.io/ch02-05-testnet-deployment.html?highlight=signer#creating-a-signer) "
-"chapter of the Starknet Book."
+"in the [Testnet Deployment](https://book.starknet.io/ch02-05-testnet-"
+"deployment.html?highlight=signer#creating-a-signer) chapter of the Starknet "
+"Book."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:260
@@ -11664,8 +13332,8 @@ msgstr ""
 #: src/ch99-01-04-01-voting-contract.md:292
 msgid ""
 "You can retrieve the smart wallet class hash (it will be the same for all "
-"your smart wallets) with the following command. Notice the use of the "
-"`--rpc` flag and the RPC endpoint provided by `katana`:"
+"your smart wallets) with the following command. Notice the use of the `--"
+"rpc` flag and the RPC endpoint provided by `katana`:"
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:294
@@ -11701,8 +13369,8 @@ msgstr ""
 msgid ""
 "If the compiler version you're using is older than the one used by Starkli "
 "and you encounter a `compiler-version` error while using the command above, "
-"you can specify a compiler version to use in the command by adding the "
-"`--compiler-version x.y.z` flag."
+"you can specify a compiler version to use in the command by adding the `--"
+"compiler-version x.y.z` flag."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:316
@@ -11716,8 +13384,8 @@ msgstr ""
 msgid ""
 "The class hash of the contract is: "
 "`0x06974677a079b7edfadcd70aa4d12aac0263a4cda379009fca125e0ab1a9ba52`. You "
-"can find it [on any block "
-"explorer](https://goerli.voyager.online/class/0x06974677a079b7edfadcd70aa4d12aac0263a4cda379009fca125e0ab1a9ba52)."
+"can find it [on any block explorer](https://goerli.voyager.online/"
+"class/0x06974677a079b7edfadcd70aa4d12aac0263a4cda379009fca125e0ab1a9ba52)."
 msgstr ""
 
 #: src/ch99-01-04-01-voting-contract.md:320
@@ -12039,15 +13707,16 @@ msgstr ""
 
 #: src/ch99-04-00-L1-L2-messaging.md:18
 msgid ""
-"The crucial component of the `L1-L2` Messaging system is the "
-"[`StarknetCore`](https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4) "
+"The crucial component of the `L1-L2` Messaging system is the [`StarknetCore`]"
+"(https://etherscan.io/address/0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4) "
 "contract. It is a set of Solidity contracts deployed on Ethereum that allows "
 "Starknet to function properly. One of the contracts of `StarknetCore` is "
 "called `StarknetMessaging` and it is the contract responsible for passing "
 "messages between Starknet and Ethereum. `StarknetMessaging` follows an "
-"[interface](https://github.com/starkware-libs/cairo-lang/blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starknet/eth/IStarknetMessaging.sol#L6) "
-"with functions allowing to send message to L2, receiving messages on L1 from "
-"L2 and canceling messages."
+"[interface](https://github.com/starkware-libs/cairo-lang/"
+"blob/4e233516f52477ad158bc81a86ec2760471c1b65/src/starkware/starknet/eth/"
+"IStarknetMessaging.sol#L6) with functions allowing to send message to L2, "
+"receiving messages on L1 from L2 and canceling messages."
 msgstr ""
 
 #: src/ch99-04-00-L1-L2-messaging.md:49
@@ -12089,12 +13758,12 @@ msgstr ""
 
 #: src/ch99-04-00-L1-L2-messaging.md:61
 msgid ""
-"Let's take a simple contract taken from [this "
-"tutorial](https://github.com/glihm/starknet-messaging-dev/blob/main/solidity/src/ContractMsg.sol) "
-"where we want to send a message to Starknet. The `_snMessaging` is a state "
+"Let's take a simple contract taken from [this tutorial](https://github.com/"
+"glihm/starknet-messaging-dev/blob/main/solidity/src/ContractMsg.sol) where "
+"we want to send a message to Starknet. The `_snMessaging` is a state "
 "variable already initialized with the address of the `StarknetMessaging` "
-"contract. You can check those addresses "
-"[here](https://docs.starknet.io/documentation/tools/important_addresses/)."
+"contract. You can check those addresses [here](https://docs.starknet.io/"
+"documentation/tools/important_addresses/)."
 msgstr ""
 
 #: src/ch99-04-00-L1-L2-messaging.md:65
@@ -12199,9 +13868,9 @@ msgstr ""
 msgid ""
 "When sending messages from Starknet to Ethereum, you will have to use the "
 "`send_message_to_l1` syscall in your Cairo contracts. This syscall allows "
-"you to send messages to the `StarknetMessaging` contract on L1. Unlike "
-"`L1->L2` messages, `L2->L1` messages must be consumed manually, which means "
-"that you will need your Solidity contract to call the `consumeMessageFromL2` "
+"you to send messages to the `StarknetMessaging` contract on L1. Unlike `L1-"
+">L2` messages, `L2->L1` messages must be consumed manually, which means that "
+"you will need your Solidity contract to call the `consumeMessageFromL2` "
 "function of the `StarknetMessaging` contract explicitly in order to consume "
 "the message."
 msgstr ""
@@ -12323,15 +13992,14 @@ msgstr ""
 #: src/ch99-04-00-L1-L2-messaging.md:200
 msgid ""
 "If you want to learn more about the messaging mechanism, you can visit the "
-"[Starknet "
-"documentation](https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/)."
+"[Starknet documentation](https://docs.starknet.io/documentation/"
+"architecture_and_concepts/Network_Architecture/messaging-mechanism/)."
 msgstr ""
 
 #: src/ch99-04-00-L1-L2-messaging.md:202
 msgid ""
-"You can also find a [detailed guide "
-"here](https://github.com/glihm/starknet-messaging-dev) to test the messaging "
-"in local."
+"You can also find a [detailed guide here](https://github.com/glihm/starknet-"
+"messaging-dev) to test the messaging in local."
 msgstr ""
 
 #: src/ch99-03-security-considerations.md:3
@@ -12420,8 +14088,8 @@ msgstr ""
 msgid ""
 "The `assert!` or `panic!` macros can be used to validate conditions before "
 "performing specific actions. You can learn more about these on the "
-"[Unrecoverable Errors with "
-"panic](./ch10-01-unrecoverable-errors-with-panic.md) page."
+"[Unrecoverable Errors with panic](./ch10-01-unrecoverable-errors-with-panic."
+"md) page."
 msgstr ""
 
 #: src/ch99-03-security-considerations.md:31
@@ -12583,12 +14251,13 @@ msgstr ""
 
 #: src/ch99-03-security-considerations.md:163
 msgid ""
-"[Semgrep Cairo 1.0 "
-"support](https://semgrep.dev/blog/2023/semgrep-now-supports-cairo-1-0)"
+"[Semgrep Cairo 1.0 support](https://semgrep.dev/blog/2023/semgrep-now-"
+"supports-cairo-1-0)"
 msgstr ""
 
 #: src/ch99-03-security-considerations.md:164
-msgid "[Caracal, a Starknet static analyzer](https://github.com/crytic/caracal)"
+msgid ""
+"[Caracal, a Starknet static analyzer](https://github.com/crytic/caracal)"
 msgstr ""
 
 #: src/appendix-00.md:3
@@ -13819,8 +15488,8 @@ msgstr ""
 #: src/appendix-03-derivable-traits.md:155
 msgid ""
 "When moving out of scope, variables need to be moved first. This is where "
-"the `Drop` trait intervenes. You can find more details about its usage "
-"[here](ch04-01-what-is-ownership.md#the-drop-trait)."
+"the `Drop` trait intervenes. You can find more details about its usage [here]"
+"(ch04-01-what-is-ownership.md#the-drop-trait)."
 msgstr ""
 
 #: src/appendix-03-derivable-traits.md:157
@@ -13828,8 +15497,8 @@ msgid ""
 "Moreover Dictionary need to be squashed before going out of scope. Calling "
 "manually the `squash` method on each of them can be quickly redundant. "
 "`Destruct` trait allows Dictionaries to be automatically squashed when they "
-"get out of scope. You can also find more information about `Destruct` "
-"[here](ch04-01-what-is-ownership.md#the-destruct-trait)."
+"get out of scope. You can also find more information about `Destruct` [here]"
+"(ch04-01-what-is-ownership.md#the-destruct-trait)."
 msgstr ""
 
 #: src/appendix-03-derivable-traits.md:159
@@ -13906,8 +15575,9 @@ msgstr ""
 
 #: src/appendix-04-useful-development-tools.md:18
 msgid ""
-"To help IDE integration, the Cairo community recommends using the "
-"[`cairo-language-server`](https://github.com/starkware-libs/cairo/tree/main/crates/cairo-lang-language-server)"
+"To help IDE integration, the Cairo community recommends using the [`cairo-"
+"language-server`](https://github.com/starkware-libs/cairo/tree/main/crates/"
+"cairo-lang-language-server)"
 msgstr ""
 
 #: src/appendix-04-useful-development-tools.md:19
@@ -13920,14 +15590,14 @@ msgstr ""
 msgid ""
 ", which is a specification for IDEs and programming languages to communicate "
 "with each other. Different clients can use `cairo-language-server`, such as "
-"[the Cairo extension for Visual Studio "
-"Code](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1)."
+"[the Cairo extension for Visual Studio Code](https://marketplace."
+"visualstudio.com/items?itemName=starkware.cairo1)."
 msgstr ""
 
 #: src/appendix-04-useful-development-tools.md:28
 msgid ""
-"Visit the `vscode-cairo` "
-"[page](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1)"
+"Visit the `vscode-cairo` [page](https://marketplace.visualstudio.com/items?"
+"itemName=starkware.cairo1)"
 msgstr ""
 
 #: src/appendix-04-useful-development-tools.md:28
@@ -13961,20 +15631,19 @@ msgstr ""
 
 #: src/appendix-05-common-types-and-traits-and-cairo-prelude.md:11
 msgid ""
-"The core library prelude is defined in the "
-"[lib.cairo](https://github.com/starkware-libs/cairo/blob/v2.4.0/corelib/src/lib.cairo) "
-"file of the corelib crate and contains Cairo's primitive data types, traits, "
-"operators, and utility functions. This includes: Data types - felts, bools, "
-"arrays, dicts, etc. Traits - behaviors for arithmetic, comparison, "
-"serialization Operators - arithmetic, logical, bitwise Utility functions - "
-"helpers for arrays, maps, boxing, etc. The core library prelude delivers the "
-"fundamental programming constructs and operations needed for basic Cairo "
-"programs, without requiring the explicit import of elements. Since the core "
-"library prelude is automatically imported, its contents are available for "
-"use in any Cairo crate without explicit imports. This prevents repetition "
-"and provides a better devX. This is what allows you to use "
-"`ArrayTrait::append()` or the `Default` trait without bringing them "
-"explicitly into scope."
+"The core library prelude is defined in the [lib.cairo](https://github.com/"
+"starkware-libs/cairo/blob/v2.4.0/corelib/src/lib.cairo) file of the corelib "
+"crate and contains Cairo's primitive data types, traits, operators, and "
+"utility functions. This includes: Data types - felts, bools, arrays, dicts, "
+"etc. Traits - behaviors for arithmetic, comparison, serialization Operators "
+"- arithmetic, logical, bitwise Utility functions - helpers for arrays, maps, "
+"boxing, etc. The core library prelude delivers the fundamental programming "
+"constructs and operations needed for basic Cairo programs, without requiring "
+"the explicit import of elements. Since the core library prelude is "
+"automatically imported, its contents are available for use in any Cairo "
+"crate without explicit imports. This prevents repetition and provides a "
+"better devX. This is what allows you to use `ArrayTrait::append()` or the "
+"`Default` trait without bringing them explicitly into scope."
 msgstr ""
 
 #: src/appendix-05-common-types-and-traits-and-cairo-prelude.md:25
@@ -14071,8 +15740,8 @@ msgstr ""
 #: src/appendix-05-common-types-and-traits-and-cairo-prelude.md:41
 msgid ""
 "`ContractAddressZeroable` is the implementation of the trait `Zeroable` for "
-"the `ContractAddress` type. It is required to check whether a value of "
-"`t:ContractAddress` is zero or not."
+"the `ContractAddress` type. It is required to check whether a value of `t:"
+"ContractAddress` is zero or not."
 msgstr ""
 
 #: src/appendix-05-common-types-and-traits-and-cairo-prelude.md:42
@@ -14192,9 +15861,8 @@ msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:18
 msgid ""
-"Installing Cairo with a Script "
-"([Installer](https://github.com/franalgaba/cairo-installer) by "
-"[Fran](https://github.com/franalgaba))"
+"Installing Cairo with a Script ([Installer](https://github.com/franalgaba/"
+"cairo-installer) by [Fran](https://github.com/franalgaba))"
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:20
@@ -14210,9 +15878,8 @@ msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:28
 msgid ""
-"After installing, follow [these "
-"instructions](#set-up-your-shell-environment-for-cairo) to set up your shell "
-"environment."
+"After installing, follow [these instructions](#set-up-your-shell-environment-"
+"for-cairo) to set up your shell environment."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:30
@@ -14223,9 +15890,8 @@ msgstr ""
 msgid ""
 "```\n"
 "rm -fr ~/.cairo\n"
-"curl -L "
-"https://github.com/franalgaba/cairo-installer/raw/main/bin/cairo-installer | "
-"bash\n"
+"curl -L https://github.com/franalgaba/cairo-installer/raw/main/bin/cairo-"
+"installer | bash\n"
 "```"
 msgstr ""
 
@@ -14301,15 +15967,15 @@ msgstr ""
 #: src/appendix-06-cairo-binaries.md:79 src/appendix-06-cairo-binaries.md:89
 #: src/appendix-06-cairo-binaries.md:95 src/appendix-06-cairo-binaries.md:102
 msgid ""
-"'command -v cairo-compile >/dev/null || export "
-"PATH=\"$CAIRO_ROOT/target/release:$PATH\"'"
+"'command -v cairo-compile >/dev/null || export PATH=\"$CAIRO_ROOT/target/"
+"release:$PATH\"'"
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:82
 msgid ""
 "Then, if you have `~/.profile`, `~/.bash_profile` or `~/.bash_login`, add "
-"the commands there as well. If you have none of these, add them to "
-"`~/.profile`."
+"the commands there as well. If you have none of these, add them to `~/."
+"profile`."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:85
@@ -14365,9 +16031,8 @@ msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:137
 msgid ""
-"Installing Cairo Manually "
-"([Guide](https://github.com/auditless/cairo-template) by "
-"[Abdel](https://github.com/abdelhamidbakhta))"
+"Installing Cairo Manually ([Guide](https://github.com/auditless/cairo-"
+"template) by [Abdel](https://github.com/abdelhamidbakhta))"
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:139
@@ -14419,10 +16084,6 @@ msgstr ""
 msgid "# Generate release binaries\n"
 msgstr ""
 
-#: src/appendix-06-cairo-binaries.md:167
-msgid "."
-msgstr ""
-
 #: src/appendix-06-cairo-binaries.md:169
 msgid "**NOTE: Keeping Cairo up to date**"
 msgstr ""
@@ -14457,22 +16118,22 @@ msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:190
 msgid ""
-"If you have the previous Cairo 0 extension installed, you can "
-"disable/uninstall it."
+"If you have the previous Cairo 0 extension installed, you can disable/"
+"uninstall it."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:191
 msgid ""
 "Install the Cairo 1 extension for proper syntax highlighting and code "
-"navigation. You can find the link to the extension "
-"[here](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1&ssr=false), "
-"or just search for \"Cairo 1.0\" in the VS Code marketplace."
+"navigation. You can find the link to the extension [here](https://"
+"marketplace.visualstudio.com/items?itemName=starkware.cairo1&ssr=false), or "
+"just search for \"Cairo 1.0\" in the VS Code marketplace."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:192
 msgid ""
-"The extension will work out of the box once you will have "
-"[Scarb](./ch01-03-hello-scarb.md) installed."
+"The extension will work out of the box once you will have [Scarb](./ch01-03-"
+"hello-scarb.md) installed."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:194
@@ -14482,10 +16143,9 @@ msgstr ""
 #: src/appendix-06-cairo-binaries.md:196
 msgid ""
 "If you don't want to depend on Scarb, you can still use the Cairo Language "
-"Server with the compiler binary. From [Step "
-"1](#installing-cairo-with-a-script-installer-by-fran), the "
-"`cairo-language-server` binary should be built and executing this command "
-"will copy its path into your clipboard."
+"Server with the compiler binary. From [Step 1](#installing-cairo-with-a-"
+"script-installer-by-fran), the `cairo-language-server` binary should be "
+"built and executing this command will copy its path into your clipboard."
 msgstr ""
 
 #: src/appendix-06-cairo-binaries.md:203
@@ -14501,7 +16161,8 @@ msgstr ""
 #: src/appendix-07-system-calls.md:3
 msgid ""
 "This chapter is based on the StarkNet documentation available at [StarkNet "
-"Docs](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/)."
+"Docs](https://docs.starknet.io/documentation/architecture_and_concepts/"
+"Smart_Contracts/system-calls-cairo1/)."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:5
@@ -14626,7 +16287,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:47
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/0c882679fdb24a818cad19f2c18decbf6ef66153/corelib/src/starknet/syscalls.cairo#L37)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/"
+"blob/0c882679fdb24a818cad19f2c18decbf6ef66153/corelib/src/starknet/syscalls."
+"cairo#L37)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:49
@@ -14659,14 +16322,16 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:71
 msgid ""
-"Returns a "
-"[struct](https://github.com/starkware-libs/cairo/blob/efbf69d4e93a60faa6e1363fd0152b8fcedbb00a/corelib/src/starknet/info.cairo#L8) "
+"Returns a [struct](https://github.com/starkware-libs/cairo/blob/"
+"efbf69d4e93a60faa6e1363fd0152b8fcedbb00a/corelib/src/starknet/info.cairo#L8) "
 "containing the execution info."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:75
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L35)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L35)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:77
@@ -14700,7 +16365,8 @@ msgid "_`address`_: The address of the contract you want to call."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:100
-msgid "_`entry_point_selector`_: A selector for a function within that contract."
+msgid ""
+"_`entry_point_selector`_: A selector for a function within that contract."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:101
@@ -14713,7 +16379,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:109
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L10)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L10)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:111
@@ -14770,7 +16438,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:149
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/4821865770ac9e57442aef6f0ce82edc7020a4d6/corelib/src/starknet/syscalls.cairo#L22)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/"
+"blob/4821865770ac9e57442aef6f0ce82edc7020a4d6/corelib/src/starknet/syscalls."
+"cairo#L22)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:151
@@ -14784,8 +16454,8 @@ msgstr ""
 #: src/appendix-07-system-calls.md:165
 msgid ""
 "For more information, and for a higher-level syntax for emitting events, see "
-"[Starknet "
-"events](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/)."
+"[Starknet events](https://docs.starknet.io/documentation/"
+"architecture_and_concepts/Smart_Contracts/starknet-events/)."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:169
@@ -14806,7 +16476,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:194
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L30)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L30)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:196
@@ -14840,7 +16512,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:226
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L43)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L43)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:228
@@ -14860,8 +16534,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:244
 msgid ""
-"For more information, see Starknet’s [messaging "
-"mechanism](https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/)."
+"For more information, see Starknet’s [messaging mechanism](https://docs."
+"starknet.io/documentation/architecture_and_concepts/Network_Architecture/"
+"messaging-mechanism/)."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:248
@@ -14880,7 +16555,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:269
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L51)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L51)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:271
@@ -14914,7 +16591,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:301
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L77)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L77)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:303
@@ -14935,8 +16614,9 @@ msgstr ""
 #: src/appendix-07-system-calls.md:319 src/appendix-07-system-calls.md:362
 msgid ""
 "For information on accessing storage by using the storage variables, see "
-"[storage "
-"variables](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage/#storage_variables)."
+"[storage variables](https://docs.starknet.io/documentation/"
+"architecture_and_concepts/Smart_Contracts/contract-storage/"
+"#storage_variables)."
 msgstr ""
 
 #: src/appendix-07-system-calls.md:323 src/appendix-07-system-calls.md:366
@@ -14960,7 +16640,9 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:344
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L60)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L60)"
 msgstr ""
 
 #: src/appendix-07-system-calls.md:346
@@ -14984,6 +16666,13 @@ msgstr ""
 
 #: src/appendix-07-system-calls.md:378
 msgid ""
-"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls.cairo#L70)"
+"[syscalls.cairo](https://github.com/starkware-libs/cairo/blob/"
+"cca08c898f0eb3e58797674f20994df0ba641983/corelib/src/starknet/syscalls."
+"cairo#L70)"
 msgstr ""
 
+#~ msgid "Genel Programlama Kavramları"
+#~ msgstr "Genel Programlama Kavramları"
+
+#~ msgid "Değişkenler ve Değişkenlik"
+#~ msgstr "Değişkenler ve Değişkenlik"

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -172,6 +172,9 @@
                             <li role="none"><button role="menuitem" class="theme">
                                 <a id="id">Indonesian</a>
                             </button></li>
+                            <li role="none"><button role="menuitem" class="theme">
+                                <a id="tr">Turkçe</a>
+                            </button></li>
                         </ul>
                         <script>
                             let langToggle = document.getElementById("language-toggle");


### PR DESCRIPTION
The sections about the basic cairo programming language, that is, the Turkish translation has been made until the 12th chapter. The remaining part will be translated with the latest updated version of the whole book.