### PR TITLE
Update ch01-03-proving-a-prime-number.md

### DIFF
--- a/src/ch01-03-proving-a-prime-number.md
+++ b/src/ch01-03-proving-a-prime-number.md
@@ -14,8 +14,15 @@ Open a terminal in your projects directory and create a new Scarb project:
 
 ```bash
 scarb new prime_prover
+```
+
+>🛠️ During the setup, you’ll be prompted to choose a test runner. Just select Cairo Test.
+```
 cd prime_prover
 ```
+
+The `scarb new` command creates a new directory called `prime_prover` with a basic project structure. Let’s examine the generated `Scarb.toml`...
+
 
 The scarb new command creates a new directory called `prime_prover` with a basic project structure. Let’s examine the generated Scarb.toml file:
 


### PR DESCRIPTION
### Description of the change

Added a note under the `scarb new` command section to instruct users to select **Cairo Test** as the test runner during project setup.

This is important because **if you don’t select Cairo Test**, the following line will be missing from the generated `Scarb.toml`:

```toml
cairo_test = "2.11.4"
```
