### PR TITLE
📚 Add missing `scarb --version` command to installation guide

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -36,6 +36,7 @@ starkup: Installation complete.
 After installation, starkup will automatically install the latest stable versions of Cairo, Scarb, and Starknet Foundry. You can verify the installations by running the following commands in a new terminal session:
 
 ```bash
+$ scarb --version
 scarb 2.10.1 (f190630a5 2025-02-17)
 cairo: 2.10.1 (https://crates.io/crates/cairo-lang-compiler/2.10.1)
 sierra: 1.7.0


### PR DESCRIPTION
### Summary

This PR adds the missing `scarb --version` command to the [[installation guide](https://book.cairo-lang.org/ch01-01-installation.html)](https://book.cairo-lang.org/ch01-01-installation.html).  
Previously, the guide displayed the expected version output for Scarb, Cairo, and Sierra, but did not show the actual command used to generate that output.

### What Changed

- Added the following command just before the output block:

  ```bash
  $ scarb --version
  ```

### Why It Matters

Including the command improves clarity, especially for newcomers who may not immediately know how to verify the Scarb installation.
