### PR TITLE
Update ch01-02-hello-world.md

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -152,7 +152,7 @@ From your _hello_world_ directory, build your project by entering the following 
 {{#include ../listings/ch01-getting-started/no_listing_01_hello_world/output_build.txt}}
 ```
 
-This command creates a `hello_world.sierra.json` file in _target/dev_, let's ignore the `sierra` file for now.
+This command creates a `hello_world_main_executable.json` file in _target/dev_, let's ignore this file for now.
 
 If you have installed Cairo correctly, you should be able to run the `main` function of your program with the `scarb execute` command and see the following output:
 


### PR DESCRIPTION
Update to reflect the actual file created when the command 
```bash
scarb build
```
is ran. The file `hello_world_main.executable.json` is created and **NOT** `hello_world.sierra.json` as stated in the docs with the given `Scarb.toml` file:-

```toml
[package]
name = "hello_world"
version = "0.1.0"
edition = "2024_07"

[cairo]
enable-gas = false

[dependencies]
cairo_execute = "2.11.4"


[[target.executable]]
name = "hello_world_main"
function = "hello_world::hello_world::main"
```