### PR TITLE
fix: improve build-version.sh for reliable version snapshots

### DIFF
--- a/scripts/build-version.sh
+++ b/scripts/build-version.sh
@@ -31,13 +31,15 @@ if [[ ! -x ${MDBOOK_BIN} ]]; then
 	echo ""
 	echo "=== Downloading mdbook v${MDBOOK_VERSION} ==="
 	ARCH=$(uname -m)
-	OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+	OS=$(uname -s)
+	OS=$(tr '[:upper:]' '[:lower:]' <<<"${OS}")
 	if [[ ${OS} == "darwin" ]]; then
 		PLATFORM="${ARCH}-apple-darwin"
 	else
 		PLATFORM="${ARCH}-unknown-linux-gnu"
 	fi
-	curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${PLATFORM}.tar.gz" | tar -xz -C /tmp/
+	curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${PLATFORM}.tar.gz" -o /tmp/mdbook.tar.gz
+	tar -xzf /tmp/mdbook.tar.gz -C /tmp/
 	mv /tmp/mdbook "${MDBOOK_BIN}"
 fi
 echo "Using mdbook v${MDBOOK_VERSION}"

--- a/scripts/build-version.sh
+++ b/scripts/build-version.sh
@@ -5,8 +5,9 @@ VERSION=$1
 COMMIT=$2
 
 if [[ -z ${VERSION} ]] || [[ -z ${COMMIT} ]]; then
-	echo "Usage: ./scripts/build-version.sh <version> <commit>"
-	echo "Example: ./scripts/build-version.sh 2.12 2a677472"
+	echo "Usage: ./scripts/build-version.sh <version> <commit> [new-latest]"
+	echo "Example: ./scripts/build-version.sh 2.13 99e952c8"
+	echo "Example: ./scripts/build-version.sh 2.13 99e952c8 2.16  # also promote 2.16 to latest"
 	exit 1
 fi
 
@@ -22,38 +23,40 @@ git worktree add -f "${WORKTREE_DIR}" "${COMMIT}" --detach
 
 cd "${WORKTREE_DIR}"
 
-# Check .tool-versions and install dependencies
-echo ""
-echo "=== Tool versions at this commit ==="
-if [[ -f .tool-versions ]]; then
-	cat .tool-versions
+# Use the same mdbook version as CI (0.4.48) for theme compatibility
+MDBOOK_VERSION="0.4.48"
+MDBOOK_BIN="/tmp/mdbook-${MDBOOK_VERSION}"
+
+if [[ ! -x ${MDBOOK_BIN} ]]; then
 	echo ""
-	echo "=== Installing dependencies with asdf ==="
-	while IFS= read -r line; do
-		if [[ -n ${line} ]]; then
-			echo "Installing: ${line}"
-			asdf install "${line}"
-			asdf global "${line}"
-		fi
-	done <.tool-versions
-else
-	echo "No .tool-versions file"
+	echo "=== Downloading mdbook v${MDBOOK_VERSION} ==="
+	ARCH=$(uname -m)
+	OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+	if [[ ${OS} == "darwin" ]]; then
+		PLATFORM="${ARCH}-apple-darwin"
+	else
+		PLATFORM="${ARCH}-unknown-linux-gnu"
+	fi
+	curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${PLATFORM}.tar.gz" | tar -xz -C /tmp/
+	mv /tmp/mdbook "${MDBOOK_BIN}"
 fi
-echo ""
+echo "Using mdbook v${MDBOOK_VERSION}"
 
 echo ""
-echo "=== Removing quiz-cairo preprocessor from book.toml ==="
+echo "=== Removing custom preprocessors from book.toml ==="
 if [[ -f "book.toml" ]]; then
-	# Remove the quiz-cairo preprocessor section
+	# Remove preprocessors that require external tools (cairo, quiz-cairo, gettext)
 	sed -i.bak '/\[preprocessor\.quiz-cairo\]/,/^$/d' book.toml
-	echo "Removed quiz-cairo preprocessor"
+	sed -i.bak '/\[preprocessor\.cairo\]/,/^$/d' book.toml
+	sed -i.bak '/\[preprocessor\.gettext\]/,/^$/d' book.toml
+	echo "Removed custom preprocessors"
 else
 	echo "WARNING: book.toml not found"
 fi
 
 echo ""
 echo "=== Building book ==="
-mdbook build -d book
+"${MDBOOK_BIN}" build -d book
 
 if [[ ! -d "book/html" ]]; then
 	echo "ERROR: book/html not found. Build may have failed."
@@ -73,10 +76,12 @@ git commit -m "Add documentation for Cairo ${VERSION}"
 
 echo ""
 echo "=== Updating versions.json ==="
+NEW_LATEST=${3-}
 node <<JSEOF
 const fs = require('fs');
 const versions = JSON.parse(fs.readFileSync('versions.json', 'utf8'));
 const newVersion = "${VERSION}";
+const newLatest = "${NEW_LATEST}";
 
 // Check if version already exists
 const exists = versions.versions.some(v => v.version === newVersion);
@@ -86,19 +91,45 @@ if (!exists) {
     path: '/v' + newVersion + '/',
     label: newVersion
   });
-
-  // Sort versions descending (latest first, then by version number)
-  versions.versions.sort((a, b) => {
-    if (a.path === '/') return -1;
-    if (b.path === '/') return 1;
-    return b.version.localeCompare(a.version, undefined, { numeric: true });
-  });
-
-  fs.writeFileSync('versions.json', JSON.stringify(versions, null, 2));
   console.log('Added version ' + newVersion);
 } else {
-  console.log('Version ' + newVersion + ' already exists, skipping');
+  console.log('Version ' + newVersion + ' already exists, skipping add');
 }
+
+// If a new latest version was specified, update labels and latest field
+if (newLatest) {
+  // Move old latest from root to its own /v<old>/ path
+  const oldLatestEntry = versions.versions.find(v => v.path === '/');
+  if (oldLatestEntry && oldLatestEntry.version !== newLatest) {
+    oldLatestEntry.path = '/v' + oldLatestEntry.version + '/';
+    oldLatestEntry.label = oldLatestEntry.version;
+  }
+
+  // Set root to new latest
+  const newLatestEntry = versions.versions.find(v => v.version === newLatest);
+  if (newLatestEntry) {
+    newLatestEntry.path = '/';
+    newLatestEntry.label = newLatest + ' (latest)';
+  } else {
+    versions.versions.unshift({
+      version: newLatest,
+      path: '/',
+      label: newLatest + ' (latest)'
+    });
+  }
+
+  versions.latest = newLatest;
+  console.log('Updated latest to ' + newLatest);
+}
+
+// Sort versions descending (latest/root first, then by version number)
+versions.versions.sort((a, b) => {
+  if (a.path === '/') return -1;
+  if (b.path === '/') return 1;
+  return b.version.localeCompare(a.version, undefined, { numeric: true });
+});
+
+fs.writeFileSync('versions.json', JSON.stringify(versions, null, 2) + '\n');
 JSEOF
 
 git add versions.json

--- a/src/title-page.md
+++ b/src/title-page.md
@@ -52,4 +52,4 @@ Additional resources for mastering Cairo:
 
 If you have any questions, feedback or comments, you can reach out through
 [Github Issues](https://github.com/cairo-book/cairo-book/issues) or directly to
-[maintainers](https://relens.ai/blog/author/eni).
+[maintainers](https://lfglabs.dev/team/eni).


### PR DESCRIPTION
- Use mdbook v0.4.48 (matching CI) instead of system mdbook, fixing theme compatibility issues with mdbook 0.5.x
- Remove all custom preprocessors (cairo, quiz-cairo, gettext) that require external tools not needed for static snapshots
- Add optional third argument to promote a new latest version in versions.json in the same operation