### PR TITLE
Update lib.cairo

### DIFF
--- a/listings/ch03-common-collections/no_listing_09_intro/src/lib.cairo
+++ b/listings/ch03-common-collections/no_listing_09_intro/src/lib.cairo
@@ -1,5 +1,3 @@
-use core::dict::Felt252Dict;
-
 fn main() {
     let mut balances: Felt252Dict<u64> = Default::default();
 


### PR DESCRIPTION
There is no need to import `use core::dict::Felt252Dict;`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/969)
<!-- Reviewable:end -->
