### PR TITLE
refactor: update impersonation syntax

### DIFF
--- a/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/Scarb.toml
+++ b/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/Scarb.toml
@@ -12,7 +12,7 @@ starknet = "=2.6.3"
 
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.22.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.24.0" }
 
 [scripts]
 test = "snforge test"

--- a/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/src/tests/foundry_test.cairo
+++ b/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/src/tests/foundry_test.cairo
@@ -9,8 +9,9 @@ use source::pizza::PizzaFactory::{ownerContractMemberStateTrait, InternalTrait};
 use starknet::{ContractAddress, contract_address_const};
 
 use snforge_std::{
-    declare, ContractClassTrait, ContractClass, start_cheat_caller_address, stop_cheat_caller_address, SpyOn,
-    EventSpy, EventAssertions, spy_events, EventFetcher, load, cheatcodes::storage::load_felt252
+    declare, ContractClassTrait, ContractClass, start_cheat_caller_address,
+    stop_cheat_caller_address, SpyOn, EventSpy, EventAssertions, spy_events, EventFetcher, load,
+    cheatcodes::storage::load_felt252
 };
 
 fn owner() -> ContractAddress {

--- a/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/src/tests/foundry_test.cairo
+++ b/listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/src/tests/foundry_test.cairo
@@ -9,7 +9,7 @@ use source::pizza::PizzaFactory::{ownerContractMemberStateTrait, InternalTrait};
 use starknet::{ContractAddress, contract_address_const};
 
 use snforge_std::{
-    declare, ContractClassTrait, ContractClass, start_prank, stop_prank, CheatTarget, SpyOn,
+    declare, ContractClassTrait, ContractClass, start_cheat_caller_address, stop_cheat_caller_address, SpyOn,
     EventSpy, EventAssertions, spy_events, EventFetcher, load, cheatcodes::storage::load_felt252
 };
 
@@ -53,7 +53,7 @@ fn test_change_owner_should_change_owner() {
     let new_owner: ContractAddress = contract_address_const::<'new_owner'>();
     assert_eq!(pizza_factory.get_owner(), owner());
 
-    start_prank(CheatTarget::One(pizza_factory_address), owner());
+    start_cheat_caller_address(pizza_factory_address, owner());
 
     pizza_factory.change_owner(new_owner);
 
@@ -65,9 +65,9 @@ fn test_change_owner_should_change_owner() {
 fn test_change_owner_should_panic_when_not_owner() {
     let (pizza_factory, pizza_factory_address) = deploy_pizza_factory();
     let not_owner = contract_address_const::<'not_owner'>();
-    start_prank(CheatTarget::One(pizza_factory_address), not_owner);
+    start_cheat_caller_address(pizza_factory_address, not_owner);
     pizza_factory.change_owner(not_owner);
-    stop_prank(CheatTarget::One(pizza_factory_address));
+    stop_cheat_caller_address(pizza_factory_address);
 }
 //ANCHOR_END: test_owner
 
@@ -77,7 +77,7 @@ fn test_change_owner_should_panic_when_not_owner() {
 fn test_make_pizza_should_panic_when_not_owner() {
     let (pizza_factory, pizza_factory_address) = deploy_pizza_factory();
     let not_owner = contract_address_const::<'not_owner'>();
-    start_prank(CheatTarget::One(pizza_factory_address), not_owner);
+    start_cheat_caller_address(pizza_factory_address, not_owner);
 
     pizza_factory.make_pizza();
 }
@@ -86,7 +86,7 @@ fn test_make_pizza_should_panic_when_not_owner() {
 fn test_make_pizza_should_increment_pizza_counter() {
     // Setup
     let (pizza_factory, pizza_factory_address) = deploy_pizza_factory();
-    start_prank(CheatTarget::One(pizza_factory_address), owner());
+    start_cheat_caller_address(pizza_factory_address, owner());
     let mut spy = spy_events(SpyOn::One(pizza_factory_address));
 
     // When

--- a/src/ch17-02-testing-smart-contracts.md
+++ b/src/ch17-02-testing-smart-contracts.md
@@ -71,9 +71,9 @@ Determining the behavior that your contract should respect is the first step in 
 
 Once our contract is deployed, we want to assert that the initial values are set as expected. If our contract has an entrypoint that returns the value of a storage variable, we can call this entrypoint. Otherwise, we can use the `load` function from `snforge` to load the value of a storage variable inside our contract, even if not exposed by an entrypoint.
 
-#### Mocking the Caller Address with `start_prank`
+#### Mocking the Caller Address with `start_cheat_caller_address`
 
-The security of our factory relies on the owner being the only one able to make pizzas and transfer ownership. To test this, we can use the `stark_prank` function to mock the caller address and assert that the contract behaves as expected.
+The security of our factory relies on the owner being the only one able to make pizzas and transfer ownership. To test this, we can use the `start_cheat_caller_address` function to mock the caller address and assert that the contract behaves as expected.
 
 ```rust,noplayground
 {{#rustdoc_include ../listings/ch17-starknet-smart-contracts-security/listing_02_pizza_factory_snfoundry/src/tests/foundry_test.cairo:test_owner}}
@@ -82,7 +82,7 @@ The security of our factory relies on the owner being the only one able to make 
 {{#label test-owner}}
 <span class="caption">Listing {{#ref test-owner}}: Testing ownership of the contract by mocking the caller address </span>
 
-Using `stark_prank`, we call the `change_owner` function first as the owner, and then as a different address. We assert that the operation fails when the caller is not the owner, and that the owner is updated when the caller is the owner.
+Using `start_cheat_caller_address`, we call the `change_owner` function first as the owner, and then as a different address. We assert that the operation fails when the caller is not the owner, and that the owner is updated when the caller is the owner.
 
 #### Capturing Events with `spy_events`
 


### PR DESCRIPTION
[Starknet Foundry](https://github.com/foundry-rs/starknet-foundry) changed its syntax to impersonate addresses in tests. They abandoned the Foundry-style naming (`prank`/`warp`/etc..) for more explicit naming (`cheat_caller_adress`/`cheat_block_timestamp`/`cheat_block_number`, etc.._)

See the latest [Starknet Foundry release](https://github.com/foundry-rs/starknet-foundry/releases/tag/v0.24.0) for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/810)
<!-- Reviewable:end -->
