### PR TITLE
Clarify `?` operator requires matching function return type (ch0902)

### DIFF
--- a/src/ch09-02-recoverable-errors.md
+++ b/src/ch09-02-recoverable-errors.md
@@ -85,9 +85,8 @@ The last operator we will talk about is the `?` operator. The `?` operator is us
 - If the value is `Err(e)` or `None`, it will propagate the error or `None` by immediately returning from the function.
 
 Another important aspect to consider is that the `?` operator can only be used if the function it's inside of returns a `Result` or an `Option`, and the type must match the value being unwrapped.
-
-- If you use `?` on a `Result<T, E>`, your function must return a `Result`
-- If you use `?` on an `Option<T>`, your function must return an `Option`
+- If you use `?` on a `Result<T, E>`, your function must also return a `Result`
+- Similarly, if you use `?` on an `Option<T>`, your function must return an `Option`
 
 Otherwise, the compiler will raise a type mismatch error.
 

--- a/src/ch09-02-recoverable-errors.md
+++ b/src/ch09-02-recoverable-errors.md
@@ -84,7 +84,14 @@ The last operator we will talk about is the `?` operator. The `?` operator is us
 - If the value is `Ok(x)` or `Some(x)`, it will return the inner value `x` directly.
 - If the value is `Err(e)` or `None`, it will propagate the error or `None` by immediately returning from the function.
 
-The `?` operator is useful when you want to handle errors implicitly and let the calling function deal with them.
+Another important aspect to consider is that the `?` operator can only be used if the function it's inside of returns a `Result` or an `Option`, and the type must match the value being unwrapped.
+
+- If you use `?` on a `Result<T, E>`, your function must return a `Result`
+- If you use `?` on an `Option<T>`, your function must return an `Option`
+
+Otherwise, the compiler will raise a type mismatch error.
+
+The `?` operator is thus useful when you want to handle errors implicitly and let the calling function deal with them.
 
 Here is an example:
 


### PR DESCRIPTION
This PR adds an important clarification to the `?` operator section in `ch0902`, emphasizing that the operator can only be used if the enclosing function returns a `Result` or an `Option`, and the type must match the value being unwrapped.

## Motivation
Many learners—myself included—run into confusing compiler errors when using the `?` operator without realizing that the function’s return type must match the type being unwrapped. This rule is subtle but crucial, especially for those new to Cairo or Rust-like error handling. Making this requirement explicit helps bridge that understanding gap and this point is currently not explained anywhere in the documentation.

## What’s Added  
A short explanatory **text block** has been added after the existing bullet points on how the `?` operator behaves. It clearly states:

> Another important aspect to consider is that the `?` operator can only be used if the function it's inside of returns a `Result` or an `Option`, and the type must match the value being unwrapped.
> - If you use `?` on a `Result<T, E>`, your function must also return a `Result`
> - Similarly, if you use `?` on an `Option<T>`, your function must return an `Option`
> 
> Otherwise, the compiler will raise a type mismatch error.

This clarification aligns the documentation with actual compiler behaviour and supports a smoother learning experience.

Closes #1199 
