### PR TITLE
Update ch01-01-installation.md

### DIFF
--- a/src/ch01-01-installation.md
+++ b/src/ch01-01-installation.md
@@ -42,7 +42,10 @@ cairo: 2.11.4 (https://crates.io/crates/cairo-lang-compiler/2.11.4)
 sierra: 1.7.0
 
 $ snforge --version
-snforge 0.39.0
+snforge 0.47.0
+
+$ sncast --version
+sncast 0.47.0
 ```
 
 We'll describe Starknet Foundry in more detail in [Chapter {{#chap testing-cairo-programs}}][writing tests] for Cairo programs testing and in [Chapter {{#chap starknet-smart-contracts-security}}][testing with snfoundry] when discussing Starknet smart contract testing and security in the second part of the book.


### PR DESCRIPTION
### Update ch01-01-installation.md

Updated `snforge` and `sncast` versions to the latest known versions used in the book (0.47.0) for consistency with `Scarb` and `Cairo` versions listed above.

This ensures that readers are using up-to-date tooling when working through the exercises.

```bash
$ snforge --version
snforge 0.47.0

$ sncast --version
sncast 0.47.0
```
