### PR TITLE
fix: code examples not matching reference contract

### DIFF
--- a/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
+++ b/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
@@ -5,8 +5,6 @@ use core::starknet::ContractAddress;
 pub trait INameRegistry<TContractState> {
     fn store_name(ref self: TContractState, name: felt252);
     fn get_name(self: @TContractState, address: ContractAddress) -> felt252;
-    fn get_owner(self: @TContractState) -> NameRegistry::Person;
-    fn get_owner_name(self: @TContractState) -> felt252;
 }
 
 #[starknet::contract]
@@ -20,7 +18,6 @@ mod NameRegistry {
     #[storage]
     struct Storage {
         names: Map::<ContractAddress, felt252>,
-        owner: Person,
         total_names: u128,
     }
     //ANCHOR_END: storage
@@ -38,9 +35,6 @@ mod NameRegistry {
     fn constructor(ref self: ContractState, owner: Person) {
         self.names.entry(owner.address).write(owner.name);
         self.total_names.write(1);
-        //ANCHOR: write_owner
-        self.owner.write(owner);
-        //ANCHOR_END: write_owner
     }
     //ANCHOR_END: constructor
 
@@ -61,19 +55,7 @@ mod NameRegistry {
             self.names.entry(address).read()
             //ANCHOR_END: read
         }
-
         //ANCHOR_END: view
-        fn get_owner(self: @ContractState) -> Person {
-            //ANCHOR: read_owner
-            self.owner.read()
-            //ANCHOR_END: read_owner
-        }
-
-        fn get_owner_name(self: @ContractState) -> felt252 {
-            //ANCHOR: read_owner_name
-            self.owner.name.read()
-            //ANCHOR_END: read_owner_name
-        }
     }
     //ANCHOR_END: impl_public
 
@@ -103,10 +85,10 @@ mod NameRegistry {
     // ANCHOR_END: generate_trait
 
     // Free function
-    fn get_owner_storage_address(self: @ContractState) -> felt252 {
-        //ANCHOR: owner_address
-        self.owner.__base_address__
-        //ANCHOR_END: owner_address
+    fn get_total_names_storage_address(self: @ContractState) -> felt252 {
+        //ANCHOR: total_names_address
+        self.total_names.__base_address__
+        //ANCHOR_END:total_names_address
     }
     // ANCHOR_END: state_internal
 }

--- a/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
+++ b/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
@@ -3,15 +3,10 @@ use core::starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait INameRegistry<TContractState> {
-    fn store_name(
-        ref self: TContractState, name: felt252, registration_type: NameRegistry::RegistrationType,
-    );
+    fn store_name(ref self: TContractState, name: felt252);
     fn get_name(self: @TContractState, address: ContractAddress) -> felt252;
     fn get_owner(self: @TContractState) -> NameRegistry::Person;
     fn get_owner_name(self: @TContractState) -> felt252;
-    fn get_registration_info(
-        self: @TContractState, address: ContractAddress,
-    ) -> NameRegistry::RegistrationInfo;
 }
 
 #[starknet::contract]
@@ -26,26 +21,9 @@ mod NameRegistry {
     struct Storage {
         names: Map::<ContractAddress, felt252>,
         owner: Person,
-        registrations: Map<ContractAddress, RegistrationNode>,
         total_names: u128,
     }
     //ANCHOR_END: storage
-
-    //ANCHOR: event
-    #[event]
-    #[derive(Drop, starknet::Event)]
-    enum Event {
-        StoredName: StoredName,
-    }
-    //ANCHOR_END: event
-    //ANCHOR: stored_name
-    #[derive(Drop, starknet::Event)]
-    struct StoredName {
-        #[key]
-        user: ContractAddress,
-        name: felt252,
-    }
-    //ANCHOR_END: stored_name
 
     //ANCHOR: person
     #[derive(Drop, Serde, starknet::Store)]
@@ -54,31 +32,6 @@ mod NameRegistry {
         name: felt252,
     }
     //ANCHOR_END: person
-
-    //ANCHOR: enum_store
-    #[derive(Copy, Drop, Serde, starknet::Store)]
-    pub enum RegistrationType {
-        Finite: u64,
-        #[default]
-        Infinite,
-    }
-    //ANCHOR_END: enum_store
-
-    //ANCHOR: storage_node_def
-    #[starknet::storage_node]
-    struct RegistrationNode {
-        count: u64,
-        info: RegistrationInfo,
-        history: Map<u64, RegistrationInfo>,
-    }
-    //ANCHOR_END: storage_node_def
-
-    #[derive(Copy, Drop, Serde, starknet::Store)]
-    pub struct RegistrationInfo {
-        name: felt252,
-        registration_type: RegistrationType,
-        registration_date: u64,
-    }
 
     //ANCHOR: constructor
     #[constructor]
@@ -96,9 +49,9 @@ mod NameRegistry {
     #[abi(embed_v0)]
     impl NameRegistry of super::INameRegistry<ContractState> {
         //ANCHOR: external
-        fn store_name(ref self: ContractState, name: felt252, registration_type: RegistrationType) {
+        fn store_name(ref self: ContractState, name: felt252) {
             let caller = get_caller_address();
-            self._store_name(caller, name, registration_type);
+            self._store_name(caller, name);
         }
         //ANCHOR_END: external
 
@@ -121,12 +74,6 @@ mod NameRegistry {
             self.owner.name.read()
             //ANCHOR_END: read_owner_name
         }
-
-        fn get_registration_info(
-            self: @ContractState, address: ContractAddress,
-        ) -> RegistrationInfo {
-            self.registrations.entry(address).info.read()
-        }
     }
     //ANCHOR_END: impl_public
 
@@ -143,37 +90,14 @@ mod NameRegistry {
     // Could be a group of functions about a same topic
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
-        fn _store_name(
-            ref self: ContractState,
-            user: ContractAddress,
-            name: felt252,
-            registration_type: RegistrationType,
-        ) {
+        fn _store_name(ref self: ContractState, user: ContractAddress, name: felt252,) {
             let total_names = self.total_names.read();
 
             //ANCHOR: write
             self.names.entry(user).write(name);
             //ANCHOR_END: write
 
-            //ANCHOR: storage_node
-            let registration_info = RegistrationInfo {
-                name: name,
-                registration_type: registration_type,
-                registration_date: starknet::get_block_timestamp(),
-            };
-            let mut registration_node = self.registrations.entry(user);
-            registration_node.info.write(registration_info);
-
-            let count = registration_node.count.read();
-            registration_node.history.entry(count).write(registration_info);
-            registration_node.count.write(count + 1);
-            //ANCHOR_END: storage_node
-
             self.total_names.write(total_names + 1);
-
-            //ANCHOR: emit_event
-            self.emit(StoredName { user: user, name: name });
-            //ANCHOR_END: emit_event
         }
     }
     // ANCHOR_END: generate_trait

--- a/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
+++ b/listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo
@@ -90,7 +90,7 @@ mod NameRegistry {
     // Could be a group of functions about a same topic
     #[generate_trait]
     impl InternalFunctions of InternalFunctionsTrait {
-        fn _store_name(ref self: ContractState, user: ContractAddress, name: felt252,) {
+        fn _store_name(ref self: ContractState, user: ContractAddress, name: felt252) {
             let total_names = self.total_names.read();
 
             //ANCHOR: write

--- a/src/ch101-00-building-starknet-smart-contracts.md
+++ b/src/ch101-00-building-starknet-smart-contracts.md
@@ -12,13 +12,3 @@ At this point, you should have multiple questions that come to mind:
 - Is there a way to reduce the boilerplate?
 
 Luckily, we'll be answering all these questions in this chapter.
-<!-- Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
-
-```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:all}}
-```
-
-{{#label reference-contract}}
-<span class="caption">Listing {{#ref reference-contract}}: Our reference contract for this chapter</span>
-
-[contract interface]: ./ch100-00-introduction-to-smart-contracts.md#the-interface-the-contracts-blueprint

--- a/src/ch101-00-building-starknet-smart-contracts.md
+++ b/src/ch101-00-building-starknet-smart-contracts.md
@@ -11,7 +11,8 @@ At this point, you should have multiple questions that come to mind:
 - How can I emit events? How can I index them?
 - Is there a way to reduce the boilerplate?
 
-Luckily, we'll be answering all these questions in this chapter. Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
+Luckily, we'll be answering all these questions in this chapter.
+<!-- Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
 
 ```cairo,noplayground
 {{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:all}}

--- a/src/ch101-00-building-starknet-smart-contracts.md
+++ b/src/ch101-00-building-starknet-smart-contracts.md
@@ -12,3 +12,5 @@ At this point, you should have multiple questions that come to mind:
 - Is there a way to reduce the boilerplate?
 
 Luckily, we'll be answering all these questions in this chapter.
+
+[contract interface]: ./ch13-01-introduction-to-smart-contracts.md#the-interface-the-contracts-blueprint

--- a/src/ch101-02-contract-functions.md
+++ b/src/ch101-02-contract-functions.md
@@ -7,7 +7,7 @@ Functions can access the contract's state easily via the `self: ContractState` o
 Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
 
 ```cairo,noplayground
-{{#include ../listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:all}}
+{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:all}}
 ```
 
 {{#label reference-contract}}

--- a/src/ch101-02-contract-functions.md
+++ b/src/ch101-02-contract-functions.md
@@ -2,7 +2,7 @@
 
 In this section, we are going to be looking at the different types of functions you could encounter in Starknet smart contracts.
 
-Functions can access the contract's state easily via `self: ContractState`, which abstracts away the complexity of underlying system calls (`storage_read_syscall` and `storage_write_syscall`). The compiler provides two modifiers: `ref` and `@` to decorate `self`, which intends to distinguish view and external functions.
+Functions can access the contract's state easily via the `self: ContractState` object, which abstracts away the complexity of underlying system calls (`storage_read_syscall` and `storage_write_syscall`). The compiler provides two modifiers: `ref` and `@` to decorate `self`, which intends to distinguish view and external functions.
 
 Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
 
@@ -12,8 +12,6 @@ Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}
 
 {{#label reference-contract}}
 <span class="caption">Listing {{#ref reference-contract}}: Our reference contract for this chapter</span>
-
-[contract interface]: ./ch13-02-anatomy-of-a-simple-contract.md#the-interface-the-contracts-blueprint
 
 ## 1. Constructors
 

--- a/src/ch101-02-contract-functions.md
+++ b/src/ch101-02-contract-functions.md
@@ -9,7 +9,7 @@ Functions can access the contract's state easily via `self: ContractState`, whic
 Constructors are a special type of function that only runs once when deploying a contract, and can be used to initialize the state of a contract.
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:constructor}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:constructor}}
 ```
 
 Some important rules to note:
@@ -30,7 +30,7 @@ The `#[abi(embed_v0)]` attribute means that all functions embedded inside it are
 Annotating an impl block with the `#[abi(embed_v0)]` attribute only affects the visibility (i.e., public vs private/internal) of the functions it contains, but it doesn't inform us on the ability of these functions to modify the state of the contract.
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:impl_public}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:impl_public}}
 ```
 
 > Similarly to the `constructor` function, all public functions, either standalone functions annotated with the `#[external(v0)]` or functions within an impl block annotated with the `#[abi(embed_v0)]` attribute, **must** take `self` as a first argument. This is not the case for private functions.
@@ -40,7 +40,7 @@ Annotating an impl block with the `#[abi(embed_v0)]` attribute only affects the 
 External functions are _public_ functions where the `self: ContractState` argument is passed by reference with the `ref` keyword, which exposes both the `read` and `write` access to storage variables. This allows modifying the state of the contract via `self` directly.
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:external}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:external}}
 ```
 
 ### View Functions
@@ -48,7 +48,7 @@ External functions are _public_ functions where the `self: ContractState` argume
 View functions are _public_ functions where the `self: ContractState` argument is passed as snapshot, which only allows the `read` access to storage variables, and restricts writes to storage made via `self` by causing compilation errors. The compiler will mark their _state_mutability_ to `view`, preventing any state modification through `self` directly.
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:view}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:view}}
 ```
 
 ### State Mutability of Public Functions
@@ -70,7 +70,7 @@ It is also possible to define public functions outside of an implementation of a
 Here, we define a standalone `get_contract_name` function outside of an impl block:
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:standalone}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:standalone}}
 ```
 
 ## 3. Private Functions
@@ -81,7 +81,7 @@ They can be grouped in a dedicated impl block (e.g., in components, to easily im
 Note that these 2 methods are equivalent. Just choose the one that makes your code more readable and easy to use.
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:state_internal}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:state_internal}}
 ```
 
 > Wait, what is this `#[generate_trait]` attribute? Where is the trait definition for this implementation? Well, the `#[generate_trait]` attribute is a special attribute that tells the compiler to generate a trait definition for the implementation block. This allows you to get rid of the boilerplate code of defining a trait with generic parameters and implementing it for the implementation block. With this attribute, we can simply define the implementation block directly, without any generic parameter, and use `self: ContractState` in our functions.
@@ -99,7 +99,7 @@ You can also define the entrypoint type of functions individually inside an impl
 Here is a short example:
 
 ```cairo,noplayground
-{{#include ../listings/ch101-building-starknet-smart-contracts/no_listing_01_abi_per_item_attribute/src/lib.cairo}}
+{{#rustdoc_include ../listings/ch101-building-starknet-smart-contracts/no_listing_01_abi_per_item_attribute/src/lib.cairo}}
 ```
 
 In the case of `#[abi(per_item)]` attribute usage without `#[generate_trait]`, it will only be possible to include `constructor`, `l1-handler` and `internal` functions in the trait implementation. Indeed, `#[abi(per_item)]` only works with a trait that is not defined as a Starknet interface. Hence, it will be mandatory to create another trait defined as interface to implement public functions.

--- a/src/ch101-02-contract-functions.md
+++ b/src/ch101-02-contract-functions.md
@@ -4,6 +4,17 @@ In this section, we are going to be looking at the different types of functions 
 
 Functions can access the contract's state easily via `self: ContractState`, which abstracts away the complexity of underlying system calls (`storage_read_syscall` and `storage_write_syscall`). The compiler provides two modifiers: `ref` and `@` to decorate `self`, which intends to distinguish view and external functions.
 
+Let's consider the `NameRegistry` contract in Listing {{#ref reference-contract}} that we'll be using throughout this chapter:
+
+```cairo,noplayground
+{{#include ../listings/ch14-building-starknet-smart-contracts/listing_01_reference_contract/src/lib.cairo:all}}
+```
+
+{{#label reference-contract}}
+<span class="caption">Listing {{#ref reference-contract}}: Our reference contract for this chapter</span>
+
+[contract interface]: ./ch13-02-anatomy-of-a-simple-contract.md#the-interface-the-contracts-blueprint
+
 ## 1. Constructors
 
 Constructors are a special type of function that only runs once when deploying a contract, and can be used to initialize the state of a contract.


### PR DESCRIPTION
- Simplification of the NameRegistry contract to match the topic
- Move NameRegistry to 14.2 so that it is displayed only for its page
- Add windows to display the entire contract in the examples