### PR TITLE
fix: remove extra whitespace in comments and ANCHOR tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<!-- Remember: Keep a span between the HTML tag and the markdown tag.  -->
+<!-- Remember: Keep a span between the HTML tag and the markdown tag. -->
 
   <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 

--- a/listings/ch02-common-programming-concepts/no_listing_08_numeric_operations/src/lib.cairo
+++ b/listings/ch02-common-programming-concepts/no_listing_08_numeric_operations/src/lib.cairo
@@ -10,8 +10,8 @@ fn main() {
     let product = 4_u128 * 30_u128;
 
     // division
-    let quotient = 56_u128 / 32_u128; //result is 1
-    let quotient = 64_u128 / 32_u128; //result is 2
+    let quotient = 56_u128 / 32_u128; // result is 1
+    let quotient = 64_u128 / 32_u128; // result is 2
 
     // remainder
     let remainder = 43_u128 % 5_u128; // result is 3

--- a/listings/ch102-starknet-cross-contract-interactions/listing_04_expanded_ierc20_library/src/lib.cairo
+++ b/listings/ch102-starknet-cross-contract-interactions/listing_04_expanded_ierc20_library/src/lib.cairo
@@ -14,10 +14,10 @@ struct IERC20LibraryDispatcher {
 impl IERC20LibraryDispatcherImpl of IERC20DispatcherTrait<IERC20LibraryDispatcher> {
     fn name(
         self: IERC20LibraryDispatcher,
-    ) -> felt252 { // starknet::syscalls::library_call_syscall  is called in here
+    ) -> felt252 { // starknet::syscalls::library_call_syscall is called in here
     }
     fn transfer(
         self: IERC20LibraryDispatcher, recipient: ContractAddress, amount: u256,
-    ) { // starknet::syscalls::library_call_syscall  is called in here
+    ) { // starknet::syscalls::library_call_syscall is called in here
     }
 }

--- a/listings/ch103-building-advanced-starknet-smart-contracts/listing_02_ownable_component/src/contract.cairo
+++ b/listings/ch103-building-advanced-starknet-smart-contracts/listing_02_ownable_component/src/contract.cairo
@@ -6,7 +6,7 @@ mod OwnableCounter {
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
-    //ANCHOR:  embedded_impl
+    //ANCHOR: embedded_impl
     #[abi(embed_v0)]
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
 

--- a/listings/ch103-building-advanced-starknet-smart-contracts/listing_03_component_dep/src/contract.cairo
+++ b/listings/ch103-building-advanced-starknet-smart-contracts/listing_03_component_dep/src/contract.cairo
@@ -8,7 +8,7 @@ mod OwnableCounter {
     component!(path: OwnableCounterComponent, storage: counter, event: CounterEvent);
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
-    //ANCHOR:  embedded_impl
+    //ANCHOR: embedded_impl
     #[abi(embed_v0)]
     impl OwnableCounterImpl =
         OwnableCounterComponent::OwnableCounterImpl<ContractState>;

--- a/listings/ch103-building-advanced-starknet-smart-contracts/listing_06_dice_game_vrf/src/lib.cairo
+++ b/listings/ch103-building-advanced-starknet-smart-contracts/listing_06_dice_game_vrf/src/lib.cairo
@@ -141,7 +141,7 @@ mod DiceGame {
 
         // Settle randomness for the current round using Cartridge VRF.
         // Requires the caller to prefix the multicall with:
-        //   VRF.request_random(caller: <this contract>, source: Source::Nonce(<this contract>))
+        // VRF.request_random(caller: <this contract>, source: Source::Nonce(<this contract>))
         fn settle_random(ref self: ContractState) {
             self.ownable.assert_only_owner();
             // Consume a random value tied to this contract's own nonce

--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -25,7 +25,7 @@ filesystem. By adding `use crate::front_of_house::hosting;` in the crate root,
 had been defined in the crate root.
 
 Note that `use` only creates the shortcut for the particular scope in which the
-`use` occurs. Listing {{#ref  use-scope}} moves the `eat_at_restaurant` function
+`use` occurs. Listing {{#ref use-scope}} moves the `eat_at_restaurant` function
 into a new child module named `customer`, which is then a different scope than
 the `use` statement, so the function body won’t compile:
 
@@ -35,7 +35,7 @@ the `use` statement, so the function body won’t compile:
 {{#include ../listings/ch07-managing-cairo-projects-with-packages-crates-and-modules/listing_07_use_and_scope/src/lib.cairo:wrong-path}}
 ```
 
-{{#label use-scope}} <span class="caption">Listing {{#ref  use-scope}}: A `use`
+{{#label use-scope}} <span class="caption">Listing {{#ref use-scope}}: A `use`
 statement only applies in the scope it’s in.</span>
 
 The compiler error shows that the shortcut no longer applies within the


### PR DESCRIPTION
Clean up formatting inconsistencies in comments across Cairo code and markdown files:


These changes improve code readability and maintain consistent formatting throughout the project without altering any functional code.
