### PR TITLE
docs: correct the should_panic expected-message claim

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10333,8 +10333,10 @@ mod tests {
 implementation that panics with different error messages</span>
 
 The test will pass because the value we put in the `should_panic` attribute’s
-`expected` parameter is the string that the `Guess::new` method panics with. We
-need to specify the entire panic message that we expect.
+`expected` parameter is the string that the `Guess::new` method panics with. It
+does not have to be the whole message: the harness only checks that the panic
+message _contains_ the expected string, so `expected: "must be <= 100"` would
+pass here too. The more of the message we specify, the more precise the test.
 
 To see what happens when a `should_panic` test with an expected message fails,
 let’s again introduce a bug into our code by swapping the bodies of the

--- a/src/ch10-01-how-to-write-tests.md
+++ b/src/ch10-01-how-to-write-tests.md
@@ -487,8 +487,10 @@ small or too large:
 implementation that panics with different error messages</span>
 
 The test will pass because the value we put in the `should_panic` attribute’s
-`expected` parameter is the string that the `Guess::new` method panics with. We
-need to specify the entire panic message that we expect.
+`expected` parameter is the string that the `Guess::new` method panics with. It
+does not have to be the whole message: the harness only checks that the panic
+message _contains_ the expected string, so `expected: "must be <= 100"` would
+pass here too. The more of the message we specify, the more precise the test.
 
 To see what happens when a `should_panic` test with an expected message fails,
 let’s again introduce a bug into our code by swapping the bodies of the


### PR DESCRIPTION
`ch10-01-how-to-write-tests.md` contradicts itself about how `#[should_panic(expected: ...)]` matches.

Line 474 correctly says the harness "will make sure that the failure message **contains** the provided text". Fifteen lines later, line 490 says:

> We need to specify the entire panic message that we expect.

That is false, and it is the sentence a reader acts on since it sits right under the listing.