### PR TITLE
add initial mdbook-quiz config with sample questions

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -21,3 +21,7 @@ runs:
     - name: Install mdbook-cairo preprocessor
       run: cargo install --path mdbook-cairo --locked
       shell: bash
+
+    - name: Install mdbook-quiz preprocessor
+      run: cargo install mdbook-quiz --locked --version 0.3.4
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ book
 target
 output
 
+# mdbook-quiz
+src/quiz
+
 # Editors tmp files.
 *~
 .idea/

--- a/book.toml
+++ b/book.toml
@@ -14,6 +14,9 @@ after = ["links"]
 [preprocessor.gettext]
 after = ["cairo"]
 
+[preprocessor.quiz]
+after = ["gettext"]
+
 [output.html]
 git-repository-url = "https://github.com/cairo-book/cairo-book.github.io"
 edit-url-template = "https://github.com/cairo-book/cairo-book.github.io/edit/main/{path}"

--- a/quizzes/ch01-01-installation.toml
+++ b/quizzes/ch01-01-installation.toml
@@ -1,0 +1,9 @@
+[[questions]]
+id = "1b7c7edd-8c2c-418b-ad80-c0b37b8ae215"
+type = "MultipleChoice"
+prompt.prompt = "What is Scarb?"
+answer.answer = "Cairo's package manager"
+prompt.distractors = [
+  "Rust compiler",
+  "the name of the VM that runs Cairo"
+]

--- a/quizzes/ch01-01-installation.toml
+++ b/quizzes/ch01-01-installation.toml
@@ -2,8 +2,8 @@
 id = "1b7c7edd-8c2c-418b-ad80-c0b37b8ae215"
 type = "MultipleChoice"
 prompt.prompt = "What is Scarb?"
-answer.answer = "Cairo's package manager"
+answer.answer = "Cairo's package manager and build system"
 prompt.distractors = [
-  "Rust compiler",
+  "a VS Code extension",
   "the name of the VM that runs Cairo"
 ]

--- a/quizzes/ch01-02-hello-world.toml
+++ b/quizzes/ch01-02-hello-world.toml
@@ -1,13 +1,8 @@
 [[questions]]
 id = "aac32d9f-b5a4-4946-81f2-eb6bcfc090ed"
-type = "MultipleChoice"
+type = "ShortAnswer"
 prompt.prompt = "What is the name of the initial function that a Cairo program runs?"
 answer.answer = "main"
-prompt.distractors = [
-  "run",
-  "entrypoint"
-]
-
 
 [[questions]]
 id = "a89b37cf-aa75-4fc7-b433-3b57d273ce1d"
@@ -15,19 +10,3 @@ type = "ShortAnswer"
 prompt.prompt = "Which command will run the code in your project?"
 answer.answer = "scarb cairo-run"
 context = "`scarb cairo-run` will first compile and then run your code."
-
-[[questions]]
-id = "44736aac-befe-40bd-8c67-5a29229af33f"
-type = "Tracing"
-prompt.program = """
-fn main() {
-  let x = 1;
-  println!("{x}")
-  let y = x + 3;
-  println!("Result: {y}");
-}
-"""
-answer.doesCompile = false
-context = """
-This program is missing a semicolon (`;`) after calling the first `println!` macro.
-"""

--- a/quizzes/ch01-02-hello-world.toml
+++ b/quizzes/ch01-02-hello-world.toml
@@ -1,0 +1,33 @@
+[[questions]]
+id = "aac32d9f-b5a4-4946-81f2-eb6bcfc090ed"
+type = "MultipleChoice"
+prompt.prompt = "What is the name of the initial function that a Cairo program runs?"
+answer.answer = "main"
+prompt.distractors = [
+  "run",
+  "entrypoint"
+]
+
+
+[[questions]]
+id = "a89b37cf-aa75-4fc7-b433-3b57d273ce1d"
+type = "ShortAnswer"
+prompt.prompt = "Which command will run the code in your project?"
+answer.answer = "scarb cairo-run"
+context = "`scarb cairo-run` will first compile and then run your code."
+
+[[questions]]
+id = "44736aac-befe-40bd-8c67-5a29229af33f"
+type = "Tracing"
+prompt.program = """
+fn main() {
+  let x = 1;
+  println!("{x}")
+  let y = x + 3;
+  println!("Result: {y}");
+}
+"""
+answer.doesCompile = false
+context = """
+This program is missing a semicolon (`;`) after calling the first `println!` macro.
+"""

--- a/quizzes/ch02-01-variables-and-mutability.toml
+++ b/quizzes/ch02-01-variables-and-mutability.toml
@@ -1,0 +1,43 @@
+[[questions]]
+id = "17e3db31-79aa-44b6-9dc2-be8b37b83ada"
+type = "MultipleChoice"
+prompt.prompt = "Which syntax creates a variable that can be reassigned?"
+answer.answer = """
+```rust
+let mut x = 99;
+```
+"""
+prompt.distractors = [
+"""
+```rust
+const MINUTES_PER_HOUR = 60;
+```
+""",
+"""
+```rust
+let y = "{}";
+```
+"""
+]
+
+[[questions]]
+id = "0a902a6d-3fca-4d72-b455-5e9ab12441d9"
+type = "MultipleChoice"
+prompt.prompt = """
+What will be the output of the following program?
+```rust
+fn main() {
+    let initial_balance = 9;
+    let initial_balance = initial_balance - 3;
+    {
+        let initial_balance = initial_balance * 2;
+    }
+    println!("Final balance is: {}", initial_balance);
+}
+```
+"""
+answer.answer = "`Final balance is: 6`"
+prompt.distractors = [
+  "`Final balance is: 12`",
+  "The program won't compile."
+]

--- a/quizzes/ch02-01-variables-and-mutability.toml
+++ b/quizzes/ch02-01-variables-and-mutability.toml
@@ -15,7 +15,7 @@ const MINUTES_PER_HOUR = 60;
 """,
 """
 ```rust
-let y = "{}";
+let y = 10;
 ```
 """
 ]

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -57,6 +57,8 @@ cairo: 2.5.3 (https://crates.io/crates/cairo-lang-compiler/2.5.3)
 sierra: 1.4.0
 ```
 
+{{#quiz ../quizzes/ch01-01-installation.toml}}
+
 ## Installing the VSCode extension
 
 Cairo has a VSCode extension that provides syntax highlighting, code completion, and other useful features. You can install it from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=starkware.cairo1).

--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -208,3 +208,5 @@ Let’s recap what we’ve learned so far about Scarb:
 An additional advantage of using Scarb is that the commands are the same no matter which operating system you’re working on. So, at this point, we’ll no longer provide specific instructions for Linux and macOS versus Windows.
 
 You’re already off to a great start on your Cairo journey! This is a great time to build a more substantial program to get used to reading and writing Cairo code.
+
+{{#quiz ../quizzes/ch01-02-hello-world.toml}}

--- a/src/ch02-01-variables-and-mutability.md
+++ b/src/ch02-01-variables-and-mutability.md
@@ -216,4 +216,6 @@ error: could not compile `variables` due to previous error
 Now that we’ve explored how variables work, let’s look at more data types they
 can have.
 
+{{#quiz ../quizzes/ch02-01-variables-and-mutability.toml}}
+
 [data-types]: ch02-02-data-types.md


### PR DESCRIPTION
#658 
- Add `mdbook-quiz` preprocessor
- Add sample questions for each available question type

@enitrat Please have a look if you want some setting from [here](https://github.com/cognitive-engineering-lab/mdbook-quiz?tab=readme-ov-file#quiz-configuration) to be added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/660)
<!-- Reviewable:end -->
