### PR TITLE
Fixed Issue #737

### DIFF
--- a/src/ch11-06-macros.md
+++ b/src/ch11-06-macros.md
@@ -16,7 +16,7 @@ This will be interpreted as `const a: felt252 = 8;` by the compiler.
 
 ## `selector!` Macro
 
-See [Entry Point Selector](./ch14-02-contract-dispatchers-library-dispatchers-and-system-calls.md#entry-point-selector).
+See [Entry Point Selector](./ch15-02-contract-dispatchers-library-dispatchers-and-system-calls.md#entry-point-selector).
 
 ## `print!` and `println!` Macros
 


### PR DESCRIPTION
#737 Dead Link on Macro

Fixed the dead link on Macro for the entry point selector item, works as shown below


![image](https://github.com/cairo-book/cairo-book/assets/116242877/37e65942-b6ea-48e4-9d15-f0ead585c283)
![image](https://github.com/cairo-book/cairo-book/assets/116242877/9b22638e-6165-461f-bce8-555276fdaace)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/739)
<!-- Reviewable:end -->
