### PR TITLE
Update ch02-05-control-flow.md

### DIFF
--- a/src/ch02-05-control-flow.md
+++ b/src/ch02-05-control-flow.md
@@ -110,7 +110,7 @@ As an example, change the _src/lib.cairo_ file in your _loops_ directory to look
 {{#include ../listings/ch02-common-programming-concepts/no_listing_32_infinite_loop/src/lib.cairo}}
 ```
 
-When we run this program, we’ll see `again!` printed over and over continuously until either the program runs out of gas or we stop the program manually. Most terminals support the keyboard shortcut ctrl-c to interrupt a program that is stuck in a continual loop. Give it a try:
+When we run this program, we’ll see `again!` printed over and over continuously until either the program runs out of memory or we stop the program manually. Most terminals support the keyboard shortcut ctrl-c to interrupt a program that is stuck in a continual loop. Give it a try:
 
 ```shell
 $ scarb cairo-run --available-gas=20000000


### PR DESCRIPTION
Updated section: [Repeating Code with loop](https://book.cairo-lang.org/ch02-05-control-flow.html#repeating-code-with-loop)
From: *When we run this program, we’ll see again! printed over and over continuously until either the program runs out of **gas** or we stop the program manually*
To: *When we run this program, we’ll see again! printed over and over continuously until either the program runs out of **memory** or we stop the program manually*

Reason: The chapter introduces Cairo as a general purpose language, not as Smart Contracts language, So, mentioning *gas* here is inappropriate

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/873)
<!-- Reviewable:end -->
