### PR TITLE
fix: update "Upgradeable Component" example to use last oz version

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -99,3 +99,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Combine Markdown Files for LLMs
+        run: |
+          chmod +x scripts/combine-markdown.sh
+          scripts/combine-markdown.sh

--- a/listings/ch103-building-advanced-starknet-smart-contracts/listing_07_oz_upgrade/src/lib.cairo
+++ b/listings/ch103-building-advanced-starknet-smart-contracts/listing_07_oz_upgrade/src/lib.cairo
@@ -1,19 +1,20 @@
 #[starknet::contract]
 mod UpgradeableContract {
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::upgrades::UpgradeableComponent;
-    use openzeppelin::upgrades::interface::IUpgradeable;
-    use starknet::{ContractAddress, ClassHash};
+    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_upgrades::UpgradeableComponent;
+    use openzeppelin_upgrades::interface::IUpgradeable;
+    use starknet::ClassHash;
+    use starknet::ContractAddress;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
-    /// Ownable
+    // Ownable Mixin
     #[abi(embed_v0)]
-    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
-    /// Upgradeable
+    // Upgradeable
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]

--- a/src/ch103-03-upgradeability.md
+++ b/src/ch103-03-upgradeability.md
@@ -37,6 +37,6 @@ OpenZeppelin Contracts for Cairo provides the `Upgradeable` component that can b
 {{#label upgradeable-contract}}
 <span class="caption">Listing {{#ref upgradeable-contract}} Integrating OpenZeppelin's Upgradeable component in a contract</span>
 
-For more information, please refer to the [OpenZeppelin docs API reference][oz upgradeability api].
+For more information, please refer to the [OpenZeppelin docs upgradeability guide][oz upgradeability docs].
 
-[oz upgradeability api]: https://docs.openzeppelin.com/contracts-cairo/0.19.0/api/upgrades
+[oz upgradeability docs]: https://docs.openzeppelin.com/contracts-cairo/1.0.0/guides/upgrades


### PR DESCRIPTION
Hi @enitrat,

A small PR, to upgrade update "Upgradeable Component" example to use OZ 1.0.0 instead 0.19.0.
Let me know if all goes well for you ser
Have a nice day