### PR TITLE
fix(docs): use `#rustdoc_include` to allow expanding for `Map` example

### DIFF
--- a/src/ch14-01-contract-storage.md
+++ b/src/ch14-01-contract-storage.md
@@ -198,8 +198,8 @@ Note: You might encounter `LegacyMap` in older code or documentation. This was t
 
 You can also create more complex mappings with multiple keys. You can find in Listing {{#ref storage-mapping}} the popular `allowances` storage variable of the ERC20 Standard which maps an `owner` and an allowed `spender` to their `allowance` amount using multiple keys passed inside a tuple:
 
-```rust,noplayground
-{{#include ../listings/ch14-building-starknet-smart-contracts/listing_02_storage_mapping/src/lib.cairo:here}}
+```rust, noplayground
+{{#rustdoc_include ../listings/ch14-building-starknet-smart-contracts/listing_02_storage_mapping/src/lib.cairo:here}}
 ```
 
 {{#label storage-mapping}}


### PR DESCRIPTION
Closes #930 

for expanding to work, we need `#rustdoc_include` instead of `#include`

here I updated only the one that was mentioned, but `#include` is used in many many other files, but its not always necessary to allow expanding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/940)
<!-- Reviewable:end -->
