### PR TITLE
Fix incorrect usage of "area" instead of "perimeter"

### DIFF
--- a/quizzes/ch05-02-an-example-program-using-structs.toml
+++ b/quizzes/ch05-02-an-example-program-using-structs.toml
@@ -18,7 +18,7 @@ fn main() {
 }
 """
 answer.doesCompile = false
-context = "The area function takes ownership of its argument `rectangle`, which doesn't implement `Copy`. Calling `perimeter(rectangle)` therefore moves `rectangle`, meaning it cannot be used on the next line."
+context = "The perimeter function takes ownership of its argument `rectangle`, which doesn't implement `Copy`. Calling `perimeter(rectangle)` therefore moves `rectangle`, meaning it cannot be used on the next line."
 id = "3d5a7161-f117-46c6-a293-ccbabe4b4a9d"
 
 [[questions]]


### PR DESCRIPTION
Fixes a typo in the Cairo Book:quiz where the term "area" was incorrectly used in a context where "perimeter" is the correct term.

This might cause confusion for readers, especially those trying to follow along with geometric or mathematical examples in the chapter.

### Fix Summary:
- Replaced “area” with “perimeter” in the appropriate sentence.
- Ensured the correction maintains the original intent and readability of the paragraph.