### PR TITLE
Fix test output block to reflect actual assert_eq! failure message for add_two

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7797,10 +7797,16 @@ $ scarb test
 
 Collected 2 test(s) from listing_10_04 package
 Running 2 test(s) from src/
-[PASS] listing_10_04::add_two::tests::it_adds_two (gas: ~1)
 [PASS] listing_10_04::add_two::tests::wrong_check (gas: ~1)
-Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
+[FAIL] listing_10_04::tests::it_adds_two
+Failure data:
+    "assertion `4 == add_two(2)` failed.
+    4: 4
+    add_two(2): 5"
+Tests: 1 passed, 1 failed, 0 skipped, 0 ignored, 0 filtered out
 
+Failures:
+    listing_10_04::tests::it_adds_two
 ```
 
 Our test caught the bug! The `it_adds_two` test failed with the following


### PR DESCRIPTION
This update corrects the test output block in the "Testing Equality and Comparisons with the assert_xx! Macros" section to match the actual failure message produced when the add_two function incorrectly adds 3 instead of 2.
The previous version described the failure abstractly, but the updated block now reflects the real output from scarb test, including:

- Exact failure message from the assert_eq! macro
- A clear summary showing 1 test failed and 1 passed