### PR TITLE
fix: cairo hidden lines

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -26,7 +26,7 @@ additional-css = ["theme/css/last-changed.css"]
 mathjax-support = true
 
 [output.html.code.hidelines]
-cairo = "#"
+cairo = "# "
 
 [output.html.fold]
 enable = true

--- a/src/ch14-01-00-contract-storage.md
+++ b/src/ch14-01-00-contract-storage.md
@@ -51,7 +51,7 @@ When working with compound types, instead of calling `read` and `write` on the s
 
 ## Storing Custom Types with the `Store` Trait
 
-The `Store` trait, defined in the `starknet::storage_access` module, is used to specify how a type should be stored in storage. In order for a type to be stored in storage, it **must** implement the `Store` trait. Most types from the core library, such as unsigned integers (`u8`, `u128`, `u256`...), `felt252`, `bool`, `ByteArray`, `ContractAddress`, etc. implement the `Store` trait and can thus be stored without further action.
+The `Store` trait, defined in the `starknet::storage_access` module, is used to specify how a type should be stored in storage. In order for a type to be stored in storage, it **must** implement the `Store` trait. Most types from the core library, such as unsigned integers (`u8`, `u128`, `u256`...), `felt252`, `bool`, `ByteArray`, `ContractAddress`, etc. implement the `Store` trait and can thus be stored without further action. However, **memory collections**, such as `Array<T>` and `Felt252Dict<T>`, **cannot** be stored in contract storage - you will have to use the special types `Vec<T>` and `Map<K, V>` instead.
 
 But what if you wanted to store a type that you defined yourself, such as an enum or a struct? In that case, you have to explicitly tell the compiler how to store this type.
 

--- a/theme/book.js
+++ b/theme/book.js
@@ -260,6 +260,14 @@ function playground_text(playground, hidden = true) {
 
   Array.from(document.querySelectorAll("code.language-cairo")).forEach(
     function (block) {
+      // Wrap the code block in a playground
+      let parent = block.parentNode;
+      let wrapper = document.createElement("pre");
+      wrapper.className = "playground";
+      parent.replaceChild(wrapper, block);
+      wrapper.appendChild(block);
+
+      // Handle boring lines
       var lines = Array.from(block.querySelectorAll(".boring"));
       // If no lines were hidden, return
       if (!lines.length) {


### PR DESCRIPTION
Fixes #961

`#` -> `# `. Fixes conflicts with derive directives.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/963)
<!-- Reviewable:end -->
