### PR TITLE
docs.cairo-lang.org migration

### DIFF
--- a/src/title-page.md
+++ b/src/title-page.md
@@ -4,6 +4,20 @@ _By the Cairo Community and its [contributors](https://github.com/cairo-book/cai
 
 This version of the text assumes you’re using [Cairo](https://github.com/starkware-libs/cairo) [version 2.11.4](https://github.com/starkware-libs/cairo/releases) and [Starknet Foundry](https://foundry-rs.github.io/starknet-foundry/index.html) [version 0.39.0](https://github.com/foundry-rs/starknet-foundry/releases). See the [Installation](ch01-01-installation.md) section of Chapter {{#chap getting-started}} to install or update Cairo and Starknet Foundry.
 
-While reading this book, if you want to experiment with Cairo code and see how it compiles into Sierra (Intermediate Representation) and CASM (Cairo Assembly), you can use the [cairovm.codes](https://cairovm.codes/) playground.
-
 This book is open source. Find a typo or want to contribute? Check out the book's [GitHub repository](https://github.com/cairo-book/cairo-book).
+
+Additional resources for mastering Cairo:
+
+* [The Scarb documentation](https://docs.swmansion.com/scarb/docs.html): The official documentation for Cairo’s package manager and build tool, covering how to create and manage packages, use dependencies, run builds, and configure projects
+
+* [The Cairo Playground](https://www.cairo-lang.org/cairovm/): A browser-based playground for Cairo, enabling to explore and experiment with Cairo by writing, compiling, debugging, and proving Cairo code without any setup, making it the ideal entrypoint for exploring and experimenting with Cairo
+
+* [The Cairo Core Library Docs](https://docs.cairo-lang.org/core?_=60): The documentation for Cairo's Core library, the standard set of types, traits, and utilities built into the language which provides essential building blocks basic used throughout the Cairo ecosystem and is automatically available in every Cairo project
+
+* [The Cairo Package Registry](https://scarbs.xyz/): The host for Cairo's growing collection of reusable libraries, including [Alexandria](https://github.com/keep-starknet-strange/alexandria), [Open Zeppelin Contracts for Cairo](https://docs.openzeppelin.com/contracts-cairo/1.0.0/), all of which can be easily integrated via Scarb, streamlining development and dependency management
+
+* [The Cairo whitepaper](https://eprint.iacr.org/2021/1063.pdf): The original paper introducing Cairo by StarkWare, which explains Cairo as a language for writing provable programs, details its architecture, and shows how it enables scalable, verifiable computation without relying on trusted setups
+
+
+
+


### PR DESCRIPTION
Migrated https://docs.cairo-lang.org/ to the title page.