### PR TITLE
chore : remove dead listing in mappings chapter

### DIFF
--- a/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
+++ b/listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
@@ -38,14 +38,14 @@ mod NameRegistry {
         StoredName: StoredName,
     }
     //ANCHOR_END: event
-    //ANCHOR: storedname
+    //ANCHOR: stored_name
     #[derive(Drop, starknet::Event)]
     struct StoredName {
         #[key]
         user: ContractAddress,
         name: felt252,
     }
-    //ANCHOR_END: storedname
+    //ANCHOR_END: stored_name
 
     //ANCHOR: person
     #[derive(Drop, Serde, starknet::Store)]

--- a/src/ch14-01-01-storage-mappings.md
+++ b/src/ch14-01-01-storage-mappings.md
@@ -67,10 +67,6 @@ The address in storage of a variable stored in a mapping is computed according t
 
 If the key of a mapping is a struct, each element of the struct constitutes a key. Moreover, the struct should implement the `Hash` trait, which can be derived with the `#[derive(Hash)]` attribute.
 
-```cairo, noplayground
-{{#rustdoc_include ../listings/ch14-building-starknet-smart-contracts/listing_02_storage_mapping/src/lib.cairo:struct_key_mapping}}
-```
-
 ## Summary
 
 - Storage mappings allow you to map keys to values in contract storage.

--- a/src/ch14-03-contract-events.md
+++ b/src/ch14-03-contract-events.md
@@ -26,7 +26,7 @@ The auto-implementation of the `starknet::Event` trait will implement the `appen
 In our example, the `Event` enum contains only one variant, which is a struct named `StoredName`. We chose to name our variant with the same name as the struct name, but this is not enforced.
 
 ```cairo,noplayground
-{{#include ../listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:storedname}}
+{{#include ../listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:stored_name}}
 ```
 
 Whenever an enum that derives the `starknet::Event` trait has an enum variant, this enum is nested by default. Therefore, the list of keys corresponding to the variant’s name will include the `sn_keccak` hash of the variant's name itself. This can be superfluous, typically when using embedded components in contracts. Indeed, in such cases, we might want the events defined in the components to be emitted without any additional data, and it could be useful to annotate the enum variant with the `#[flat]` attribute. By doing so, we allow to opt out of the nested behavior and ignore the variant name in the serialization process. On the other hand, nested events have the benefit of distinguishing between the main contract event and different components events, which might be helpful.


### PR DESCRIPTION
@enitrat  there is a listing that doesnt point to anything at the end of Mapping Storages chapter. i dont think any listing is required here

<img width="840" alt="Screenshot 2024-09-03 at 10 34 50" src="https://github.com/user-attachments/assets/1bbe3f50-5461-4c18-a542-161792254b8e">

also updated an anchor to snake case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/955)
<!-- Reviewable:end -->
