### PR TITLE
Update ch03-01-arrays.md

### DIFF
--- a/src/ch03-01-arrays.md
+++ b/src/ch03-01-arrays.md
@@ -122,7 +122,7 @@ All methods provided by `Array` can also be used with `Span`, except for the `ap
 To create a `Span` of an `Array`, call the `span()` method:
 
 ```cairo
-{{#rustdoc_include ../listings/ch03-common-collections/no_listing_08_array_span/src/lib.cairo:3}}
+{{#rustdoc_include ../listings/ch03-common-collections/no_listing_08_array_span/src/lib.cairo}}
 ```
 
 {{#quiz ../quizzes/ch03-01-arrays.toml}}


### PR DESCRIPTION
### What was changed

Replaced the following line:

```cairo
{{#rustdoc_include ../listings/ch03-common-collections/no_listing_08_array_span/src/lib.cairo:3}}
```

with:

```cairo
{{#rustdoc_include ../listings/ch03-common-collections/no_listing_08_array_span/src/lib.cairo}}
```

### Why

The previous line only included line 3 of the file, which resulted in incomplete code being shown.
By removing the `:3` line specifier, the full file is now included as intended.

<img width="883" height="550" alt="image" src="https://github.com/user-attachments/assets/bdfc3cb8-7af8-4ca1-a077-c12e96ac07d5" />

