### PR TITLE
Update ch02-05-control-flow.md

### DIFF
--- a/src/ch02-05-control-flow.md
+++ b/src/ch02-05-control-flow.md
@@ -154,7 +154,7 @@ Executing this program will not print the value of `i` when it is equal to `5`.
 One of the uses of a `loop` is to retry an operation you know might fail, such
 as checking whether an operation has succeeded. You might also need to pass
 the result of that operation out of the loop to the rest of your code. To do
-this, you can add the value you want returned after the `break` expression you
+this, you can add the value you want to be returned after the `break` expression you
 use to stop the loop; that value will be returned out of the loop so you can
 use it, as shown here:
 


### PR DESCRIPTION
Fixed a typo in the cairo book, chapter 02 / 05 : Control flow

From `the value you want returned` to `the value you want to be returned`

LMK if this is a valid change

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/838)
<!-- Reviewable:end -->
