### PR TITLE
docs: rephrase generics example sentence for clarity

### DIFF
--- a/src/ch08-01-generic-data-types.md
+++ b/src/ch08-01-generic-data-types.md
@@ -26,7 +26,7 @@ The new `largest_list` function includes in its definition the requirement that 
 
 When defining generic types, it is useful to have information about them. Knowing which traits a generic type implements allows us to use it more effectively in a function's logic at the cost of constraining the generic types that can be used with the function. We saw an example of this previously by adding the `TDrop` implementation as part of the generic arguments of `largest_list`. While `TDrop` was added to satisfy the compiler's requirements, we can also add constraints to benefit our function logic.
 
-Imagine that we want, given a list of elements of some generic type `T`, to find the smallest element among them. Initially, we know that for an element of type `T` to be comparable, it must implement the `PartialOrd` trait. The resulting function would be:
+Imagine we have a list of elements of some generic type `T`, and we want to find the smallest element among them. Initially, we know that for an element of type `T` to be comparable, it must implement the `PartialOrd` trait. The resulting function would be:
 
 ```cairo
 {{#include ../listings/ch08-generic-types-and-traits/no_listing_03_missing_tcopy/src/lib.cairo:missing-tcopy}}


### PR DESCRIPTION
This PR improves the readability of a sentence in the generics section.
- The original sentence was grammatically correct but somewhat awkward and difficult to parse.
- The updated version provides a clearer and more natural flow, making it easier for readers to understand the intent of the example.

Before:
> "Imagine that we want, given a list of elements of some generic type T, to find the smallest element among them."

After:

> "Imagine we have a list of elements of some generic type T, and we want to find the smallest element among them."


No changes to logic or content — just a style/clarity improvement.


