### PR TITLE
Update ch02-01-variables-and-mutability.md

### DIFF
--- a/src/ch02-01-variables-and-mutability.md
+++ b/src/ch02-01-variables-and-mutability.md
@@ -49,7 +49,7 @@ whole class of bugs impossible, because values will never change unexpectedly.
 This makes code easier to reason about.
 
 But mutability can be very useful, and can make code more convenient to write.
-Although variables are immutable by default, you can make them mutable by
+Although variables are immutable by default, you can make them act mutable by
 adding `mut` in front of the variable name. Adding `mut` also conveys
 intent to future readers of the code by indicating that other parts of the code
 will be changing the value associated to this variable.


### PR DESCRIPTION
by default cairo's variables  are immutable and remain immutable, what happens under the hood using 'mut' is that, the corresponding Sierra variable storing its value is first dropped as it's no longer used, and then a new variable is created with the updated value. so we can say the mut keyword is used to make variables "act" in a mutable way. rather than saying "make them mutable"