### PR TITLE
fix(chat): prevent arrow keys from triggering page navigation in chat input

### DIFF
--- a/theme/chat.js
+++ b/theme/chat.js
@@ -182,6 +182,16 @@
 				.addEventListener("keypress", (e) => {
 					if (e.key === "Enter") this.sendMessage();
 				});
+			// Prevent arrow keys from triggering mdBook navigation
+			document
+				.getElementById("message-input")
+				.addEventListener("keydown", (e) => {
+					if (
+						["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)
+					) {
+						e.stopPropagation();
+					}
+				});
 			document
 				.getElementById("clear-history")
 				.addEventListener("click", () => this.clearChatHistory());


### PR DESCRIPTION
Closes https://github.com/cairo-book/cairo-book/issues/1240

## Summary

- Added event listener to stop arrow key propagation in chat input field
- Prevents mdBook page navigation shortcuts from interfering with text editing

## Problem

When typing in the Cairo Assistant chat input, arrow keys would navigate between documentation pages instead of moving the cursor within the text. This made editing text in the chat input very difficult.

## Solution

Added a `keydown` event listener that calls `stopPropagation()` for arrow key events (ArrowLeft, ArrowRight, ArrowUp, ArrowDown) when they occur in the message input field. This prevents the events from bubbling up to mdBook's keyboard shortcut handlers while preserving normal cursor movement behavior.

## Test Plan

- [x] Build and serve the book locally with `mdbook serve`
- [x] Open the Cairo Assistant chat window
- [x] Type text in the chat input field
- [x] Use arrow keys to move cursor within the text - should work normally
- [x] Verify arrow keys still navigate pages when focus is outside the chat input
- [x] Validate JavaScript syntax with Node.js
