### PR TITLE
fix: add missing --output standard flag to scarb execute commands

### DIFF
--- a/listings/ch01-getting-started/prime_prover/output.txt
+++ b/listings/ch01-getting-started/prime_prover/output.txt
@@ -1,8 +1,7 @@
-$ scarb execute -p prime_prover --print-program-output --arguments 17
+$ scarb execute -p prime_prover --print-program-output --output standard --arguments 17
    Compiling prime_prover v0.1.0 (listings/ch01-getting-started/prime_prover/Scarb.toml)
     Finished `dev` profile target(s) in 1 second
    Executing prime_prover
 Program output:
 1
-
-
+Saving output to: target/execute/prime_prover/execution1

--- a/src/ch01-03-proving-a-prime-number.md
+++ b/src/ch01-03-proving-a-prime-number.md
@@ -114,11 +114,13 @@ Now let’s run the program with Scarb to test it. Use the scarb execute command
 and provide an input number as an argument:
 
 ```bash
-scarb execute -p prime_prover --print-program-output --arguments 17
+scarb execute -p prime_prover --print-program-output --output standard --arguments 17
 ```
 
 - `-p prime_prover` specifies the package name (matches Scarb.toml).
 - `--print-program-output` displays the result.
+- `--output standard` saves the execution artifacts (trace, memory,
+  public/private inputs) needed for proving.
 - `--arguments 17` passes the number 17 as input.
 
 You should see output like this:
@@ -132,9 +134,9 @@ of the program. Here, `0` indicates success (no panic), and `1` represents true
 (17 is prime). Try a few more numbers:
 
 ```bash
-$ scarb execute -p prime_prover --print-program-output --arguments 4
+$ scarb execute -p prime_prover --print-program-output --output standard --arguments 4
 [0, 0]  # 4 is not prime
-$ scarb execute -p prime_prover --print-program-output --arguments 23
+$ scarb execute -p prime_prover --print-program-output --output standard --arguments 23
 [0, 1]  # 23 is prime
 ```
 


### PR DESCRIPTION
## Summary

- Adds the missing `--output standard` flag to all `scarb execute` commands in the "Proving that a number is prime" chapter
- Updates `output.txt` to reflect the correct command and its output (including the `Saving output to:` line)
- Adds a bullet point explaining what `--output standard` does

Without this flag, `scarb execute` does not generate `prover_input.json` in `execution1/`, causing `scarb prove --execution-id 1` to fail.

## Test plan

- [x] Verified locally: `scarb execute` without `--output standard` produces no artifacts
- [x] Verified locally: `scarb execute` with `--output standard` creates `prover_input.json`
- [x] Verified locally: `scarb prove --execution-id 1` succeeds after the fix

Closes #1254