### PR TITLE
feat: delete Copy trait in snapshots

### DIFF
--- a/listings/ch04-understanding-ownership/listing_04_05/src/lib.cairo
+++ b/listings/ch04-understanding-ownership/listing_04_05/src/lib.cairo
@@ -1,4 +1,4 @@
-#[derive(Copy, Drop)]
+#[derive(Drop)]
 struct Rectangle {
     height: u64,
     width: u64,

--- a/listings/ch04-understanding-ownership/no_listing_10_desnap/src/lib.cairo
+++ b/listings/ch04-understanding-ownership/no_listing_10_desnap/src/lib.cairo
@@ -1,4 +1,4 @@
-#[derive(Copy, Drop)]
+#[derive(Drop)]
 struct Rectangle {
     height: u64,
     width: u64,


### PR DESCRIPTION
excess Copy
```rust
#[derive(Copy, Drop)]
struct Rectangle {
    height: u64,
    width: u64,
}

fn main() {
    let rec = Rectangle { height: 3, width: 10 };
    let area = calculate_area(rec);
    println!("Area: {}", area);
}

fn calculate_area(rec: Rectangle) -> u64 {
    rec.height * rec.width
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/667)
<!-- Reviewable:end -->
