### PR TITLE
chore: update the playground WASM runner from cairo-wasm 2.20

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -35,6 +35,13 @@ lint:
     - linters: [markdownlint]
       paths:
         - src/appendix-08-system-calls.md
+    # wasm-bindgen output, copied verbatim from cairo-wasm's `wasm-pack build`.
+    # Generated code: it must not be reformatted or hand-edited, or the next
+    # update stops being a straight copy. biome also flags wasm-bindgen's own
+    # `handleError(..., arguments)` under noArguments, which we cannot fix here.
+    - linters: [biome]
+      paths:
+        - src/wasm/cairo_lang_runner_wasm.js
   enabled:
     # Go tooling
     - bandit@1.9.2

--- a/src/wasm/cairo_lang_runner_wasm.js
+++ b/src/wasm/cairo_lang_runner_wasm.js
@@ -5,38 +5,34 @@
  * @returns {string}
  */
 export function compile_and_run(request_json) {
-	let deferred2_0;
-	let deferred2_1;
-	try {
-		const ptr0 = passStringToWasm0(
-			request_json,
-			wasm.__wbindgen_malloc_command_export,
-			wasm.__wbindgen_realloc_command_export,
-		);
-		const len0 = WASM_VECTOR_LEN;
-		const ret = wasm.compile_and_run(ptr0, len0);
-		deferred2_0 = ret[0];
-		deferred2_1 = ret[1];
-		return getStringFromWasm0(ret[0], ret[1]);
-	} finally {
-		wasm.__wbindgen_free_command_export(deferred2_0, deferred2_1, 1);
-	}
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ptr0 = passStringToWasm0(request_json, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.compile_and_run(ptr0, len0);
+        deferred2_0 = ret[0];
+        deferred2_1 = ret[1];
+        return getStringFromWasm0(ret[0], ret[1]);
+    } finally {
+        wasm.__wbindgen_free_command_export(deferred2_0, deferred2_1, 1);
+    }
 }
 
 /**
  * @returns {string}
  */
 export function embedded_corelib_manifest() {
-	let deferred1_0;
-	let deferred1_1;
-	try {
-		const ret = wasm.embedded_corelib_manifest();
-		deferred1_0 = ret[0];
-		deferred1_1 = ret[1];
-		return getStringFromWasm0(ret[0], ret[1]);
-	} finally {
-		wasm.__wbindgen_free_command_export(deferred1_0, deferred1_1, 1);
-	}
+    let deferred1_0;
+    let deferred1_1;
+    try {
+        const ret = wasm.embedded_corelib_manifest();
+        deferred1_0 = ret[0];
+        deferred1_1 = ret[1];
+        return getStringFromWasm0(ret[0], ret[1]);
+    } finally {
+        wasm.__wbindgen_free_command_export(deferred1_0, deferred1_1, 1);
+    }
 }
 
 /**
@@ -44,242 +40,263 @@ export function embedded_corelib_manifest() {
  * @returns {string}
  */
 export function run_sierra(request_json) {
-	let deferred2_0;
-	let deferred2_1;
-	try {
-		const ptr0 = passStringToWasm0(
-			request_json,
-			wasm.__wbindgen_malloc_command_export,
-			wasm.__wbindgen_realloc_command_export,
-		);
-		const len0 = WASM_VECTOR_LEN;
-		const ret = wasm.run_sierra(ptr0, len0);
-		deferred2_0 = ret[0];
-		deferred2_1 = ret[1];
-		return getStringFromWasm0(ret[0], ret[1]);
-	} finally {
-		wasm.__wbindgen_free_command_export(deferred2_0, deferred2_1, 1);
-	}
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ptr0 = passStringToWasm0(request_json, wasm.__wbindgen_malloc_command_export, wasm.__wbindgen_realloc_command_export);
+        const len0 = WASM_VECTOR_LEN;
+        const ret = wasm.run_sierra(ptr0, len0);
+        deferred2_0 = ret[0];
+        deferred2_1 = ret[1];
+        return getStringFromWasm0(ret[0], ret[1]);
+    } finally {
+        wasm.__wbindgen_free_command_export(deferred2_0, deferred2_1, 1);
+    }
+}
+function __wbg_get_imports() {
+    const import0 = {
+        __proto__: null,
+        __wbg___wbindgen_is_undefined_c05833b95a3cf397: function(arg0) {
+            const ret = arg0 === undefined;
+            return ret;
+        },
+        __wbg___wbindgen_throw_344f42d3211c4765: function(arg0, arg1) {
+            throw new Error(getStringFromWasm0(arg0, arg1));
+        },
+        __wbg_getRandomValues_cc7f052a444bb2ce: function() { return handleError(function (arg0, arg1) {
+            globalThis.crypto.getRandomValues(getArrayU8FromWasm0(arg0, arg1));
+        }, arguments); },
+        __wbg_now_e7c6795a7f81e10f: function(arg0) {
+            const ret = arg0.now();
+            return ret;
+        },
+        __wbg_performance_3fcf6e32a7e1ed0a: function(arg0) {
+            const ret = arg0.performance;
+            return ret;
+        },
+        __wbg_static_accessor_GLOBAL_4ef717fb391d88b7: function() {
+            const ret = typeof global === 'undefined' ? null : global;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_GLOBAL_THIS_8d1badc68b5a74f4: function() {
+            const ret = typeof globalThis === 'undefined' ? null : globalThis;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_SELF_146583524fe1469b: function() {
+            const ret = typeof self === 'undefined' ? null : self;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_WINDOW_f2829a2234d7819e: function() {
+            const ret = typeof window === 'undefined' ? null : window;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbindgen_init_externref_table: function() {
+            const table = wasm.__wbindgen_externrefs;
+            const offset = table.grow(4);
+            table.set(0, undefined);
+            table.set(offset + 0, undefined);
+            table.set(offset + 1, null);
+            table.set(offset + 2, true);
+            table.set(offset + 3, false);
+        },
+    };
+    return {
+        __proto__: null,
+        "./cairo_lang_runner_wasm_bg.js": import0,
+    };
 }
 
-function __wbg_get_imports() {
-	const import0 = {
-		__proto__: null,
-		__wbg___wbindgen_throw_be289d5034ed271b: (arg0, arg1) => {
-			throw new Error(getStringFromWasm0(arg0, arg1));
-		},
-		__wbindgen_init_externref_table: () => {
-			const table = wasm.__wbindgen_externrefs;
-			const offset = table.grow(4);
-			table.set(0, undefined);
-			table.set(offset + 0, undefined);
-			table.set(offset + 1, null);
-			table.set(offset + 2, true);
-			table.set(offset + 3, false);
-		},
-	};
-	return {
-		__proto__: null,
-		"./cairo_lang_runner_wasm_bg.js": import0,
-	};
+function addToExternrefTable0(obj) {
+    const idx = wasm.__externref_table_alloc_command_export();
+    wasm.__wbindgen_externrefs.set(idx, obj);
+    return idx;
+}
+
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
 }
 
 function getStringFromWasm0(ptr, len) {
-	ptr = ptr >>> 0;
-	return decodeText(ptr, len);
+    return decodeText(ptr >>> 0, len);
 }
 
 let cachedUint8ArrayMemory0 = null;
 function getUint8ArrayMemory0() {
-	if (
-		cachedUint8ArrayMemory0 === null ||
-		cachedUint8ArrayMemory0.byteLength === 0
-	) {
-		cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-	}
-	return cachedUint8ArrayMemory0;
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store_command_export(idx);
+    }
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
 }
 
 function passStringToWasm0(arg, malloc, realloc) {
-	if (realloc === undefined) {
-		const buf = cachedTextEncoder.encode(arg);
-		const ptr = malloc(buf.length, 1) >>> 0;
-		getUint8ArrayMemory0()
-			.subarray(ptr, ptr + buf.length)
-			.set(buf);
-		WASM_VECTOR_LEN = buf.length;
-		return ptr;
-	}
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
 
-	let len = arg.length;
-	let ptr = malloc(len, 1) >>> 0;
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
 
-	const mem = getUint8ArrayMemory0();
+    const mem = getUint8ArrayMemory0();
 
-	let offset = 0;
+    let offset = 0;
 
-	for (; offset < len; offset++) {
-		const code = arg.charCodeAt(offset);
-		if (code > 0x7f) break;
-		mem[ptr + offset] = code;
-	}
-	if (offset !== len) {
-		if (offset !== 0) {
-			arg = arg.slice(offset);
-		}
-		ptr = realloc(ptr, len, (len = offset + arg.length * 3), 1) >>> 0;
-		const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
-		const ret = cachedTextEncoder.encodeInto(arg, view);
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
 
-		offset += ret.written;
-		ptr = realloc(ptr, len, offset, 1) >>> 0;
-	}
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
 
-	WASM_VECTOR_LEN = offset;
-	return ptr;
+    WASM_VECTOR_LEN = offset;
+    return ptr;
 }
 
-let cachedTextDecoder = new TextDecoder("utf-8", {
-	ignoreBOM: true,
-	fatal: true,
-});
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 cachedTextDecoder.decode();
 const MAX_SAFARI_DECODE_BYTES = 2146435072;
 let numBytesDecoded = 0;
 function decodeText(ptr, len) {
-	numBytesDecoded += len;
-	if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
-		cachedTextDecoder = new TextDecoder("utf-8", {
-			ignoreBOM: true,
-			fatal: true,
-		});
-		cachedTextDecoder.decode();
-		numBytesDecoded = len;
-	}
-	return cachedTextDecoder.decode(
-		getUint8ArrayMemory0().subarray(ptr, ptr + len),
-	);
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
 const cachedTextEncoder = new TextEncoder();
 
-if (!("encodeInto" in cachedTextEncoder)) {
-	cachedTextEncoder.encodeInto = (arg, view) => {
-		const buf = cachedTextEncoder.encode(arg);
-		view.set(buf);
-		return {
-			read: arg.length,
-			written: buf.length,
-		};
-	};
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    };
 }
 
 let WASM_VECTOR_LEN = 0;
 
-let wasmModule, wasm;
+let wasmModule, wasmInstance, wasm;
 function __wbg_finalize_init(instance, module) {
-	wasm = instance.exports;
-	wasmModule = module;
-	cachedUint8ArrayMemory0 = null;
-	wasm.__wbindgen_start();
-	return wasm;
+    wasmInstance = instance;
+    wasm = instance.exports;
+    wasmModule = module;
+    cachedUint8ArrayMemory0 = null;
+    wasm.__wbindgen_start();
+    return wasm;
 }
 
 async function __wbg_load(module, imports) {
-	if (typeof Response === "function" && module instanceof Response) {
-		if (typeof WebAssembly.instantiateStreaming === "function") {
-			try {
-				return await WebAssembly.instantiateStreaming(module, imports);
-			} catch (e) {
-				const validResponse = module.ok && expectedResponseType(module.type);
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+            } catch (e) {
+                const validResponse = module.ok && expectedResponseType(module.type);
 
-				if (
-					validResponse &&
-					module.headers.get("Content-Type") !== "application/wasm"
-				) {
-					console.warn(
-						"`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n",
-						e,
-					);
-				} else {
-					throw e;
-				}
-			}
-		}
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
 
-		const bytes = await module.arrayBuffer();
-		return await WebAssembly.instantiate(bytes, imports);
-	} else {
-		const instance = await WebAssembly.instantiate(module, imports);
+                } else { throw e; }
+            }
+        }
 
-		if (instance instanceof WebAssembly.Instance) {
-			return { instance, module };
-		} else {
-			return instance;
-		}
-	}
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
 
-	function expectedResponseType(type) {
-		switch (type) {
-			case "basic":
-			case "cors":
-			case "default":
-				return true;
-		}
-		return false;
-	}
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+        } else {
+            return instance;
+        }
+    }
+
+    function expectedResponseType(type) {
+        switch (type) {
+            case 'basic': case 'cors': case 'default': return true;
+        }
+        return false;
+    }
 }
 
 function initSync(module) {
-	if (wasm !== undefined) return wasm;
+    if (wasm !== undefined) return wasm;
 
-	if (module !== undefined) {
-		if (Object.getPrototypeOf(module) === Object.prototype) {
-			({ module } = module);
-		} else {
-			console.warn(
-				"using deprecated parameters for `initSync()`; pass a single object instead",
-			);
-		}
-	}
 
-	const imports = __wbg_get_imports();
-	if (!(module instanceof WebAssembly.Module)) {
-		module = new WebAssembly.Module(module);
-	}
-	const instance = new WebAssembly.Instance(module, imports);
-	return __wbg_finalize_init(instance, module);
+    if (module !== undefined) {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+    const instance = new WebAssembly.Instance(module, imports);
+    return __wbg_finalize_init(instance, module);
 }
 
 async function __wbg_init(module_or_path) {
-	if (wasm !== undefined) return wasm;
+    if (wasm !== undefined) return wasm;
 
-	if (module_or_path !== undefined) {
-		if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
-			({ module_or_path } = module_or_path);
-		} else {
-			console.warn(
-				"using deprecated parameters for the initialization function; pass a single object instead",
-			);
-		}
-	}
 
-	if (module_or_path === undefined) {
-		module_or_path = new URL("cairo_lang_runner_wasm_bg.wasm", import.meta.url);
-	}
-	const imports = __wbg_get_imports();
+    if (module_or_path !== undefined) {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
 
-	if (
-		typeof module_or_path === "string" ||
-		(typeof Request === "function" && module_or_path instanceof Request) ||
-		(typeof URL === "function" && module_or_path instanceof URL)
-	) {
-		module_or_path = fetch(module_or_path);
-	}
+    if (module_or_path === undefined) {
+        module_or_path = new URL('cairo_lang_runner_wasm_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
 
-	const { instance, module } = await __wbg_load(await module_or_path, imports);
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
 
-	return __wbg_finalize_init(instance, module);
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
 }
 
 export { initSync, __wbg_init as default };


### PR DESCRIPTION
Rebuilds `src/wasm/` from cairo-wasm at `49879144f` with:

```bash
wasm-pack build crates/cairo-lang-runner-wasm --target web --release
```

wasm-pack 0.15.0, wasm-bindgen 0.2.126. **The binary drops 17.7 MB → 15 MB.**
