### PR TITLE
help flag

### DIFF
--- a/cairo-listings/src/config.rs
+++ b/cairo-listings/src/config.rs
@@ -8,6 +8,21 @@ pub struct Config {
     #[arg(short, long, default_value = "./listings")]
     pub path: String,
 
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Run the verification process
+    Verify(VerifyArgs),
+
+    /// Process the output.txt file in listings
+    Output,
+}
+
+#[derive(Parser, Debug, Default)]
+pub struct VerifyArgs {
     /// Print more information.
     #[arg(short, long)]
     pub verbose: bool,
@@ -39,18 +54,6 @@ pub struct Config {
     /// Specify file to check
     #[arg(long)]
     pub file: Option<String>,
-
-    #[command(subcommand)]
-    pub command: Option<Commands>,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum Commands {
-    /// Run the verification process
-    Verify,
-
-    /// Process the output.txt file in listings
-    Output,
 }
 
 /// Expected statement in a cairo program for it to be runnable.

--- a/cairo-listings/src/logger.rs
+++ b/cairo-listings/src/logger.rs
@@ -1,8 +1,8 @@
 use env_logger::Env;
 use indicatif::ProgressBar;
-use log::{Log, Metadata, Record};
+use log::{LevelFilter, Log, Metadata, Record};
 
-use crate::Config;
+use crate::VerifyArgs;
 
 struct ProgressBarLogger {
     pb: ProgressBar,
@@ -21,23 +21,22 @@ impl Log for ProgressBarLogger {
 
     fn flush(&self) {}
 }
-
-pub fn setup(cfg: &Config, pb: ProgressBar) {
+pub fn setup(args: &VerifyArgs, pb: ProgressBar) {
     let env = Env::default()
         .filter_or("APP_LOG", "info") // Default log level is "info"
         .write_style_or("APP_LOG_STYLE", "always");
 
-    if cfg.verbose {
+    if args.verbose {
         let logger = ProgressBarLogger { pb };
         log::set_boxed_logger(Box::new(logger)).unwrap();
-        log::set_max_level(log::LevelFilter::max());
-    } else if cfg.quiet {
+        log::set_max_level(LevelFilter::max());
+    } else if args.quiet {
         env_logger::Builder::from_env(env)
-            .filter(None, log::LevelFilter::Off)
+            .filter(None, LevelFilter::Off)
             .init();
     } else {
         let logger = ProgressBarLogger { pb };
         log::set_boxed_logger(Box::new(logger)).unwrap();
-        log::set_max_level(log::LevelFilter::Error);
+        log::set_max_level(LevelFilter::Error);
     }
 }

--- a/cairo-listings/src/output.rs
+++ b/cairo-listings/src/output.rs
@@ -6,10 +6,12 @@ use std::{
 
 use regex::Regex;
 
-use crate::{cmd::ScarbCmd, run_command, utils::find_scarb_manifests, CFG};
+use crate::{
+    cmd::ScarbCmd, config::VerifyArgs, run_command, utils::find_scarb_manifests, Config, CFG,
+};
 
-pub fn process_outputs() {
-    let scarb_packages = find_scarb_manifests(&CFG);
+pub fn process_outputs(cfg: &Config, arg: &VerifyArgs) {
+    let scarb_packages = find_scarb_manifests(cfg, arg);
 
     for file in scarb_packages {
         process_file(&file);

--- a/cairo-listings/src/output.rs
+++ b/cairo-listings/src/output.rs
@@ -6,9 +6,7 @@ use std::{
 
 use regex::Regex;
 
-use crate::{
-    cmd::ScarbCmd, config::VerifyArgs, run_command, utils::find_scarb_manifests, Config, CFG,
-};
+use crate::{cmd::ScarbCmd, config::VerifyArgs, run_command, utils::find_scarb_manifests, Config};
 
 pub fn process_outputs(cfg: &Config, arg: &VerifyArgs) {
     let scarb_packages = find_scarb_manifests(cfg, arg);

--- a/cairo-listings/src/utils.rs
+++ b/cairo-listings/src/utils.rs
@@ -3,9 +3,9 @@ use regex::Regex;
 use std::collections::HashSet;
 use walkdir::WalkDir;
 
-use crate::config::Config;
+use crate::config::{Config, VerifyArgs};
 
-pub fn find_scarb_manifests(cfg: &Config) -> Vec<String> {
+pub fn find_scarb_manifests(cfg: &Config, args: &VerifyArgs) -> Vec<String> {
     let path = cfg.path.as_str();
 
     let mut scarb_manifests: Vec<String> = Vec::new();
@@ -13,7 +13,7 @@ pub fn find_scarb_manifests(cfg: &Config) -> Vec<String> {
     for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
         if let Some(file_name) = entry.file_name().to_str() {
             if file_name.eq("Scarb.toml") {
-                if cfg.file.is_some() && !file_name.ends_with(cfg.file.as_ref().unwrap()) {
+                if args.file.is_some() && !file_name.ends_with(args.file.as_ref().unwrap()) {
                     continue;
                 }
 


### PR DESCRIPTION
@enitrat  now it should be good.

```
cairo-listings -h  
A tool for running adequate cairo tests tools on cairo files.

Usage: cairo-listings [OPTIONS] <COMMAND>

Commands:
  verify  Run the verification process
  output  Process the output.txt file in listings
  help    Print this message or the help of the given subcommand(s)

Options:
  -p, --path <PATH>  The path to explore for *.cairo files [default: ./listings]
  -h, --help         Print help
  -V, --version      Print version
  ```
  
  
  
  ```
  
  cairo-listings verify --help
Run the verification process

Usage: cairo-listings verify [OPTIONS]

Options:
  -v, --verbose        Print more information
  -q, --quiet          Only print final results
  -f, --formats-skip   Skip cairo-format checks
  -s, --starknet-skip  Skip starknet-compile checks
  -c, --compile-skip   Skip cairo-compile checks
  -r, --run-skip       Skip cairo-run checks
  -t, --test-skip      Skip cairo-test checks
      --file <FILE>    Specify file to check
  -h, --help           Print help
  
 ```
 
 
 
 Also tried some flags and it works well
 
 
 
 ```
 
 cairo-listings output --help
Process the output.txt file in listings

Usage: cairo-listings output

Options:
  -h, --help  Print help
  
  ```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/835)
<!-- Reviewable:end -->
