### PR TITLE
Update cairo-documentation-style-guide.md

### DIFF
--- a/cairo-documentation-style-guide.md
+++ b/cairo-documentation-style-guide.md
@@ -263,8 +263,8 @@ In markdown:
 ### Code
 
 - [Style Guidelines](https://doc.rust-lang.org/1.0.0/style/README.html)
-- [The Rust RFC Book](https://rust-lang.github.io/rfcs/2436-style-guide.html), chapter _Style Guide_
+- [The Rust RFC Book](https://rust-lang.github.io/rfcs/2436-style-guide.html) chapter _Style Guide_
 - [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
 - [Rust Style Guide](https://riptutorial.com/rust/topic/4620/rust-style-guide) (riptutorial.com)
-- [Rust Style Guide](https://github.com/rust-lang/style-team/blob/master/guide/guide.md) (github.com/rust-lang)
+- [Rust Style Guide](https://github.com/rust-lang/rust/blob/master/src/doc/style-guide/src/principles.md) (github.com/rust-lang)
 


### PR DESCRIPTION

PR:https://github.com/cairo-book/cairo-book/pull/720  add `cairo-documentation-style-guide.md`
for [Rust Style Guide](https://github.com/rust-lang/style-team/blob/master/guide/guide.md) (github.com/rust-lang) part's link is outdated, see:
> The [Rust style guide](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src) lives in the rust-lang/rust repository. In particular, see the [guiding principles](https://github.com/rust-lang/rust/blob/HEAD/src/doc/style-guide/src/principles.md) of the Rust style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/829)
<!-- Reviewable:end -->
