### PR TITLE
chore: add precisions for `#[cairofmt::skip]` attribute usage

### DIFF
--- a/src/appendix-06-useful-development-tools.md
+++ b/src/appendix-06-useful-development-tools.md
@@ -28,7 +28,7 @@ let table: Array<ByteArray> = array![
 ];
 ```
 
-This attribute can be applied to modules, functions, statements or struct defintions.
+This attribute can be applied to modules, functions, statements or struct definitions.
 
 ## IDE Integration Using `cairo-language-server`
 

--- a/src/appendix-06-useful-development-tools.md
+++ b/src/appendix-06-useful-development-tools.md
@@ -28,7 +28,7 @@ let table: Array<ByteArray> = array![
 ];
 ```
 
-This attribute can be applied to modules, functions, statements or structs.
+This attribute can be applied to modules, functions, statements or struct defintions.
 
 ## IDE Integration Using `cairo-language-server`
 

--- a/src/appendix-06-useful-development-tools.md
+++ b/src/appendix-06-useful-development-tools.md
@@ -17,7 +17,7 @@ To format any Cairo project, enter the following inside the project directory:
 scarb fmt
 ```
 
-For things you do not want `scarb fmt` to mangle, use `#[cairofmt::skip]`:
+For items (modules, functions, structs) or statements you do not want `scarb fmt` to mangle, use `#[cairofmt::skip]`:
 
 ```cairo, noplayground
 #[cairofmt::skip]
@@ -27,8 +27,6 @@ let table: Array<ByteArray> = array![
     "oxo",
 ];
 ```
-
-This attribute can be applied to modules, functions, statements or struct definitions.
 
 ## IDE Integration Using `cairo-language-server`
 

--- a/src/appendix-06-useful-development-tools.md
+++ b/src/appendix-06-useful-development-tools.md
@@ -28,6 +28,8 @@ let table: Array<ByteArray> = array![
 ];
 ```
 
+This attribute can be applied to modules, functions, or statements.
+
 ## IDE Integration Using `cairo-language-server`
 
 To help IDE integration, the Cairo community recommends using the

--- a/src/appendix-06-useful-development-tools.md
+++ b/src/appendix-06-useful-development-tools.md
@@ -28,7 +28,7 @@ let table: Array<ByteArray> = array![
 ];
 ```
 
-This attribute can be applied to modules, functions, or statements.
+This attribute can be applied to modules, functions, statements or structs.
 
 ## IDE Integration Using `cairo-language-server`
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cairo-book/cairo-book/995)
<!-- Reviewable:end -->
