### PR TITLE
feat: add Cairo VM sub-book skeleton

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -157,3 +157,66 @@
 
 - [Appendix (Starknet)](appendix-000.md)
   - [A - System Calls](appendix-08-system-calls.md)
+
+---
+
+# Cairo VM
+
+- [Introduction](ch200-introduction.md)
+
+- [Architecture]()
+
+## Memory
+
+- [Memory]()
+
+  - [Non-Deterministic Read-only Memory]()
+  - [Segments]()
+  - [Segment Value]()
+  - [Relocation]()
+  - [Layout]()
+
+## Execution Model
+
+- [Execution Model]()
+
+  - [Registers]()
+  - [Instructions]()
+  - [Cairo Assembly (CASM)]()
+  - [State transition]()
+
+## Builtins
+
+- [Builtins]()
+  - [Memory Communication]()
+  - [List of builtins]()
+
+## Hints
+
+- [Hints]()
+  - [Structure]()
+  - [Hint runner]()
+  - [List of hints]()
+
+## Runner
+
+- [Runner]()
+
+  - [Program]()
+    - [Program Artifacts]()
+    - [Program Parsing]()
+  - [Runner Mode]()
+    - [Execution Mode]()
+    - [Proof Mode]()
+  - [Output]()
+    - [Cairo PIE]()
+    - [Memory File]()
+    - [Trace file]()
+    - [AIR public input]()
+    - [AIR private input]()
+
+- [Tracer]()
+
+- [Implementations]()
+
+- [Resources]()

--- a/src/ch200-introduction.md
+++ b/src/ch200-introduction.md
@@ -1,0 +1,1 @@
+# Introduction


### PR DESCRIPTION
Closes #757 

All the chapters are currently empty except for the introduction with an empty file (enforcing the convention `ch20x-chapter.md`.

Should the writing of the introduction be in this PR or in a separated one?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/848)
<!-- Reviewable:end -->
