### PR TITLE
fix: array `at` code example incoherent with explanation

### DIFF
--- a/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
+++ b/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
@@ -3,6 +3,10 @@ fn main() {
     a.append(0);
     a.append(1);
 
+    // The first element of the array 'a', accessed using the .at() method.
+    let first = *a.at(0);
+    // The second element of the array 'a', accessed using the .at() method.
+    let second = *a.at(1);
     // using `at()` method
     assert(*a.at(0) == 0, 'item mismatch on index 0');
     // using subscripting operator

--- a/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
+++ b/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
@@ -3,10 +3,10 @@ fn main() {
     a.append(0);
     a.append(1);
 
+    // using the `at()` method
     let first = *a.at(0);
-    let second = *a.at(1);
-    // using `at()` method
-    assert(first == 0, 'item mismatch on index 0');
-    // using subscripting operator
-    assert(second == 1, 'item mismatch on index 1');
+    assert!(first == 0);
+    // using the subscripting operator
+    let second = *a[1];
+    assert!(second == 1);
 }

--- a/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
+++ b/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
@@ -3,9 +3,7 @@ fn main() {
     a.append(0);
     a.append(1);
 
-    // The first element of the array 'a', accessed using the .at() method.
     let first = *a.at(0);
-    // The second element of the array 'a', accessed using the .at() method.
     let second = *a.at(1);
     // using `at()` method
     assert(first == 0, 'item mismatch on index 0');

--- a/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
+++ b/listings/ch03-common-collections/no_listing_04_array_at/src/lib.cairo
@@ -8,7 +8,7 @@ fn main() {
     // The second element of the array 'a', accessed using the .at() method.
     let second = *a.at(1);
     // using `at()` method
-    assert(*a.at(0) == 0, 'item mismatch on index 0');
+    assert(first == 0, 'item mismatch on index 0');
     // using subscripting operator
-    assert(*a[1] == 1, 'item mismatch on index 1');
+    assert(second == 1, 'item mismatch on index 1');
 }


### PR DESCRIPTION
From the at method section for getting items from an array, the variables 'first' and 'second' were assumed to have been declared as a reference was made to them but they were never declared in the code section. so I declared the first and second variables let first = *a.at(0);
let second = *a.at(1);
I followed the method of dereferencing the array before accessing the values cause that what the rest of the code section used. The same result  can be achieved without dereferencing the array  let first = a.at(0);
let second = a.at(1);