### PR TITLE
Update(at method) ch03-01-arrays.md

### DIFF
--- a/src/ch03-01-arrays.md
+++ b/src/ch03-01-arrays.md
@@ -68,8 +68,11 @@ The `at` function, and its equivalent the subscripting operator, on the other ha
 
 ```cairo
 {{#include ../listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo}}
+//  The first element of the array 'a', accessed using the .at() method.
+let first = *(a.at(0)); 
+// The second element of the array 'a', accessed using the .at() method.
+let second = *(a.at(1)); 
 ```
-
 In this example, the variable named `first` will get the value `0` because that
 is the value at index `0` in the array. The variable named `second` will get
 the value `1` from index `1` in the array.


### PR DESCRIPTION
From the at method section for getting items from an array, the variables 'first' and 'second' were assumed to have been declared as a reference was made to them but they were never declared in the code section. so I declared the first and second variables
let first = *(a.at(0);
let second = *(a.at(1));
I followed the method of dereferencing the array before accessing the values cause that what the rest of the code section used. The same thing can be achieved without dereferencing the array let first = a.at(0);
let second = a.at(1);