### PR TITLE
add references + stylistics

### DIFF
--- a/src/ch05-03-method-syntax.md
+++ b/src/ch05-03-method-syntax.md
@@ -66,7 +66,7 @@ Let's write a new method `scale` which resizes a rectangle of a `factor` given a
 
 It is also possible to define a method which takes ownership of the instance by using just `self` as the first parameter but it is rare. This technique is usually used when the method transforms `self` into something else and you want to prevent the caller from using the original instance after the transformation.
 
-Look at the [Understand Ownership](ch04-00-understanding-ownership.md) chapter for more details about these important notions.
+Look at the [Understanding Ownership](ch04-00-understanding-ownership.md) chapter for more details about these important notions.
 
 ## Methods with several parameters
 

--- a/src/ch06-01-enums.md
+++ b/src/ch06-01-enums.md
@@ -92,4 +92,4 @@ We are demonstrating two approaches for the above function:
 
 Enums can be useful in many situations, especially when using the `match` flow construct that we just used. We will describe it in the next section.
 
-Other enums are used very often, such as the `Result` enum, allowing to handle error gracefully. We will explain the `Result` enum in detail in the [Error Handling](ch09-02-recoverable-errors.md) chapter.
+Other enums are used very often, such as the `Result` enum, allowing to handle errors gracefully. We will explain the `Result` enum in detail in the [Error Handling](ch09-02-recoverable-errors.md) chapter.

--- a/src/ch06-02-the-match-control-flow-construct.md
+++ b/src/ch06-02-the-match-control-flow-construct.md
@@ -50,6 +50,8 @@ In the `match` expression for this code, we add a variable called `state` to the
 
 Because `state` is an `UsState` enum which implements the `Debug` trait, we can print `state` value with `println!` macro.
 
+> Note: `{:?}` is a special formatting syntax that allows you to print a debug form of the parameter passed to the `println!` macro. You can find more information about it [here](appendix-03-derivable-traits.html#debug-for-programmer-output).
+
 If we were to call `value_in_cents(Coin::Quarter(UsState::Alaska))`, `coin` would be `Coin::Quarter(UsState::Alaska)`. When we compare that value with each of the match arms, none of them match until we reach `Coin::Quarter(state)`. At that point, the binding for `state` will be the value `UsState::Alaska`. We can then use that binding in `println!` macro, thus getting the inner state value out of the Coin enum variant for Quarter.
 
 ## Matching with `Option<T>`
@@ -111,7 +113,7 @@ error: Missing match arm: `None` not covered.
 error: could not compile `match` due to previous error
 ```
 
-Cairo knows that we didn’t cover every possible case, and even knows which pattern we forgot! Matches in Cairo are exhaustive: we must exhaust every last possibility in order for the code to be valid. Especially in the case of `Option<T>`, when Cairo prevents us from forgetting to explicitly handle the `None` case, it protects us from assuming that we have a value when we might have null, thus making the billion-dollar mistake discussed earlier impossible.
+Cairo knows that we didn’t cover every possible case, and even knows which pattern we forgot! Matches in Cairo are exhaustive: we must exhaust every last possibility in order for the code to be valid. Especially in the case of `Option<T>`, when Cairo prevents us from forgetting to explicitly handle the `None` case, it protects us from assuming that we have a value when we might have null, thus making the [billion-dollar mistake](https://en.wikipedia.org/wiki/Null_pointer#History) discussed earlier impossible.
 
 ## Catch-all with the `_` Placeholder
 

--- a/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
+++ b/src/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md
@@ -20,11 +20,11 @@ To illustrate this notion let's take back our example Listing {{#ref front_of_ho
 {{#label path-types}}
 <span class="caption">Listing {{#ref path-types}}: Calling the `add_to_waitlist` function using absolute and relative paths</span>
 
-The `eat_at_restaurant function` is part of our library's public API, so we mark it with the `pub` keyword. In the [Exposing Paths with the pub Keyword](ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md#exposing-paths-with-the-pub-keyword) section, we’ll go into more detail about `pub`.
+The `eat_at_restaurant` function is part of our library's public API, so we mark it with the `pub` keyword. In the [Exposing Paths with the pub Keyword](ch07-03-paths-for-referring-to-an-item-in-the-module-tree.md#exposing-paths-with-the-pub-keyword) section, we’ll go into more detail about `pub`.
 
 The first time we call the `add_to_waitlist` function in `eat_at_restaurant`,
 we use an absolute path. The `add_to_waitlist` function is defined in the same
-crate as `eat_at_restaurant`. In Cairo, absolute paths start from the crate root, which you need to refer to by using the crate name. You can imagine a filesystem with the same structure: we’d specify the path _/front_of_house/hosting/add_to_waitlist_ to run the _add_to_waitlist_ program; using the crate name to start from the crate root is like using _/_ to start from the filesystem root in your shell.
+crate as `eat_at_restaurant`. In Cairo, absolute paths start from the crate root, which you need to refer to by using the crate name. You can imagine a filesystem with the same structure: we’d specify the path _/front_of_house/hosting/add_to_waitlist_ to run the _add_to_waitlist_ program; using the crate name to start from the crate root is like using a slash (`/`) to start from the filesystem root in your shell.
 
 The second time we call `add_to_waitlist`, we use a relative path. The path starts with `front_of_house`, the name of the module defined at the same level of the module tree as `eat_at_restaurant`. Here the filesystem equivalent would be using the path _./front_of_house/hosting/add_to_waitlist_. Starting with a module name means that the path is relative to the current module.
 

--- a/src/ch07-05-separating-modules-into-different-files.md
+++ b/src/ch07-05-separating-modules-into-different-files.md
@@ -92,6 +92,6 @@ Cairo lets you split a package into multiple crates and a crate into modules
 so you can refer to items defined in one module from another module. You can do
 this by specifying absolute or relative paths. These paths can be brought into
 scope with a `use` statement so you can use a shorter path for multiple uses of
-the item in that scope. Module code is public by default.
+the item in that scope. Module code is **private** by default.
 
 [paths]: ch06-03-paths-for-referring-to-an-item-in-the-module-tree.html

--- a/src/ch08-00-generic-types-and-traits.md
+++ b/src/ch08-00-generic-types-and-traits.md
@@ -12,7 +12,7 @@ Then you’ll learn how to use traits to define behavior in a generic way. You c
 
 ## Removing Duplication by Extracting a Function
 
-Generics allow us to replace specific types with a placeholder that represents multiple types to remove code duplication. Before diving into generics syntax, then, let’s first look at how to remove duplication in a way that doesn’t involve generic types by extracting a function that replaces specific values with a placeholder that represents multiple values. Then we’ll apply the same technique to extract a generic function! By looking at how to recognize duplicated code you can extract into a function, you’ll start to recognize duplicated code that can use generics.
+Generics allow us to replace specific types with a placeholder that represents multiple types to remove code duplication. Before diving into generics syntax, then, let’s first look at how to remove duplication in a way that doesn’t involve generic types by extracting a function that replaces specific values with a placeholder that represents multiple values. Then we’ll apply the same technique to extract a generic function! By learning how to identify duplicated code that can be extracted into a function, you'll start to recognize instances where generics can be used to reduce duplication.
 
 We begin with a short program that finds the largest number in an array of `u8`:
 
@@ -46,4 +46,4 @@ In summary, here are the steps we took to change the code:
 - Extract the duplicate code into the body of the function and specify the inputs and return values of that code in the function signature.
 - Update the two instances of duplicated code to call the function instead.
 
-Next, we’ll use these same steps with generics to reduce code duplication. In the same way that the function body can operate on an abstract `Array<u8>` instead of specific `u8` values, generics allow code to operate on abstract types.
+Next, we’ll use these same steps with generics to reduce code duplication. In the same way that the function body can operate on an abstract `Array<T>` instead of specific `u8` values, generics allow code to operate on abstract types.


### PR DESCRIPTION
Added some links to the mentioned concepts + some minor stylistic fixes.

Two things I'm not sure about:

[Here](https://book.cairo-lang.org/ch07-02-defining-modules-to-control-scope.html#grouping-related-code-in-modules) it states that code within modules is private by default but [here](https://book.cairo-lang.org/ch07-05-separating-modules-into-different-files.html#summary) it's public by default. I corrected it to private, but please have a closer look. 

[Here](https://book.cairo-lang.org/ch07-04-bringing-paths-into-scope-with-the-use-keyword.html#using-external-packages-in-cairo-with-scarb) git branch imports are mentioned as deprecated but I couldn't find a reference to it in the current [Scarb docs](https://docs.swmansion.com/scarb/docs/guides/dependencies.html). I can fix it if it's needed + maybe add the reference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/649)
<!-- Reviewable:end -->
