### PR TITLE
Chore: bumped scarb and starknet version to v2.7.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.7.0-rc.3 2.6.4
+scarb 2.7.0 2.6.4
 starknet-foundry 0.25.0

--- a/listings/ch02-common-programming-concepts/no_listing_38_mod_doc_comments/Scarb.toml
+++ b/listings/ch02-common-programming-concepts/no_listing_38_mod_doc_comments/Scarb.toml
@@ -6,4 +6,4 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch06-enums-and-pattern-matching/no_listing_10_match_catch_all/Scarb.toml
+++ b/listings/ch06-enums-and-pattern-matching/no_listing_10_match_catch_all/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch06-enums-and-pattern-matching/no_listing_11_match_or/Scarb.toml
+++ b/listings/ch06-enums-and-pattern-matching/no_listing_11_match_or/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch06-enums-and-pattern-matching/no_listing_12_match_tuple/Scarb.toml
+++ b/listings/ch06-enums-and-pattern-matching/no_listing_12_match_tuple/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch09-error-handling/listing_09_01/Scarb.toml
+++ b/listings/ch09-error-handling/listing_09_01/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch09-error-handling/listing_09_02/Scarb.toml
+++ b/listings/ch09-error-handling/listing_09_02/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_01/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_01/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_02/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_02/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_03/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_03/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_04/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_04/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_05/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_05/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_06/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_06/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_07/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_07/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/listing_10_08/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/listing_10_08/Scarb.toml
@@ -8,4 +8,4 @@ edition = "2023_11"
 [dependencies]
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_02_custom_messages/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_02_custom_messages/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_04_new_bug/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_04_new_bug/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_05_ignore_tests/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_05_ignore_tests/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_06_test_gas/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_06_test_gas/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_07_benchmark_gas/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_07_benchmark_gas/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_09_integration_test/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_09_integration_test/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_10_assert_eq_ne_macro/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_10_assert_eq_ne_macro/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_11_test_private_function/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_11_test_private_function/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_12_submodules/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_12_submodules/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch10-testing-cairo-programs/no_listing_13_single_integration_crate/Scarb.toml
+++ b/listings/ch10-testing-cairo-programs/no_listing_13_single_integration_crate/Scarb.toml
@@ -9,4 +9,4 @@ edition = "2023_11"
 # foo = { path = "vendor/foo" }
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch13-introduction-to-starknet-smart-contracts/listing_01_simple_contract/Scarb.toml
+++ b/listings/ch13-introduction-to-starknet-smart-contracts/listing_01_simple_contract/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch13-introduction-to-starknet-smart-contracts/listing_02_wrong_impl/Scarb.toml
+++ b/listings/ch13-introduction-to-starknet-smart-contracts/listing_02_wrong_impl/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/Scarb.toml
+++ b/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_10"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
+++ b/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
@@ -137,7 +137,7 @@ mod NameRegistry {
     // Free function
     fn get_owner_storage_address(self: @ContractState) -> felt252 {
         //ANCHOR: owner_address
-        self.owner.address
+        self.owner.__base_address__
         //ANCHOR_END: owner_address
     }
     // ANCHOR_END: state_internal

--- a/listings/ch14-building-starknet-smart-contracts/listing_02_storage_mapping/Scarb.toml
+++ b/listings/ch14-building-starknet-smart-contracts/listing_02_storage_mapping/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch14-building-starknet-smart-contracts/no_listing_01_abi_per_item_attribute/Scarb.toml
+++ b/listings/ch14-building-starknet-smart-contracts/no_listing_01_abi_per_item_attribute/Scarb.toml
@@ -6,4 +6,4 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch14-building-starknet-smart-contracts/no_listing_02_event_trait/Scarb.toml
+++ b/listings/ch14-building-starknet-smart-contracts/no_listing_02_event_trait/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch14-building-starknet-smart-contracts/no_listing_03_explicit_internal_fn/Scarb.toml
+++ b/listings/ch14-building-starknet-smart-contracts/no_listing_03_explicit_internal_fn/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_01_simple_erc20_interface/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_01_simple_erc20_interface/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_02_expanded_ierc20_dispatcher/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_02_expanded_ierc20_dispatcher/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_03_contract_dispatcher/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_03_contract_dispatcher/Scarb.toml
@@ -6,4 +6,4 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_04_expanded_ierc20_library/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_04_expanded_ierc20_library/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_05_library_dispatcher/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_05_library_dispatcher/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_06_syscalls/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_06_syscalls/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch15-starknet-cross-contract-interactions/listing_07_library_syscall/Scarb.toml
+++ b/listings/ch15-starknet-cross-contract-interactions/listing_07_library_syscall/Scarb.toml
@@ -6,4 +6,4 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_01_storage_packing/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_01_storage_packing/Scarb.toml
@@ -7,7 +7,7 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_02_ownable_component/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_02_ownable_component/Scarb.toml
@@ -6,6 +6,6 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [[target.starknet-contract]]

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_03_component_dep/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_03_component_dep/Scarb.toml
@@ -6,6 +6,6 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [[target.starknet-contract]]

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_04_test_component/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_04_test_component/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [dev-dependencies]
-cairo_test = "2.7.0-rc.3"
+cairo_test = "2.7.0"

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_05_vote_contract/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_05_vote_contract/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch16-building-advanced-starknet-smart-contracts/listing_06_upgrade_with_syscall/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/listing_06_upgrade_with_syscall/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [[target.starknet-contract]]
 casm = true

--- a/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_01_embeddable/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_01_embeddable/Scarb.toml
@@ -6,6 +6,6 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [[target.starknet-contract]]

--- a/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_02_embeddable_as_output/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_02_embeddable_as_output/Scarb.toml
@@ -6,4 +6,4 @@ edition = "2023_11"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_03_L1_L2_messaging/Scarb.toml
+++ b/listings/ch16-building-advanced-starknet-smart-contracts/no_listing_03_L1_L2_messaging/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch17-starknet-smart-contracts-security/no_listing_01_assert_balance/Scarb.toml
+++ b/listings/ch17-starknet-smart-contracts-security/no_listing_01_assert_balance/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/listings/ch17-starknet-smart-contracts-security/no_listing_02_simple_access_control/Scarb.toml
+++ b/listings/ch17-starknet-smart-contracts-security/no_listing_02_simple_access_control/Scarb.toml
@@ -7,4 +7,4 @@ edition = "2023_11"
 
 [dependencies]
 # foo = { path = "vendor/foo" }
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"

--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -36,13 +36,13 @@ asdf plugin add scarb
 This will allow you to download specific versions:
 
 ```bash
-asdf install scarb 2.7.0-rc.3
+asdf install scarb 2.7.0
 ```
 
 and set a global version:
 
 ```bash
-asdf global scarb 2.7.0-rc.3
+asdf global scarb 2.7.0
 ```
 
 Otherwise, you can simply run the following command in your terminal, and follow the onscreen instructions. This will install the latest stable release of Scarb.
@@ -56,8 +56,8 @@ In both cases, you can verify installation by running the following command in a
 
 ```bash
 $ scarb --version
-scarb 2.7.0-rc.3 (e6f921dfd 2024-03-13)
-cairo: 2.7.0-rc.3 (https://crates.io/crates/cairo-lang-compiler/2.7.0-rc.3)
+scarb 2.7.0 (e6f921dfd 2024-03-13)
+cairo: 2.7.0 (https://crates.io/crates/cairo-lang-compiler/2.7.0)
 sierra: 1.5.0
 ```
 

--- a/src/ch13-00-introduction-to-starknet-smart-contracts.md
+++ b/src/ch13-00-introduction-to-starknet-smart-contracts.md
@@ -24,7 +24,7 @@ name = "package_name"
 version = "0.1.0"
 
 [dependencies]
-starknet = ">=2.7.0-rc.3"
+starknet = ">=2.7.0"
 
 [[target.starknet-contract]]
 ```

--- a/src/ch14-01-contract-storage.md
+++ b/src/ch14-01-contract-storage.md
@@ -24,7 +24,7 @@ The address of a storage variable is computed as follows:
 
 - If the variable is a [mapping][storage mappings] with a key `k`, the address of the value at key `k` is `h(sn_keccak(variable_name),k)`, where ℎ is the Pedersen hash and the final value is taken modulo \\( {2^{251}} - 256\\). If the key is composed of more than one `felt252`, the address of the value will be `h(...h(h(sn_keccak(variable_name),k_1),k_2),...,k_n)`, with `k_1,...,k_n` being all `felt252` that constitute the key. In the case of mappings to complex values (e.g., tuples or structs), then this complex value lies in a continuous segment starting from the address calculated with the previous formula. Note that 256 field elements is the current limitation on the maximal size of a complex storage value.
 
-You can access the base address of a storage variable by calling the `address` attribute on the variable, which returns a `felt252` value.
+You can access the base address of a storage variable by accessing the `__base_address__` attribute on the variable, which returns a `felt252` value.
 
 ```rust, noplayground
 {{#rustdoc_include ../listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:owner_address}}
@@ -99,13 +99,13 @@ You might have noticed that we also derived `Drop` and `Serde` on our custom typ
 ### Structs Storage Layout
 
 On Starknet, structs are stored in storage as a sequence of primitive types.
-The elements of the struct are stored in the same order as they are defined in the struct definition. The first element of the struct is stored at the base address of the struct, which is computed as specified in ["Addresses of Storage Variables"][storage addresses] section and can be obtained by calling `var.address()`, and subsequent elements are stored at addresses contiguous to the first element.
+The elements of the struct are stored in the same order as they are defined in the struct definition. The first element of the struct is stored at the base address of the struct, which is computed as specified in ["Addresses of Storage Variables"][storage addresses] section and can be obtained with `var.__base_address__` and subsequent elements are stored at addresses contiguous to the first element.
 For example, the storage layout for the `owner` variable of type `Person` will result in the following layout:
 
-| Fields  | Address            |
-| ------- | ------------------ |
-| name    | owner.address()    |
-| address | owner.address() +1 |
+| Fields  | Address                     |
+| ------- | --------------------------- |
+| name    | `owner.__base_address__`    |
+| address | `owner.__base_address__ +1` |
 
 Note that tuples are similarly stored in contract's storage, with the first element of the tuple being stored at the base address, and subsequent elements stored contiguously.
 
@@ -117,16 +117,16 @@ When you store an enum variant, what you're essentially storing is the variant's
 If your variant has an associated value, this value is stored starting from the address immediately following the address of the index of the variant.
 For example, suppose we have the `RegistrationType` enum with the `finite` variant that carries an associated limit date, and the `infinite` variant without associated data. The storage layout for the `finite` variant would look like this:
 
-| Element                      | Address                         |
-| ---------------------------- | ------------------------------- |
-| Variant index (0 for finite) | registration_type.address()     |
-| Associated limit date        | registration_type.address() + 1 |
+| Element                      | Address                                  |
+| ---------------------------- | ---------------------------------------- |
+| Variant index (0 for finite) | `registration_type.__base_address__`     |
+| Associated limit date        | `registration_type.__base_address__ + 1` |
 
 while the storage layout for the `infinite` would be as follows:
 
-| Element                        | Address                     |
-| ------------------------------ | --------------------------- |
-| Variant index (1 for infinite) | registration_type.address() |
+| Element                        | Address                              |
+| ------------------------------ | ------------------------------------ |
+| Variant index (1 for infinite) | `registration_type.__base_address__` |
 
 ## Storage Mappings
 

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -2,6 +2,6 @@
 
 By the Cairo Community and its [contributors](https://github.com/cairo-book/cairo-book.github.io). Special thanks to [StarkWare](https://starkware.co/) through [OnlyDust](https://www.onlydust.xyz/), and [Voyager](https://voyager.online/) for supporting the creation of this book.
 
-This version of the text assumes you’re using the [Cairo Compiler](https://github.com/starkware-libs/cairo) [version 2.7.0-rc.3](https://github.com/starkware-libs/cairo/releases). See the [Installation](ch01-01-installation.md) section of Chapter 1 to install or update Cairo.
+This version of the text assumes you’re using the [Cairo Compiler](https://github.com/starkware-libs/cairo) [version 2.7.0](https://github.com/starkware-libs/cairo/releases). See the [Installation](ch01-01-installation.md) section of Chapter 1 to install or update Cairo.
 
 If you want to play around with Cairo code and see how it compiles into Sierra (Intermediate Representation) and CASM (Cairo Assembly), you can use [cairovm.codes](https://cairovm.codes/) playground.


### PR DESCRIPTION
I have found and replaced all starknet dependencies and scarb version of 2.7.0-rc.3 to 2.7.0

Closes: https://github.com/cairo-book/cairo-book/issues/900

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/901)
<!-- Reviewable:end -->
