### PR TITLE
help config

### DIFF
--- a/cairo-listings/src/config.rs
+++ b/cairo-listings/src/config.rs
@@ -47,10 +47,50 @@ pub struct Config {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Run the verification process
-    Verify,
+    Verify(VerifyCommand),
 
     /// Process the output.txt file in listings
-    Output,
+    Output(OutputCommand),
+}
+
+#[derive(Parser, Debug)]
+pub struct VerifyCommand {
+    #[arg(short, long)]
+    pub verbose: bool,
+    #[arg(short, long)]
+    pub quiet: bool,
+    #[arg(short, long)]
+    pub formats_skip: bool,
+    #[arg(short, long)]
+    pub starknet_skip: bool,
+    #[arg(short, long)]
+    pub compile_skip: bool,
+    #[arg(short, long)]
+    pub run_skip: bool,
+    #[arg(short, long)]
+    pub test_skip: bool,
+    #[arg(long)]
+    pub file: Option<String>,
+}
+
+#[derive(Parser, Debug)]
+pub struct OutputCommand {
+    #[arg(short, long)]
+    pub verbose: bool,
+    #[arg(short, long)]
+    pub quiet: bool,
+    #[arg(short, long)]
+    pub formats_skip: bool,
+    #[arg(short, long)]
+    pub starknet_skip: bool,
+    #[arg(short, long)]
+    pub compile_skip: bool,
+    #[arg(short, long)]
+    pub run_skip: bool,
+    #[arg(short, long)]
+    pub test_skip: bool,
+    #[arg(long)]
+    pub file: Option<String>,
 }
 
 /// Expected statement in a cairo program for it to be runnable.

--- a/cairo-listings/src/config.rs
+++ b/cairo-listings/src/config.rs
@@ -2,7 +2,7 @@ use clap::{Parser, Subcommand};
 use regex::Regex;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(name = "cairo-listings", author, version, about, long_about = None)]
 pub struct Config {
     /// The path to explore for *.cairo files.
     #[arg(short, long, default_value = "./listings")]

--- a/cairo-listings/src/config.rs
+++ b/cairo-listings/src/config.rs
@@ -47,34 +47,14 @@ pub struct Config {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Run the verification process
-    Verify(VerifyCommand),
+    Verify(Options),
 
     /// Process the output.txt file in listings
-    Output(OutputCommand),
+    Output(Options),
 }
 
 #[derive(Parser, Debug)]
-pub struct VerifyCommand {
-    #[arg(short, long)]
-    pub verbose: bool,
-    #[arg(short, long)]
-    pub quiet: bool,
-    #[arg(short, long)]
-    pub formats_skip: bool,
-    #[arg(short, long)]
-    pub starknet_skip: bool,
-    #[arg(short, long)]
-    pub compile_skip: bool,
-    #[arg(short, long)]
-    pub run_skip: bool,
-    #[arg(short, long)]
-    pub test_skip: bool,
-    #[arg(long)]
-    pub file: Option<String>,
-}
-
-#[derive(Parser, Debug)]
-pub struct OutputCommand {
+pub struct Options {
     #[arg(short, long)]
     pub verbose: bool,
     #[arg(short, long)]

--- a/cairo-listings/src/main.rs
+++ b/cairo-listings/src/main.rs
@@ -19,7 +19,7 @@ mod tags;
 mod utils;
 
 use crate::cmd::ScarbCmd;
-use crate::config::{Commands, Config, VerifyCommand};
+use crate::config::{Commands, Config, Options};
 use crate::error_sets::ErrorSets;
 use crate::tags::Tags;
 use crate::utils::{clickable, find_scarb_manifests, print_error_table};
@@ -42,7 +42,7 @@ fn main() {
     }
 }
 
-fn run_verification(cfg: &Config, cmd: &VerifyCommand) {
+fn run_verification(cfg: &Config, cmd: &Options) {
     let scarb_packages = find_scarb_manifests(cfg);
 
     let pb = ProgressBar::new(scarb_packages.len() as u64);
@@ -83,7 +83,7 @@ fn run_verification(cfg: &Config, cmd: &VerifyCommand) {
     }
 }
 
-fn process_file(manifest_path: &str, cmd: &VerifyCommand) {
+fn process_file(manifest_path: &str, cmd: &Options) {
     let manifest_path_as_path = std::path::Path::new(manifest_path);
     let file_path = manifest_path_as_path
         .parent()

--- a/cairo-listings/src/main.rs
+++ b/cairo-listings/src/main.rs
@@ -33,6 +33,7 @@ lazy_static! {
 }
 
 fn main() {
+    let _ = &*CFG;
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 {
         match args[1].as_str() {

--- a/cairo-listings/src/main.rs
+++ b/cairo-listings/src/main.rs
@@ -25,11 +25,11 @@ use crate::tags::Tags;
 use crate::utils::{clickable, find_scarb_manifests, print_error_table};
 
 lazy_static! {
-    static ref ERRORS: Mutex<ErrorSets> = Mutex::new(ErrorSets::new());
+    static ref CFG: Config = Config::parse();
 }
 
 lazy_static! {
-    static ref CFG: Config = Config::parse();
+    static ref ERRORS: Mutex<ErrorSets> = Mutex::new(ErrorSets::new());
 }
 
 fn main() {


### PR DESCRIPTION
@enitrat  now, doing `cairo-listings --help` prints:

```
A tool for running adequate cairo tests tools on cairo files.

Usage: cairo-listings [OPTIONS] [COMMAND]

Commands:
  verify  Run the verification process
  output  Process the output.txt file in listings
  help    Print this message or the help of the given subcommand(s)

Options:
  -p, --path <PATH>    The path to explore for *.cairo files [default: ./listings]
  -v, --verbose        Print more information
  -q, --quiet          Only print final results
  -f, --formats-skip   Skip cairo-format checks
  -s, --starknet-skip  Skip starknet-compile checks
  -c, --compile-skip   Skip cairo-compile checks
  -r, --run-skip       Skip cairo-run checks
  -t, --test-skip      Skip cairo-test checks
      --file <FILE>    Specify file to check
  -h, --help           Print help
  -V, --version        Print version
  ```
  
   not finished, still have issues:
   
   ```
   tristan@Tristans-MacBook-Pro cairo-book.github.io % cairo-listings verify -v
error: unexpected argument '-v' found

Usage: cairo-listings verify
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/814)
<!-- Reviewable:end -->
